### PR TITLE
[KYUUBI #782] SparkProcessBuilder fails to generate SPARK_HOME after codebase migration

### DIFF
--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -41,7 +41,7 @@ class SparkProcessBuilder(
     val sparkHomeOpt = env.get("SPARK_HOME").orElse {
       val cwd = getClass.getProtectionDomain.getCodeSource.getLocation.getPath.split("kyuubi-main")
       assert(cwd.length > 1)
-      Paths.get(cwd.head).getParent.getParent
+      Paths.get(cwd.head)
         .resolve("externals")
         .resolve("kyuubi-download")
         .resolve("target")

--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -39,11 +39,13 @@ class SparkProcessBuilder(
 
   override protected val executable: String = {
     val sparkHomeOpt = env.get("SPARK_HOME").orElse {
-      val kyuubiPattern = "/kyuubi/"
-      val cwd = getClass.getProtectionDomain.getCodeSource.getLocation.getPath
-      val idx = kyuubiPattern.length + cwd.lastIndexOf(kyuubiPattern)
-      val kyuubiDevHome = cwd.substring(0, idx)
-      Paths.get(kyuubiDevHome, "externals", "kyuubi-download", "target").toFile
+      val cwd = getClass.getProtectionDomain.getCodeSource.getLocation.getPath.split("kyuubi-main")
+      assert(cwd.length > 1)
+      Paths.get(cwd.head).getParent.getParent
+        .resolve("externals")
+        .resolve("kyuubi-download")
+        .resolve("target")
+        .toFile
         .listFiles(new FilenameFilter {
         override def accept(dir: File, name: String): Boolean = {
           dir.isDirectory && name.startsWith("spark-")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/NetEase/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix failed test

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
