### PR TITLE
Kyuubi Spark External Shuffle Service

### DIFF
--- a/tools/kyuubi-shuffle-service/README.md
+++ b/tools/kyuubi-shuffle-service/README.md
@@ -1,0 +1,19 @@
+# Kyuubi Spark External Shuffle Service
+
+This enables the missing feature of Dynamic Resource Allocation(a.k.a, DRA, DA) for running Spark on Kubernetes, which provides the auto-scaling capability for Spark application, especially downscaling.
+
+Although there is a feature called shuffle tracking to track the shuffle data and tell Spark to remove executor while the data exceeds the time to live, these removals are coarse-grained.
+
+
+## Prerequisites
+
+- Every thing you need to know about Spark on Kubernetes
+- Running Spark on Kubernetes apps with hostNetwork enabled
+- Running this module as a DaemonSet with hostNetwork enabled
+- Self-managed shuffle data cleaner as the state of apps will not be posted to this service
+  - See: tools/spark-block-cleaner/kubernetes/spark-block-cleaner.yml
+
+
+## Usage
+
+Check `tools/kyuubi-shuffle-service/kubernetes/example.yaml` for more information.

--- a/tools/kyuubi-shuffle-service/README.md
+++ b/tools/kyuubi-shuffle-service/README.md
@@ -7,9 +7,9 @@ Although there is a feature called shuffle tracking to track the shuffle data an
 
 ## Prerequisites
 
-- Every thing you need to know about Spark on Kubernetes
-- Running Spark on Kubernetes apps with hostNetwork enabled
-- Running this module as a DaemonSet with hostNetwork enabled
+- Everything you need to know about Spark on Kubernetes
+- Running Spark on Kubernetes apps with `hostNetwork` enabled
+- Running this module as a DaemonSet with `hostNetwork` enabled
 - Self-managed shuffle data cleaner as the state of apps will not be posted to this service
   - See: tools/spark-block-cleaner/kubernetes/spark-block-cleaner.yml
 

--- a/tools/kyuubi-shuffle-service/kubernetes/docker/Dockerfile
+++ b/tools/kyuubi-shuffle-service/kubernetes/docker/Dockerfile
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Usage:
+#   docker build -f tools/kyuubi-shuffle-service/kubernetes/docker/Dockerfile -t yaooqinn/kyuubi-shuffle-service:tagname .
+#   docker push yaooqinn/kyuubi-shuffle-service:tagname
+
+# TODO: REPALCE it with offical spark image iff Apache Spark community deploy
+# Or make one after kyuubi to be setup under ASF
+
+ARG SPARK_IMAGE=yaooqinn/spark:3.1.2
+FROM ${SPARK_IMAGE}
+
+CMD [ "../bin/spark-class", "org.apache.spark.deploy.ExternalShuffleService" ]

--- a/tools/kyuubi-shuffle-service/kubernetes/example.yaml
+++ b/tools/kyuubi-shuffle-service/kubernetes/example.yaml
@@ -34,7 +34,7 @@ spec:
       containers:
         # the image built base on ./docker/Dockerfile
         - image: yaooqinn/kyuubi-shuffle-service:latest
-          name: exterbal-shuffle-server
+          name: external-shuffle-server
           resources:
             limits:
               memory: 1024Mi

