### PR TITLE
Avoid calling a stopped SparkContext

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -24,7 +24,8 @@ import org.apache.spark.SparkConf
 import org.apache.spark.kyuubi.SparkSQLEngineListener
 import org.apache.spark.sql.SparkSession
 
-import org.apache.kyuubi.{Logging, Utils}
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.Utils._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.spark.SparkSQLEngine.countDownLatch
 import org.apache.kyuubi.ha.HighAvailabilityConf._
@@ -68,7 +69,7 @@ object SparkSQLEngine extends Logging {
 
   var currentEngine: Option[SparkSQLEngine] = None
 
-  private val user = Utils.currentUser
+  private val user = currentUser
 
   private val countDownLatch = new CountDownLatch(1)
 
@@ -107,7 +108,8 @@ object SparkSQLEngine extends Logging {
     val engine = new SparkSQLEngine(spark)
     engine.initialize(kyuubiConf)
     engine.start()
-    sys.addShutdownHook(engine.stop())
+    // Stop engine before SparkContext stopped to avoid calling a stopped SparkContext
+    addShutdownHook(() => engine.stop(), SPARK_CONTEXT_SHUTDOWN_PRIORITY + 1)
     currentEngine = Some(engine)
     engine
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Utils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Utils.scala
@@ -168,12 +168,16 @@ private[kyuubi] object Utils extends Logging {
     System.getProperty(IS_TESTING.key) != null
   }
 
+  val DEFAULT_SHUTDOWN_PRIORITY = 100
+  val SERVER_SHUTDOWN_PRIORITY = 75
+  val SPARK_CONTEXT_SHUTDOWN_PRIORITY = 50
+
   /**
    * Add some operations that you want into ShutdownHook
    * @param hook
    * @param priority: 0~100
    */
-  def addShutdownHook(hook: Runnable, priority: Int): Unit = {
+  def addShutdownHook(hook: Runnable, priority: Int = DEFAULT_SHUTDOWN_PRIORITY): Unit = {
     ShutdownHookManager.get().addShutdownHook(hook, priority)
   }
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Utils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Utils.scala
@@ -170,6 +170,8 @@ private[kyuubi] object Utils extends Logging {
 
   val DEFAULT_SHUTDOWN_PRIORITY = 100
   val SERVER_SHUTDOWN_PRIORITY = 75
+  // The value follows org.apache.spark.util.ShutdownHookManager.SPARK_CONTEXT_SHUTDOWN_PRIORITY
+  // Hooks need to be invoked before the SparkContext stopped shall use a higher priority.
   val SPARK_CONTEXT_SHUTDOWN_PRIORITY = 50
 
   /**

--- a/kyuubi-main/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-main/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -46,7 +46,7 @@ object KyuubiServer extends Logging {
     server.start()
     Utils.addShutdownHook(new Runnable {
       override def run(): Unit = server.stop()
-    }, 100)
+    }, Utils.SERVER_SHUTDOWN_PRIORITY)
     server
   }
 

--- a/kyuubi-zookeeper/src/main/scala/org/apache/kyuubi/zookeeper/EmbeddedZookeeper.scala
+++ b/kyuubi-zookeeper/src/main/scala/org/apache/kyuubi/zookeeper/EmbeddedZookeeper.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.curator.test.{InstanceSpec, TestingServer}
 
-import org.apache.kyuubi.Utils
+import org.apache.kyuubi.Utils._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.service.{AbstractService, ServiceState}
 import org.apache.kyuubi.zookeeper.ZookeeperConf._
@@ -55,7 +55,7 @@ class EmbeddedZookeeper extends AbstractService("EmbeddedZookeeper") {
       }).toMap[String, Object].asJava
 
     val hostname = conf.get(ZK_CLIENT_PORT_ADDRESS).map(InetAddress.getByName)
-      .getOrElse(Utils.findLocalInetAddress).getCanonicalHostName
+      .getOrElse(findLocalInetAddress).getCanonicalHostName
     spec = new InstanceSpec(
       dataDirectory,
       clientPort,
@@ -74,7 +74,8 @@ class EmbeddedZookeeper extends AbstractService("EmbeddedZookeeper") {
   override def start(): Unit = synchronized {
     server.start()
     info(s"$getName is started at $getConnectString")
-    Utils.addShutdownHook(() => server.close(), 50)
+    // Stop the EmbeddedZookeeper after the Kyuubi server stopped
+    addShutdownHook(() => server.close(), SERVER_SHUTDOWN_PRIORITY - 1)
     super.start()
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We shall avoid calling cancelJobGroup if the sc is already stopped.

We shall stop the engine to stop serving before we stop the sc during the shutdown hook

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
