### PR TITLE
[KYUUBI #844] Exposing Kyuubi as a NodePort service

### DIFF
--- a/docker/kyuubi-pod.yaml
+++ b/docker/kyuubi-pod.yaml
@@ -19,13 +19,13 @@
 # Start:
 #   kubectl apply -f https://raw.githubusercontent.com/apache/incubator-kyuubi/master/docker/kyuubi-pod.yaml
 # Expose port:
-# 1. for tmp test
+# 1. Expose the Pod by port-forward, for temporary test
 #   kubectl port-forward kyuubi-example --address localhost 10009:10009
 #   Connect:
 #     kubectl exec -it kyuubi-example -- /bin/bash
 #
 #     ${SPARK_HOME}/bin/beeline -u 'jdbc:hive2://localhost:10009'
-# 2. use NodePort
+# 2. Expose the Pod as a service with NodePort
 #   see usage of kyuubi-service.yaml
 # Logging
 #   kubectl logs -f kyuubi-example

--- a/docker/kyuubi-pod.yaml
+++ b/docker/kyuubi-pod.yaml
@@ -1,0 +1,51 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Usage:
+# Start:
+#   kubectl apply -f https://raw.githubusercontent.com/apache/incubator-kyuubi/master/docker/kyuubi-pod.yaml
+# Expose port:
+#  1. for tmp test
+#    kubectl port-forward kyuubi-example --address localhost 10009:10009
+#  2. use NodePort
+#    see usage of kyuubi-service.yaml
+# Connect:
+#   kubectl exec -it kyuubi-example -- /bin/bash
+#
+#   ${SPARK_HOME}/bin/beeline -u 'jdbc:hive2://localhost:10009'
+# Logging
+#   kubectl logs -f kyuubi-example
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kyuubi-example
+  labels:
+    app: kyuubi-server
+spec:
+  containers:
+    - name: kyuubi-server
+      # TODO: replace this with the official repo
+      image: yaooqinn/kyuubi:1.3.0
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: KYUUBI_JAVA_OPTS
+          value: -Dkyuubi.frontend.bind.host=0.0.0.0
+      ports:
+        - name: frontend-port
+          containerPort: 10009
+          protocol: TCP

--- a/docker/kyuubi-pod.yaml
+++ b/docker/kyuubi-pod.yaml
@@ -19,14 +19,14 @@
 # Start:
 #   kubectl apply -f https://raw.githubusercontent.com/apache/incubator-kyuubi/master/docker/kyuubi-pod.yaml
 # Expose port:
-#  1. for tmp test
-#    kubectl port-forward kyuubi-example --address localhost 10009:10009
-#  2. use NodePort
-#    see usage of kyuubi-service.yaml
-# Connect:
-#   kubectl exec -it kyuubi-example -- /bin/bash
+# 1. for tmp test
+#   kubectl port-forward kyuubi-example --address localhost 10009:10009
+#   Connect:
+#     kubectl exec -it kyuubi-example -- /bin/bash
 #
-#   ${SPARK_HOME}/bin/beeline -u 'jdbc:hive2://localhost:10009'
+#     ${SPARK_HOME}/bin/beeline -u 'jdbc:hive2://localhost:10009'
+# 2. use NodePort
+#   see usage of kyuubi-service.yaml
 # Logging
 #   kubectl logs -f kyuubi-example
 

--- a/docker/kyuubi-service.yaml
+++ b/docker/kyuubi-service.yaml
@@ -17,30 +17,25 @@
 
 # Usage:
 # Start:
-#   kubectl apply -f https://raw.githubusercontent.com/apache/incubator-kyuubi/master/docker/example.yaml
+#   kubectl apply -f https://raw.githubusercontent.com/apache/incubator-kyuubi/master/docker/kyuubi-service.yaml
 # Connect:
-#   kubectl port-forward kyuubi-example --address localhost 10009:10009
-# Or
-#   kubectl exec -it kyuubi-example -- /bin/bash
-#
-#   ${SPARK_HOME}/bin/beeline -u 'jdbc:hive2://localhost:10009'
-# Logging
-#   kubectl logs -f kyuubi-example
+#   ${SPARK_HOME}/bin/beeline -u 'jdbc:hive2://${hostname}:30009'
 
 apiVersion: v1
-kind: Pod
+kind: Service
 metadata:
-  name: kyuubi-example
+  name: kyuubi-example-service
 spec:
-  containers:
-    - name: kyuubi-server
-      # TODO: replace this with the official repo
-      image: yaooqinn/kyuubi:1.3.0
-      imagePullPolicy: IfNotPresent
-      env:
-        - name: KYUUBI_JAVA_OPTS
-          value: -Dkyuubi.frontend.bind.host=0.0.0.0
-      ports:
-        - name: frontend-port
-          containerPort: 10009
-          protocol: TCP
+  ports:
+    # The default port limit is 30000-32767
+    # to change:
+    #   vim kube-apiserver.yaml (usually under path: /etc/kubernetes/manifests/)
+    #   add or change line 'service-node-port-range=1-32767' under kube-apiserver
+    - nodePort: 30009
+      # same of containerPort in pod yaml
+      port: 10009
+      protocol: TCP
+  type: NodePort
+  selector:
+    # some of pod label
+    app: kyuubi-server

--- a/docker/kyuubi-service.yaml
+++ b/docker/kyuubi-service.yaml
@@ -19,7 +19,7 @@
 # Start:
 #   kubectl apply -f https://raw.githubusercontent.com/apache/incubator-kyuubi/master/docker/kyuubi-service.yaml
 # Connect:
-#   ${SPARK_HOME}/bin/beeline -u 'jdbc:hive2://${hostname}:30009'
+#   ${SPARK_HOME}/bin/beeline -u 'jdbc:hive2://${any_hostname_of_k8s_nodes}:30009'
 
 apiVersion: v1
 kind: Service

--- a/docker/kyuubi-service.yaml
+++ b/docker/kyuubi-service.yaml
@@ -37,5 +37,5 @@ spec:
       protocol: TCP
   type: NodePort
   selector:
-    # some of pod label
+    # same of pod label
     app: kyuubi-server


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`kubectl port-forward` usually use to test, use `NodePort` to visit kyuubi service in pod.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
