### PR TITLE
[KYUUBI #828] Manage Spark-Block-Cleaner log files

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -195,9 +195,9 @@ cp "$KYUUBI_HOME/externals/kyuubi-spark-sql-engine/target/kyuubi-spark-sql-engin
 
 # Copy kyuubi tools
 if [[ -f "$KYUUBI_HOME/tools/spark-block-cleaner/target/spark-block-cleaner-$VERSION.jar" ]]; then
-  mkdir -p "$DISTDIR/tools/spark-block-cleaner/kubernetes/docker"
+  mkdir -p "$DISTDIR/tools/spark-block-cleaner/kubernetes"
   mkdir -p "$DISTDIR/tools/spark-block-cleaner/jars"
-  cp -r "$KYUUBI_HOME/tools/spark-block-cleaner/kubernetes/" "$DISTDIR/tools/spark-block-cleaner/kubernetes/"
+  cp -r "$KYUUBI_HOME/tools/spark-block-cleaner/kubernetes/" "$DISTDIR/tools/spark-block-cleaner/"
   cp "$KYUUBI_HOME/tools/spark-block-cleaner/target/spark-block-cleaner-$VERSION.jar" "$DISTDIR/tools/spark-block-cleaner/jars/"
 fi
 

--- a/tools/spark-block-cleaner/kubernetes/docker/entrypoint.sh
+++ b/tools/spark-block-cleaner/kubernetes/docker/entrypoint.sh
@@ -20,5 +20,4 @@
 
 # shellcheck disable=SC2046
 exec /usr/bin/tini -s -- java -cp "${CLASS_PATH}:${CLEANER_CLASSPATH}" \
-  org.apache.kyuubi.tools.KubernetesSparkBlockCleaner \
-  | tee /log/cleanerLog/cleaner$(date "+%Y%m%d%H%M%S").out
+  org.apache.kyuubi.tools.KubernetesSparkBlockCleaner

--- a/tools/spark-block-cleaner/pom.xml
+++ b/tools/spark-block-cleaner/pom.xml
@@ -55,5 +55,10 @@
     <build>
         <outputDirectory>target/scala-${scala.binary.version}/classes</outputDirectory>
         <testOutputDirectory>target/scala-${scala.binary.version}/test-classes</testOutputDirectory>
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+        </resources>
     </build>
 </project>

--- a/tools/spark-block-cleaner/src/main/resources/log4j-block-cleaner.properties
+++ b/tools/spark-block-cleaner/src/main/resources/log4j-block-cleaner.properties
@@ -22,7 +22,7 @@ log4j.rootCategory=INFO, console, logFile
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{2}: %m%n
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %d{yyyy} %p %c{2}: %m%n
 
 ### logFile
 log4j.appender.logFile=org.apache.log4j.RollingFileAppender

--- a/tools/spark-block-cleaner/src/main/resources/log4j-block-cleaner.properties
+++ b/tools/spark-block-cleaner/src/main/resources/log4j-block-cleaner.properties
@@ -20,19 +20,14 @@ log4j.rootCategory=INFO, console, logFile
 
 ### console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
-log4j.appender.console.target=System.err
+log4j.appender.console.target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %d{yyyy} %p %c{2}: %m%n
 
 ### logFile
 log4j.appender.logFile=org.apache.log4j.RollingFileAppender
 log4j.appender.logFile.File=/logs/spark-block-cleaner-log/cleaner-log.out
-log4j.appender.logFile.MaxFileSize=100MB
+log4j.appender.logFile.MaxFileSize=20MB
 log4j.appender.logFile.MaxBackupIndex=5
 log4j.appender.logFile.layout=org.apache.log4j.PatternLayout
 log4j.appender.logFile.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{2}: %m%n
-
-# SPARK-34128：Suppress undesirable TTransportException warnings involved in THRIFT-4805
-log4j.appender.console.filter.1=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.console.filter.1.StringToMatch=Thrift error occurred during processing of message
-log4j.appender.console.filter.1.AcceptOnMatch=false

--- a/tools/spark-block-cleaner/src/main/resources/log4j-defaults.properties
+++ b/tools/spark-block-cleaner/src/main/resources/log4j-defaults.properties
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Set everything to be logged to the console
+log4j.rootCategory=INFO, console, logFile
+
+### console
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.target=System.err
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{2}: %m%n
+
+### logFile
+log4j.appender.logFile=org.apache.log4j.RollingFileAppender
+log4j.appender.logFile.File=/logs/spark-block-cleaner-log/cleaner-log.out
+log4j.appender.logFile.MaxFileSize=100MB
+log4j.appender.logFile.MaxBackupIndex=5
+log4j.appender.logFile.layout=org.apache.log4j.PatternLayout
+log4j.appender.logFile.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{2}: %m%n
+
+# SPARK-34128：Suppress undesirable TTransportException warnings involved in THRIFT-4805
+log4j.appender.console.filter.1=org.apache.log4j.varia.StringMatchFilter
+log4j.appender.console.filter.1.StringToMatch=Thrift error occurred during processing of message
+log4j.appender.console.filter.1.AcceptOnMatch=false

--- a/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
+++ b/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
@@ -20,9 +20,10 @@ package org.apache.kyuubi.tools
 import java.io.File
 import java.nio.file.{Files, Paths}
 import java.util.concurrent.{CountDownLatch, Executors}
-import org.apache.kyuubi.Logging
+
 import org.apache.log4j.PropertyConfigurator
 
+import org.apache.kyuubi.Logging
 /*
 * Spark storage shuffle data as the following structure.
 *

--- a/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
+++ b/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
@@ -20,8 +20,8 @@ package org.apache.kyuubi.tools
 import java.io.File
 import java.nio.file.{Files, Paths}
 import java.util.concurrent.{CountDownLatch, Executors}
-
 import org.apache.kyuubi.Logging
+import org.apache.log4j.PropertyConfigurator
 
 /*
 * Spark storage shuffle data as the following structure.
@@ -175,6 +175,8 @@ object KubernetesSparkBlockCleaner extends Logging {
 
   def main(args: Array[String]): Unit = {
     do {
+      PropertyConfigurator.configure(
+        Thread.currentThread().getContextClassLoader.getResource("log4j-block-cleaner.properties"))
       info(s"start all clean job")
       val startTime = System.currentTimeMillis()
       val hasFinished = new CountDownLatch(cacheDirs.length)

--- a/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
+++ b/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
@@ -24,6 +24,7 @@ import java.util.concurrent.{CountDownLatch, Executors}
 import org.apache.log4j.PropertyConfigurator
 
 import org.apache.kyuubi.Logging
+
 /*
 * Spark storage shuffle data as the following structure.
 *

--- a/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
+++ b/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
@@ -46,6 +46,9 @@ object KubernetesSparkBlockCleaner extends Logging {
 
   private val envMap = System.getenv()
 
+  PropertyConfigurator.configure(
+    Thread.currentThread().getContextClassLoader.getResource("log4j-block-cleaner.properties"))
+
   private val freeSpaceThreshold = envMap.getOrDefault(FREE_SPACE_THRESHOLD_KEY,
     "60").toInt
   private val fileExpiredTime = envMap.getOrDefault(FILE_EXPIRED_TIME_KEY,
@@ -176,8 +179,6 @@ object KubernetesSparkBlockCleaner extends Logging {
 
   def main(args: Array[String]): Unit = {
     do {
-      PropertyConfigurator.configure(
-        Thread.currentThread().getContextClassLoader.getResource("log4j-block-cleaner.properties"))
       info(s"start all clean job")
       val startTime = System.currentTimeMillis()
       val hasFinished = new CountDownLatch(cacheDirs.length)


### PR DESCRIPTION
### _Why are the changes needed?_
Spark-Block-Cleaner log files are not governed by itself.
Add log4j-defaults.properties to help input both console and file.
And use rollingFileApeender to split big logfile to small logFiles.
Create a log file under /logs/spark-block-cleaner-log/ so that you can manage the log yourself with the ability to clear the folder leading to `spark-`.  

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
