### PR TITLE
[WIP] [KYUUBI #825] Introduce jcommander framework to kyuubi project

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -239,6 +239,7 @@ io.prometheus:simpleclient_common
 io.prometheus:simpleclient_dropwizard
 io.prometheus:simpleclient_servlet
 org.apache.zookeeper:zookeeper
+com.beust:jcommander
 
 BSD 3-Clause
 ------------

--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -34,6 +34,7 @@ jakarta.servlet-api/4.0.4//jakarta.servlet-api-4.0.4.jar
 javassist/3.18.1-GA//javassist-3.18.1-GA.jar
 jaxb-api/2.2.11//jaxb-api-2.2.11.jar
 jcl-over-slf4j/1.7.30//jcl-over-slf4j-1.7.30.jar
+jcommander/1.81//jcommander-1.81.jar
 jetty-http/9.4.41.v20210516//jetty-http-9.4.41.v20210516.jar
 jetty-io/9.4.41.v20210516//jetty-io-9.4.41.v20210516.jar
 jetty-security/9.4.41.v20210516//jetty-security-9.4.41.v20210516.jar

--- a/kyuubi-ctl/pom.xml
+++ b/kyuubi-ctl/pom.xml
@@ -114,7 +114,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/kyuubi-ctl/pom.xml
+++ b/kyuubi-ctl/pom.xml
@@ -109,6 +109,11 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kyuubi-ctl/pom.xml
+++ b/kyuubi-ctl/pom.xml
@@ -75,6 +75,11 @@
             <artifactId>zookeeper</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.beust</groupId>
+            <artifactId>jcommander</artifactId>
+        </dependency>
+
         <!-- Begin: for EmbeddedZkServer -->
         <dependency>
             <groupId>org.apache.curator</groupId>
@@ -110,10 +115,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>com.beust</groupId>
-            <artifactId>jcommander</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/KyuubiCli.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/KyuubiCli.scala
@@ -42,7 +42,7 @@ class KyuubiCli extends Logging {
     // scalastyle:off println
     val sj = new StringJoiner("|", "<", ">")
     ServiceType.values.foreach(v => sj.add(String.valueOf(v)))
-    println(s"Usage: kyuubi-ctl ${sj.toString} [actions] [options] \n")
+    println(s"Usage: kyuubi-ctl ${sj} [actions] [options] \n")
     var prefixIndent = 0
     for (st <- commands.keys) {
       val prefix = "  " + String.valueOf(st)
@@ -111,14 +111,14 @@ object KyuubiCli extends Logging {
   def main(args: Array[String]): Unit = {
     val shell = new KyuubiCli
 
-    if (args == null || args(0).equals("-h") || args(0).equals("--help") || args.length == 1) {
+    if (args.isEmpty || args(0).equals("-h") || args(0).equals("--help")) {
       shell.printAllCommandUsage()
     } else {
       try {
         shell.run(ServiceType.withName(args(0)), args.drop(1))
       } catch {
         case _: NoSuchElementException =>
-          error(s"unknown service type: args(0)")
+          error(s"unknown service type: ${args.head}")
           shell.printAllCommandUsage()
       }
     }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/KyuubiCli.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/KyuubiCli.scala
@@ -62,7 +62,7 @@ class KyuubiCli extends Logging {
   }
 
   def printUsageOfJcommander(service: String, action: Option[String],
-                             jcommander: JCommander): Unit = {
+      jcommander: JCommander): Unit = {
     // scalastyle:off println
     val act = if (action.isEmpty) "[actions]" else action
     println(s"Usage: kyuubi-ctl ${service} ${act} [options]")

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/KyuubiCli.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/KyuubiCli.scala
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable.HashMap
+
+import com.beust.jcommander.JCommander
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.ctl.ServiceType.ServiceType
+import org.apache.kyuubi.ctl.commands.common.{AbstractCommand, UnixStyleUsage}
+import org.apache.kyuubi.ctl.commands.engine._
+import org.apache.kyuubi.ctl.commands.server._
+
+private[ctl] object ServiceType extends Enumeration {
+  type ServiceType = Value
+  val SERVER, ENGINE = Value
+}
+
+class KyuubiCli extends Logging {
+
+  private lazy val commands = initCommands()
+
+  def initCommands(): HashMap[ServiceType, JCommander] = {
+    // init engine commands
+    val engineCommand = JCommander
+      .newBuilder()
+      .addCommand(new GetEngineCommand)
+      .addCommand(new DeleteEngineCommand)
+      .addCommand(new ListEngineCommand)
+      .build()
+
+    // init server commands
+    val serverCommand = JCommander
+      .newBuilder()
+      .addCommand(new CreateServerCommand)
+      .addCommand(new GetServerCommand)
+      .addCommand(new DeleteServerCommand)
+      .addCommand(new ListServerCommand)
+      .build()
+
+    // register commands
+    HashMap(
+      ServiceType.ENGINE -> engineCommand,
+      ServiceType.SERVER -> serverCommand
+    )
+  }
+
+  def usage(): Unit = {
+    // scalastyle:off println
+    println("Usage: kyuubi-ctl <server|engine> <create|get|delete|list> [options]")
+    for ((service, commander) <- commands) {
+      println(s"[ $service ]")
+      for (cmd <- commander.getCommands.values().asScala) {
+        cmd.setColumnSize(100)
+        cmd.setUsageFormatter(new UnixStyleUsage(cmd))
+        cmd.usage()
+      }
+      print(System.lineSeparator())
+    }
+    // scalastyle:off println
+  }
+
+  def run(service: ServiceType, args: Array[String]): Unit = {
+
+    val serviceCommand = commands.getOrElse(service, throw new RuntimeException)
+
+    serviceCommand.parse(args: _*)
+    val parsedCommand = serviceCommand.getCommands.get(serviceCommand.getParsedCommand)
+    parsedCommand.getObjects.asScala.find(_.isInstanceOf[AbstractCommand]).foreach(cmd => {
+      cmd.asInstanceOf[AbstractCommand].run(parsedCommand)
+    })
+
+  }
+
+}
+
+object KyuubiCli extends Logging {
+
+  def main(args: Array[String]): Unit = {
+
+    val shell = new KyuubiCli
+    if (args(0).equals("--help")) {
+      shell.usage()
+    } else {
+      shell.run(ServiceType.withName(args(0).toUpperCase()), args.drop(1))
+    }
+
+  }
+
+}
+

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/AbstractCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/AbstractCommand.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.common
+
+import com.beust.jcommander.JCommander
+
+trait AbstractCommand {
+
+  def run(jc: JCommander): Unit = {}
+
+}

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/Command.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/Command.scala
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.common
+
+import com.beust.jcommander.JCommander
+
+trait Command {
+
+  def run(jc: JCommander): Unit
+
+}

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/CommandGroup.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/CommandGroup.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.common
+
+import com.beust.jcommander.JCommander
+
+trait CommandGroup {
+
+  def desc(): String
+  def cmd(): JCommander
+
+}

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/ServiceType.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/ServiceType.scala
@@ -17,10 +17,7 @@
 
 package org.apache.kyuubi.ctl.commands.common
 
-import com.beust.jcommander.JCommander
-
-trait AbstractCommand {
-
-  def run(jc: JCommander): Unit = {}
-
+object ServiceType extends Enumeration {
+  type ServiceType = Value
+  val server, engine, config = Value
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/UnixStyleUsage.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/UnixStyleUsage.scala
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.common
+
+import java.lang.{StringBuilder => Builder}
+import java.util.List
+
+import scala.collection.JavaConverters._
+
+import com.beust.jcommander.{DefaultUsageFormatter, JCommander, ParameterDescription}
+
+class UnixStyleUsage(commander: JCommander) extends DefaultUsageFormatter(commander) {
+
+  override def appendMainLine(out: Builder, hasOptions: Boolean,
+                              hasCommands: Boolean, indentCount: Int, indent: String): Unit = {
+    wrapDescription(out, indentCount, commander.getProgramDisplayName + "\n")
+  }
+
+  override def appendAllParametersDetails(out: Builder, indentCount: Int, indent: String,
+                                          sortedParameters: List[ParameterDescription]): Unit = {
+    var prefixIndent = 0
+    for (pd <- sortedParameters.asScala) {
+      val prefix = "  " + pd.getNames
+      if (prefix.length > prefixIndent) prefixIndent = prefix.length
+    }
+
+    for (pd <- sortedParameters.asScala) {
+      val prefix = "  " + pd.getNames
+      out.append(indent)
+        .append(prefix)
+        .append(DefaultUsageFormatter.s(prefixIndent-prefix.length))
+        .append(" ")
+
+      val initialLinePrefixLength = indent.length + prefixIndent + 3;
+      val description = pd.getDescription
+      wrapDescription(out, indentCount + prefixIndent - 3, initialLinePrefixLength, description)
+      out.append("\n")
+    }
+    out.deleteCharAt(out.length - 1)
+  }
+}

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/UnixStyleUsage.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/common/UnixStyleUsage.scala
@@ -27,12 +27,12 @@ import com.beust.jcommander.{DefaultUsageFormatter, JCommander, ParameterDescrip
 class UnixStyleUsage(commander: JCommander) extends DefaultUsageFormatter(commander) {
 
   override def appendMainLine(out: Builder, hasOptions: Boolean,
-                              hasCommands: Boolean, indentCount: Int, indent: String): Unit = {
+      hasCommands: Boolean, indentCount: Int, indent: String): Unit = {
     wrapDescription(out, indentCount, commander.getProgramDisplayName + "\n")
   }
 
   override def appendAllParametersDetails(out: Builder, indentCount: Int, indent: String,
-                                          sortedParameters: List[ParameterDescription]): Unit = {
+      sortedParameters: List[ParameterDescription]): Unit = {
     var prefixIndent = 0
     for (pd <- sortedParameters.asScala) {
       val prefix = "  " + pd.getNames

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/config/ConfigCommandGroup.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/config/ConfigCommandGroup.scala
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.config
+
+import com.beust.jcommander.JCommander
+
+import org.apache.kyuubi.ctl.commands.common.CommandGroup
+
+class ConfigCommandGroup extends CommandGroup {
+  override def desc(): String = "Commands on operating config"
+
+  override def cmd(): JCommander = _cmd
+
+  lazy val _cmd: JCommander = {
+    JCommander.newBuilder()
+      .addCommand(new SetConfigCommand)
+      .build()
+  }
+
+}

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/config/SetConfigCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/config/SetConfigCommand.scala
@@ -15,40 +15,22 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.ctl.commands.server
+package org.apache.kyuubi.ctl.commands.config
 
 import com.beust.jcommander.{JCommander, Parameter, Parameters}
 
 import org.apache.kyuubi.ctl.commands.common.{Command, UnixStyleUsage}
 
-@Parameters(commandNames = Array("delete"))
-class DeleteServerCommand extends Command {
+@Parameters(commandNames = Array("set"))
+class SetConfigCommand extends Command {
 
   @Parameter(
-    names = Array("-zk", "--zk-quorum"),
-    description = "The connection string for the zookeeper ensemble, using zk quorum manually.",
-    order = 1)
-  var zkQuorum: String = _
-
-  @Parameter(
-    names = Array("-n", "--namespace"),
-    description = "The namespace, using kyuubi-defaults/conf if absent.",
-    order = 2)
-  var namespace: String = _
-
-  @Parameter(
-    names = Array("-s", "--host"),
-    description = "Hostname or IP address of a service.",
-    order = 3)
-  var host: String = _
-
-  @Parameter(
-    names = Array("-p", "--port"),
+    names = Array("-c", "--cfg"),
     description = "Listening port of a service.",
-    order = 4)
-  var port: String = _
+    order = 1)
+  var config: String = _
 
-  @Parameter(names = Array("-h", "--help"), help = true, order = 5)
+  @Parameter(names = Array("-h", "--help"), help = true, order = 2)
   var help: Boolean = false
 
   override def run(jc: JCommander): Unit = {

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/DeleteEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/DeleteEngineCommand.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.engine
+
+import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+
+import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+
+@Parameters(commandNames = Array("delete"))
+class DeleteEngineCommand extends AbstractCommand {
+
+  @Parameter(
+    names = Array("-zk", "--zk-quorum"),
+    description = "The connection string for the zookeeper ensemble, using zk quorum manually.",
+    order = 1)
+  var zkQuorum: String = _
+
+  @Parameter(
+    names = Array("-n", "--namespace"),
+    description = "The namespace, using kyuubi-defaults/conf if absent.",
+    order = 1)
+  var namespace: String = _
+
+  @Parameter(
+    names = Array("-s", "--host"),
+    description = "Hostname or IP address of a service.",
+    order = 1)
+  var host: String = _
+
+  @Parameter(
+    names = Array("-p", "--port"),
+    description = "Listening port of a service.",
+    order = 1)
+  var port: String = _
+
+  @Parameter(
+    names = Array("-u", "--user"),
+    description = "The user name this engine belong to.",
+    order = 1)
+  var user: String = _
+
+  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  var help: Boolean = false
+
+  override def run(jc: JCommander): Unit = {
+    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
+    jc.usage()
+  }
+}
+

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/DeleteEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/DeleteEngineCommand.scala
@@ -17,12 +17,12 @@
 
 package org.apache.kyuubi.ctl.commands.engine
 
-import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+import com.beust.jcommander.{JCommander, Parameter, Parameters}
 
-import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+import org.apache.kyuubi.ctl.commands.common.{Command, UnixStyleUsage}
 
 @Parameters(commandNames = Array("delete"))
-class DeleteEngineCommand extends AbstractCommand {
+class DeleteEngineCommand extends Command {
 
   @Parameter(
     names = Array("-zk", "--zk-quorum"),
@@ -39,27 +39,31 @@ class DeleteEngineCommand extends AbstractCommand {
   @Parameter(
     names = Array("-s", "--host"),
     description = "Hostname or IP address of a service.",
-    order = 1)
+    order = 2)
   var host: String = _
 
   @Parameter(
     names = Array("-p", "--port"),
     description = "Listening port of a service.",
-    order = 1)
+    order = 3)
   var port: String = _
 
   @Parameter(
     names = Array("-u", "--user"),
     description = "The user name this engine belong to.",
-    order = 1)
+    order = 4)
   var user: String = _
 
-  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  @Parameter(names = Array("-h", "--help"), help = true, order = 5)
   var help: Boolean = false
 
   override def run(jc: JCommander): Unit = {
-    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
-    jc.usage()
+    if (help) {
+      jc.setUsageFormatter(new UnixStyleUsage(jc))
+      jc.usage()
+    } else {
+      // TODO
+    }
   }
 }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/EngineCommandGroup.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/EngineCommandGroup.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.engine
+
+import com.beust.jcommander.JCommander
+
+import org.apache.kyuubi.ctl.commands.common.CommandGroup
+
+class EngineCommandGroup extends CommandGroup {
+  override def desc(): String = "Commands on operating engine"
+
+  override def cmd(): JCommander = _cmd
+
+  lazy val _cmd: JCommander = {
+    JCommander.newBuilder()
+      .addCommand(new GetEngineCommand)
+      .addCommand(new DeleteEngineCommand)
+      .addCommand(new ListEngineCommand)
+      .build()
+  }
+
+}
+

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/GetEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/GetEngineCommand.scala
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.engine
+
+import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+import com.google.common.annotations.VisibleForTesting
+
+import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+
+@Parameters(commandNames = Array("get"))
+class GetEngineCommand extends AbstractCommand {
+
+  @Parameter(
+    names = Array("-zk", "--zk-quorum"),
+    description = "The connection string for the zookeeper ensemble, using zk quorum manually.",
+    order = 1)
+  var zkQuorum: String = _
+
+  @Parameter(
+    names = Array("-n", "--namespace"),
+    description = "The namespace, using kyuubi-defaults/conf if absent.",
+    order = 1)
+  var namespace: String = _
+
+  @Parameter(
+    names = Array("-s", "--host"),
+    description = "Hostname or IP address of a service.",
+    order = 1)
+  var host: String = _
+
+  @Parameter(
+    names = Array("-p", "--port"),
+    description = "Listening port of a service.",
+    order = 1)
+  var port: Int = _
+
+  @Parameter(
+    names = Array("-u", "--user"),
+    description = "The user name this engine belong to.",
+    order = 1)
+  var user: String = _
+
+  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  var help: Boolean = false
+
+  override def run(jc: JCommander): Unit = {
+    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
+    jc.usage()
+  }
+
+  @VisibleForTesting
+  def test(): (String, String, Int) = {
+    (namespace, host, port)
+  }
+}
+

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/GetEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/GetEngineCommand.scala
@@ -17,13 +17,13 @@
 
 package org.apache.kyuubi.ctl.commands.engine
 
-import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+import com.beust.jcommander.{JCommander, Parameter, Parameters}
 import com.google.common.annotations.VisibleForTesting
 
-import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+import org.apache.kyuubi.ctl.commands.common.{Command, UnixStyleUsage}
 
 @Parameters(commandNames = Array("get"))
-class GetEngineCommand extends AbstractCommand {
+class GetEngineCommand extends Command {
 
   @Parameter(
     names = Array("-zk", "--zk-quorum"),
@@ -34,33 +34,37 @@ class GetEngineCommand extends AbstractCommand {
   @Parameter(
     names = Array("-n", "--namespace"),
     description = "The namespace, using kyuubi-defaults/conf if absent.",
-    order = 1)
+    order = 2)
   var namespace: String = _
 
   @Parameter(
     names = Array("-s", "--host"),
     description = "Hostname or IP address of a service.",
-    order = 1)
+    order = 3)
   var host: String = _
 
   @Parameter(
     names = Array("-p", "--port"),
     description = "Listening port of a service.",
-    order = 1)
+    order = 4)
   var port: Int = _
 
   @Parameter(
     names = Array("-u", "--user"),
     description = "The user name this engine belong to.",
-    order = 1)
+    order = 5)
   var user: String = _
 
-  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  @Parameter(names = Array("-h", "--help"), help = true, order = 6)
   var help: Boolean = false
 
   override def run(jc: JCommander): Unit = {
-    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
-    jc.usage()
+    if (help) {
+      jc.setUsageFormatter(new UnixStyleUsage(jc))
+      jc.usage()
+    } else {
+      // TODO
+    }
   }
 
   @VisibleForTesting

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/GetEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/GetEngineCommand.scala
@@ -18,7 +18,6 @@
 package org.apache.kyuubi.ctl.commands.engine
 
 import com.beust.jcommander.{JCommander, Parameter, Parameters}
-import com.google.common.annotations.VisibleForTesting
 
 import org.apache.kyuubi.ctl.commands.common.{Command, UnixStyleUsage}
 
@@ -67,9 +66,5 @@ class GetEngineCommand extends Command {
     }
   }
 
-  @VisibleForTesting
-  def test(): (String, String, Int) = {
-    (namespace, host, port)
-  }
 }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/ListEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/ListEngineCommand.scala
@@ -17,12 +17,12 @@
 
 package org.apache.kyuubi.ctl.commands.engine
 
-import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+import com.beust.jcommander.{JCommander, Parameter, Parameters}
 
-import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+import org.apache.kyuubi.ctl.commands.common.{Command, UnixStyleUsage}
 
 @Parameters(commandNames = Array("list"))
-class ListEngineCommand extends AbstractCommand {
+class ListEngineCommand extends Command {
 
   @Parameter(
     names = Array("-zk", "--zk-quorum"),
@@ -33,33 +33,37 @@ class ListEngineCommand extends AbstractCommand {
   @Parameter(
     names = Array("-n", "--namespace"),
     description = "The namespace, using kyuubi-defaults/conf if absent.",
-    order = 1)
+    order = 2)
   var namespace: String = _
 
   @Parameter(
     names = Array("-s", "--host"),
     description = "Hostname or IP address of a service.",
-    order = 1)
+    order = 3)
   var host: String = _
 
   @Parameter(
     names = Array("-p", "--port"),
     description = "Listening port of a service.",
-    order = 1)
+    order = 4)
   var port: String = _
 
   @Parameter(
     names = Array("-u", "--user"),
     description = "The user name this engine belong to.",
-    order = 1)
+    order = 5)
   var user: String = _
 
-  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  @Parameter(names = Array("-h", "--help"), help = true, order = 6)
   var help: Boolean = false
 
   override def run(jc: JCommander): Unit = {
-    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
-    jc.usage()
+    if (help) {
+      jc.setUsageFormatter(new UnixStyleUsage(jc))
+      jc.usage()
+    } else {
+      // TODO
+    }
   }
 }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/ListEngineCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/engine/ListEngineCommand.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.engine
+
+import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+
+import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+
+@Parameters(commandNames = Array("list"))
+class ListEngineCommand extends AbstractCommand {
+
+  @Parameter(
+    names = Array("-zk", "--zk-quorum"),
+    description = "The connection string for the zookeeper ensemble, using zk quorum manually.",
+    order = 1)
+  var zkQuorum: String = _
+
+  @Parameter(
+    names = Array("-n", "--namespace"),
+    description = "The namespace, using kyuubi-defaults/conf if absent.",
+    order = 1)
+  var namespace: String = _
+
+  @Parameter(
+    names = Array("-s", "--host"),
+    description = "Hostname or IP address of a service.",
+    order = 1)
+  var host: String = _
+
+  @Parameter(
+    names = Array("-p", "--port"),
+    description = "Listening port of a service.",
+    order = 1)
+  var port: String = _
+
+  @Parameter(
+    names = Array("-u", "--user"),
+    description = "The user name this engine belong to.",
+    order = 1)
+  var user: String = _
+
+  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  var help: Boolean = false
+
+  override def run(jc: JCommander): Unit = {
+    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
+    jc.usage()
+  }
+}
+

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/CreateServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/CreateServerCommand.scala
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.server
+
+import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+
+import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+
+@Parameters(commandNames = Array("create"))
+class CreateServerCommand extends AbstractCommand {
+
+  @Parameter(
+    names = Array("-zk", "--zk-quorum"),
+    description = "The connection string for the zookeeper ensemble, using zk quorum manually.",
+    order = 1)
+  var zkQuorum: String = _
+
+  @Parameter(
+    names = Array("-n", "--namespace"),
+    description = "The namespace, using kyuubi-defaults/conf if absent.",
+    order = 1)
+  var namespace: String = _
+
+  @Parameter(
+    names = Array("-s", "--host"),
+    description = "Hostname or IP address of a service.",
+    order = 1)
+  var host: String = _
+
+  @Parameter(
+    names = Array("-p", "--port"),
+    description = "Listening port of a service.",
+    order = 1)
+  var port: String = _
+
+  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  var help: Boolean = false
+
+  override def run(jc: JCommander): Unit = {
+    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
+    jc.usage()
+    // println(s"${namespace} ${host}")
+  }
+}
+

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/CreateServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/CreateServerCommand.scala
@@ -17,12 +17,12 @@
 
 package org.apache.kyuubi.ctl.commands.server
 
-import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+import com.beust.jcommander.{JCommander, Parameter, Parameters}
 
-import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+import org.apache.kyuubi.ctl.commands.common.{Command, UnixStyleUsage}
 
 @Parameters(commandNames = Array("create"))
-class CreateServerCommand extends AbstractCommand {
+class CreateServerCommand extends Command {
 
   @Parameter(
     names = Array("-zk", "--zk-quorum"),
@@ -33,28 +33,31 @@ class CreateServerCommand extends AbstractCommand {
   @Parameter(
     names = Array("-n", "--namespace"),
     description = "The namespace, using kyuubi-defaults/conf if absent.",
-    order = 1)
+    order = 2)
   var namespace: String = _
 
   @Parameter(
     names = Array("-s", "--host"),
     description = "Hostname or IP address of a service.",
-    order = 1)
+    order = 3)
   var host: String = _
 
   @Parameter(
     names = Array("-p", "--port"),
     description = "Listening port of a service.",
-    order = 1)
+    order = 4)
   var port: String = _
 
-  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  @Parameter(names = Array("-h", "--help"), help = true, order = 5)
   var help: Boolean = false
 
   override def run(jc: JCommander): Unit = {
-    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
-    jc.usage()
-    // println(s"${namespace} ${host}")
+    if (help) {
+      jc.setUsageFormatter(new UnixStyleUsage(jc))
+      jc.usage()
+    } else {
+      // TODO
+    }
   }
 }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/DeleteServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/DeleteServerCommand.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.server
+
+import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+
+import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+
+@Parameters(commandNames = Array("delete"))
+class DeleteServerCommand extends AbstractCommand {
+
+  @Parameter(
+    names = Array("-zk", "--zk-quorum"),
+    description = "The connection string for the zookeeper ensemble, using zk quorum manually.",
+    order = 1)
+  var zkQuorum: String = _
+
+  @Parameter(
+    names = Array("-n", "--namespace"),
+    description = "The namespace, using kyuubi-defaults/conf if absent.",
+    order = 1)
+  var namespace: String = _
+
+  @Parameter(
+    names = Array("-s", "--host"),
+    description = "Hostname or IP address of a service.",
+    order = 1)
+  var host: String = _
+
+  @Parameter(
+    names = Array("-p", "--port"),
+    description = "Listening port of a service.",
+    order = 1)
+  var port: String = _
+
+  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  var help: Boolean = false
+
+  override def run(jc: JCommander): Unit = {
+    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
+    jc.usage()
+  }
+}
+

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/GetServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/GetServerCommand.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.server
+
+import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+
+import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+
+@Parameters(commandNames = Array("get"))
+class GetServerCommand extends AbstractCommand {
+
+  @Parameter(
+    names = Array("-zk", "--zk-quorum"),
+    description = "The connection string for the zookeeper ensemble, using zk quorum manually.",
+    order = 1)
+  var zkQuorum: String = _
+
+  @Parameter(
+    names = Array("-n", "--namespace"),
+    description = "The namespace, using kyuubi-defaults/conf if absent.",
+    order = 1)
+  var namespace: String = _
+
+  @Parameter(
+    names = Array("-s", "--host"),
+    description = "Hostname or IP address of a service.",
+    order = 1)
+  var host: String = _
+
+  @Parameter(
+    names = Array("-p", "--port"),
+    description = "Listening port of a service.",
+    order = 1)
+  var port: String = _
+
+  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  var help: Boolean = false
+
+  override def run(jc: JCommander): Unit = {
+    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
+    jc.usage()
+  }
+}
+

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/GetServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/GetServerCommand.scala
@@ -17,12 +17,12 @@
 
 package org.apache.kyuubi.ctl.commands.server
 
-import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+import com.beust.jcommander.{JCommander, Parameter, Parameters}
 
-import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+import org.apache.kyuubi.ctl.commands.common.{Command, UnixStyleUsage}
 
 @Parameters(commandNames = Array("get"))
-class GetServerCommand extends AbstractCommand {
+class GetServerCommand extends Command {
 
   @Parameter(
     names = Array("-zk", "--zk-quorum"),
@@ -33,27 +33,31 @@ class GetServerCommand extends AbstractCommand {
   @Parameter(
     names = Array("-n", "--namespace"),
     description = "The namespace, using kyuubi-defaults/conf if absent.",
-    order = 1)
+    order = 2)
   var namespace: String = _
 
   @Parameter(
     names = Array("-s", "--host"),
     description = "Hostname or IP address of a service.",
-    order = 1)
+    order = 3)
   var host: String = _
 
   @Parameter(
     names = Array("-p", "--port"),
     description = "Listening port of a service.",
-    order = 1)
+    order = 4)
   var port: String = _
 
-  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  @Parameter(names = Array("-h", "--help"), help = true, order = 5)
   var help: Boolean = false
 
   override def run(jc: JCommander): Unit = {
-    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
-    jc.usage()
+    if (help) {
+      jc.setUsageFormatter(new UnixStyleUsage(jc))
+      jc.usage()
+    } else {
+      // TODO
+    }
   }
 }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/ListServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/ListServerCommand.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.server
+
+import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+
+import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+
+@Parameters(commandNames = Array("list"))
+class ListServerCommand extends AbstractCommand {
+
+  @Parameter(
+    names = Array("-zk", "--zk-quorum"),
+    description = "The connection string for the zookeeper ensemble, using zk quorum manually.",
+    order = 1)
+  var zkQuorum: String = _
+
+  @Parameter(
+    names = Array("-n", "--namespace"),
+    description = "The namespace, using kyuubi-defaults/conf if absent.",
+    order = 1)
+  var namespace: String = _
+
+  @Parameter(
+    names = Array("-s", "--host"),
+    description = "Hostname or IP address of a service.",
+    order = 1)
+  var host: String = _
+
+  @Parameter(
+    names = Array("-p", "--port"),
+    description = "Listening port of a service.",
+    order = 1)
+  var port: String = _
+
+  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  var help: Boolean = false
+
+  override def run(jc: JCommander): Unit = {
+    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
+    jc.usage()
+  }
+}
+

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/ListServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/ListServerCommand.scala
@@ -17,12 +17,12 @@
 
 package org.apache.kyuubi.ctl.commands.server
 
-import com.beust.jcommander.{JCommander, Parameter, Parameters, UnixStyleUsageFormatter}
+import com.beust.jcommander.{JCommander, Parameter, Parameters}
 
-import org.apache.kyuubi.ctl.commands.common.AbstractCommand
+import org.apache.kyuubi.ctl.commands.common.{Command, UnixStyleUsage}
 
 @Parameters(commandNames = Array("list"))
-class ListServerCommand extends AbstractCommand {
+class ListServerCommand extends Command {
 
   @Parameter(
     names = Array("-zk", "--zk-quorum"),
@@ -33,27 +33,31 @@ class ListServerCommand extends AbstractCommand {
   @Parameter(
     names = Array("-n", "--namespace"),
     description = "The namespace, using kyuubi-defaults/conf if absent.",
-    order = 1)
+    order = 2)
   var namespace: String = _
 
   @Parameter(
     names = Array("-s", "--host"),
     description = "Hostname or IP address of a service.",
-    order = 1)
+    order = 3)
   var host: String = _
 
   @Parameter(
     names = Array("-p", "--port"),
     description = "Listening port of a service.",
-    order = 1)
+    order = 4)
   var port: String = _
 
-  @Parameter(names = Array("-h", "--help"), help = true, order = 3)
+  @Parameter(names = Array("-h", "--help"), help = true, order = 5)
   var help: Boolean = false
 
   override def run(jc: JCommander): Unit = {
-    jc.setUsageFormatter(new UnixStyleUsageFormatter(jc))
-    jc.usage()
+    if (help) {
+      jc.setUsageFormatter(new UnixStyleUsage(jc))
+      jc.usage()
+    } else {
+      // TODO
+    }
   }
 }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/ServerCommandGroup.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/commands/server/ServerCommandGroup.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.commands.server
+
+import com.beust.jcommander.JCommander
+
+import org.apache.kyuubi.ctl.commands.common.CommandGroup
+
+class ServerCommandGroup extends CommandGroup {
+  override def desc(): String = "Commands on operating server"
+
+  override def cmd(): JCommander = _cmd
+
+  lazy val _cmd: JCommander = {
+    JCommander.newBuilder()
+      .addCommand(new CreateServerCommand)
+      .addCommand(new GetServerCommand)
+      .addCommand(new DeleteServerCommand)
+      .addCommand(new ListServerCommand)
+      .build()
+  }
+
+}

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/KyuubiCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/KyuubiCliSuite.scala
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl
+
+import com.beust.jcommander.JCommander
+
+import org.apache.kyuubi.KyuubiFunSuite
+import org.apache.kyuubi.ctl.commands.engine.GetEngineCommand
+
+class KyuubiCliSuite extends KyuubiFunSuite with TestPrematureExit {
+
+  test("test jcommander parse args") {
+
+    val args = Array(
+      "--namespace", "namespace",
+      "--host", "localhost",
+      "--port", "65535"
+    )
+
+    val getEngineCommand = new GetEngineCommand
+    val engineCommand = JCommander.newBuilder()
+      .addObject(getEngineCommand)
+      .build()
+
+    engineCommand.parse(args: _*)
+    assert(("namespace", "localhost", 65535).equals(getEngineCommand.test()))
+  }
+
+  test("test kyuubi cli usage") {
+
+    val args = Array(
+      "--help"
+    )
+
+    KyuubiCli.main(args)
+  }
+
+  test("test kyuubi cli parse args") {
+
+    val args = Array(
+      "engine", "get",
+      "--namespace", "namespace",
+      "--host", "localhost",
+      "--port", "65535"
+    )
+
+    KyuubiCli.main(args)
+  }
+
+}

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/KyuubiCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/KyuubiCliSuite.scala
@@ -38,7 +38,9 @@ class KyuubiCliSuite extends KyuubiFunSuite with TestPrematureExit {
       .build()
 
     engineCommand.parse(args: _*)
-    assert(("namespace", "localhost", 65535).equals(getEngineCommand.test()))
+    assert("namespace".equals(getEngineCommand.namespace))
+    assert("localhost".equals(getEngineCommand.host))
+    assert(65535 == getEngineCommand.port)
   }
 
   test("test kyuubi cli usage") {

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,7 @@
         <ldapsdk.version>5.1.4</ldapsdk.version>
         <prometheus.version>0.10.0</prometheus.version>
         <scopt.version>4.0.1</scopt.version>
+        <jcommander.version>1.81</jcommander.version>
         <spark.version>3.1.2</spark.version>
         <spark.archive.name>spark-${spark.version}-bin-hadoop${hadoop.binary.version}.tgz</spark.archive.name>
         <spark.archive.mirror>https://archive.apache.org/dist/spark/spark-${spark.version}</spark.archive.mirror>
@@ -1037,6 +1038,12 @@
                 <groupId>com.github.scopt</groupId>
                 <artifactId>scopt_${scala.binary.version}</artifactId>
                 <version>${scopt.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.beust</groupId>
+                <artifactId>jcommander</artifactId>
+                <version>${jcommander.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_

Fixes #825

For more details, please go to #775 


Hi @yaooqinn @pan3793, 

Here's the patch base on JCommander in scala, please point out if the scala grammar is not used correctly.

The following usage is generated from JCommander, I think it seems a bit long for users, we can discuss it here.
By the way, we can use the format of bookkeeper-ctl‘s usage.

Thanks.
```
Usage: kyuubi-ctl <server|engine> <create|get|delete|list> [options]
[ ENGINE ]
get
  -s, --host       Hostname or IP address of a service.
  -u, --user       The user name this engine belong to.
  -n, --namespace  The namespace, using kyuubi-defaults/conf if absent.
  -p, --port       Listening port of a service.
  -zk, --zk-quorum The connection string for the zookeeper ensemble, using zk quorum manually.
  -h, --help       
delete
  -zk, --zk-quorum The connection string for the zookeeper ensemble, using zk quorum manually.
  -n, --namespace  The namespace, using kyuubi-defaults/conf if absent.
  -p, --port       Listening port of a service.
  -s, --host       Hostname or IP address of a service.
  -u, --user       The user name this engine belong to.
  -h, --help       
list
  -zk, --zk-quorum The connection string for the zookeeper ensemble, using zk quorum manually.
  -p, --port       Listening port of a service.
  -n, --namespace  The namespace, using kyuubi-defaults/conf if absent.
  -u, --user       The user name this engine belong to.
  -s, --host       Hostname or IP address of a service.
  -h, --help       

[ SERVER ]
create
  -s, --host       Hostname or IP address of a service.
  -n, --namespace  The namespace, using kyuubi-defaults/conf if absent.
  -zk, --zk-quorum The connection string for the zookeeper ensemble, using zk quorum manually.
  -p, --port       Listening port of a service.
  -h, --help       
get
  -n, --namespace  The namespace, using kyuubi-defaults/conf if absent.
  -s, --host       Hostname or IP address of a service.
  -p, --port       Listening port of a service.
  -zk, --zk-quorum The connection string for the zookeeper ensemble, using zk quorum manually.
  -h, --help       
delete
  -s, --host       Hostname or IP address of a service.
  -n, --namespace  The namespace, using kyuubi-defaults/conf if absent.
  -zk, --zk-quorum The connection string for the zookeeper ensemble, using zk quorum manually.
  -p, --port       Listening port of a service.
  -h, --help       
list
  -p, --port       Listening port of a service.
  -zk, --zk-quorum The connection string for the zookeeper ensemble, using zk quorum manually.
  -s, --host       Hostname or IP address of a service.
  -n, --namespace  The namespace, using kyuubi-defaults/conf if absent.
  -h, --help  
```


### BooKKeeper CTL Usage

#### 1. Totoal Usage
```
[bookkeeper-all-4.13.0]$ bin/bkctl
bkctl interacts and operates Apache BookKeeper clusters

Usage:  bkctl [flags] [command group] [commands]

    cookie              Commands on operating cookies

Infrastructure commands :

    autorecovery        Command on some specific operation.
    bookie              Commands on operating a single bookie
    bookieid            Commands operating on bookie ids
    bookies             Commands on operating a cluster of bookies
    cluster             Commands on administrating bookkeeper clusters
```

#### 2. When choose one command
````
[bookkeeper-all-4.13.0]$ bin/bkctl bookie
Commands on operating a single bookie

Usage:  bkctl bookie [command] [command options]

Commands:

    converttodbstorage                              Convert bookie indexes from
                                                    InterleavedStorage to DbLedgerStorage format
    converttointerleavedstorage                     Convert bookie indexes from
                                                    DbLedgerStorage to InterleavedStorage
                                                    format
    endpointinfo                                    Get all end point
                                                    information about a given bookie.
    flip-bookie-id                                  Update bookie id in ledgers
                                                    (this may take a long time).
    format                                          Format the current server

````





### _How was this patch tested?_
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
