### PR TITLE
[KYUUBI 817] Fix KyuubiDriverSuite UT failure because of NPE

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/package.scala
@@ -26,6 +26,13 @@ package object kyuubi {
     private val buildFile = "kyuubi-version-info.properties"
     private val buildFileStream =
       Thread.currentThread().getContextClassLoader.getResourceAsStream(buildFile)
+
+    if (buildFileStream == null) {
+      throw new KyuubiException(s"Can not load the core build file: $buildFile, if you meet " +
+        s"this exception when running unit tests " +
+        s"please make sure you have run the `mvn package` or `mvn generate-resources` command.")
+    }
+
     private val unknown = "<unknown>"
     private val props = new Properties()
 


### PR DESCRIPTION
### _Why are the changes needed?_

See issue #817 , when we pull the project and do not invoke any build action, e.g. `mvn package` or `mvn generate-resources`, we would miss the `kyuubi-version-info.properties` file, it caused the NPE. 

As discussed under issue #817 , this PR tries to check it and enhance the exception message to make it more friendly to newbie developers.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request

- [ ] Verified in the local env and no need to add test cases.