--- a/tools/kyuubi-shuffle-service/kubernetes/example.yaml
+++ b/tools/kyuubi-shuffle-service/kubernetes/example.yaml
@@ -1,0 +1,81 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# kubectl apply -f tools/kyuubi-shuffle-service/kubernetes/example.yaml
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kyuubi-shuffle-service
+  namespace: default
+spec:
+  selector:
+    matchLabels:
+      name: kyuubi-shuffle-service
+  template:
+    metadata:
+      labels:
+        name: kyuubi-shuffle-service
+    spec:
+      containers:
+        # the image built base on ./docker/Dockerfile
+        - image: yaooqinn/kyuubi-shuffle-service:latest
+          name: exterbal-shuffle-server
+          resources:
+            limits:
+              memory: 1024Mi
+            requests:
+              cpu: 100m
+              memory: 512Mi
+          volumeMounts:
+            - name: spark-local-dir-1
+              mountPath: /opt/spark/data1
+            - name: spark-local-dir-2
+              mountPath: /opt/spark/data2
+          env:
+            # Change this in case of OOM based on you spec.containers.resources.* for
+            # the heap memory of shuffle service proc
+            - name: SPARK_DAEMON_MEMORY
+              value: 512M
+            # SPARK_SHUFFLE_OPTS allows us to pass spark configurations to the shuffle service
+            # spark.local.dir points to spec.containers.volumeMounts.*, shall be same as Spark
+            # app side.
+            # spark.shuffle.cleaner.interval=30s, this currently not work because only can a
+            # MesosExternalBlockStoreClient post ShuffleServiceHeartbeat here to change to app
+            # state for shuffle data clean, which means spark-block-cleaner tool is required
+            # spark.shuffle.service.enabled shall be enabled at least
+            # spark.shuffle.service.port=7337
+            # spark.shuffle.service.db.enabled=true
+            - name: SPARK_SHUFFLE_OPTS
+              value: -Dspark.shuffle.service.enabled=true -Dspark.local.dir=/opt/spark/data1,/opt/spark/data2
+          ports:
+            - name: ess-port
+              containerPort: 7337
+              protocol: TCP
+      terminationGracePeriodSeconds: 30
+      volumes:
+        # Directory on the host which store block dirs, see also in `volumeMounts`
+        - name: spark-local-dir-1
+          hostPath:
+            path: /Users/kentyao/Downloads/data/1
+        - name: spark-local-dir-2
+          hostPath:
+            path: /Users/kentyao/Downloads/data/2
+      # Currently, this ***requires* hostNetwork enabled for he executors to register.
+      # In other words, you have to run spark on kubernetes with executor pods' hostNetwork also
+      # enabled.
+      hostNetwork: true

--- a/tools/kyuubi-shuffle-service/kubernetes/example.yaml
+++ b/tools/kyuubi-shuffle-service/kubernetes/example.yaml
@@ -71,10 +71,10 @@ spec:
         # Directory on the host which store block dirs, see also in `volumeMounts`
         - name: spark-local-dir-1
           hostPath:
-            path: /Users/kentyao/Downloads/data/1
+            path: /tmp/data1
         - name: spark-local-dir-2
           hostPath:
-            path: /Users/kentyao/Downloads/data/2
+            path: /tmp/data2
       # Currently, this ***requires* hostNetwork enabled for he executors to register.
       # In other words, you have to run spark on kubernetes with executor pods' hostNetwork also
       # enabled.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

#### Kyuubi Spark External Shuffle Service

This enables the missing feature of Dynamic Resource Allocation(a.k.a, DRA, DA) for running Spark on Kubernetes, which provides the auto-scaling capability for Spark application, especially downscaling.

Although there is a feature called shuffle tracking to track the shuffle data and tell Spark to remove executor while the data exceeds the time to live, these removals are coarse-grained.


##### Prerequisites

- Everything you need to know about Spark on Kubernetes
- Running Spark on Kubernetes apps with hostNetwork enabled
- Running this module as a DaemonSet with hostNetwork enabled
- Self-managed shuffle data cleaner as the state of apps will not be posted to this service
  - See: tools/spark-block-cleaner/kubernetes/spark-block-cleaner.yml


##### Usage

Check `tools/kyuubi-shuffle-service/kubernetes/example.yaml` for more information.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request


#### cmd
```
bin/spark-sql 
```

#### config
```
spark.kubernetes.file.upload.path=./
spark.master=k8s://https://kubernetes.docker.internal:6443
spark.kubernetes.container.image=yaooqinn/spark:v20210619
spark.kubernetes.context=docker-for-desktop_1
spark.dynamicAllocation.enabled=true
spark.dynamicAllocation.minExecutors=2
spark.dynamicAllocation.maxExecutors=10
spark.driver.memory 5g
spark.kubernetes.executor.podNamePrefix=sparksql
spark.shuffle.service.enabled=true

spark.kubernetes.executor.podTemplateFile=/Users/kentyao/Downloads/executor-template.yml
spark.kubernetes.executor.volumes.hostPath.spark-local-dir-1.mount.path=/opt/spark/data1

spark.kubernetes.executor.volumes.hostPath.spark-local-dir-1.options.path=/Users/kentyao/Downloads/data/1

spark.kubernetes.executor.volumes.hostPath.spark-local-dir-2.mount.path=/opt/spark/data2

spark.kubernetes.executor.volumes.hostPath.spark-local-dir-2.options.path=/Users/kentyao/Downloads/data/2
spark.blockManager.port=0
```

#### query
```
SELECT /*+ REPARTITION */ 1 as pid, id from range(1, 10000, 1, 500);
```