### PR TITLE
[KYUUBI #821] Improper exception for closing a non-existent session

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
@@ -217,11 +217,12 @@ class FrontendService private (name: String, be: BackendService, oomHook: Runnab
     try {
       be.closeSession(handle)
       resp.setStatus(OK_STATUS)
-      Option(CURRENT_SERVER_CONTEXT.get()).foreach(_.setSessionHandle(null))
     } catch {
       case e: Exception =>
         warn("Error closing session: ", e)
         resp.setStatus(KyuubiSQLException.toTStatus(e))
+    } finally {
+      Option(CURRENT_SERVER_CONTEXT.get()).foreach(_.setSessionHandle(null))
     }
     info(s"Finished closing $handle")
     resp


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

**ROOT CAUSE**
When server receive request of close session, will call `FrontendService#CloseSession`. When an error is encountered when closing the session, `CURRENT_SERVER_CONTEXT` will never be called.

```
2021-08-02 09:41:50.945 INFO service.FrontendService: Received request of closing SessionHandle [f3545c54-2e94-4090-aaa6-4397e653bb72]
2021-08-02 09:41:50.946 INFO session.KyuubiSessionManager: SessionHandle [f3545c54-2e94-4090-aaa6-4397e653bb72] is closed, current opening sessions 0
2021-08-02 09:41:50.949 WARN service.FrontendService: Error closing session: 
org.apache.kyuubi.KyuubiSQLException: Error while cleaning up the engine resources
	at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:68)
	at org.apache.kyuubi.session.KyuubiSessionImpl.close(KyuubiSessionImpl.scala:89)
	at org.apache.kyuubi.session.SessionManager.closeSession(SessionManager.scala:74)
	at org.apache.kyuubi.service.AbstractBackendService.closeSession(AbstractBackendService.scala:49)
	at org.apache.kyuubi.service.FrontendService.CloseSession(FrontendService.scala:218)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$CloseSession.getResult(TCLIService.java:1397)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$CloseSession.getResult(TCLIService.java:1382)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
	at org.apache.kyuubi.service.authentication.TSetIpAddressProcessor.process(TSetIpAddressProcessor.scala:36)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: org.apache.thrift.transport.TTransportException
	at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:132)
	at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
	at org.apache.thrift.transport.TSaslTransport.readLength(TSaslTransport.java:376)
	at org.apache.thrift.transport.TSaslTransport.readFrame(TSaslTransport.java:453)
	at org.apache.thrift.transport.TSaslTransport.read(TSaslTransport.java:435)
	at org.apache.thrift.transport.TSaslClientTransport.read(TSaslClientTransport.java:37)
	at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86)
	at org.apache.thrift.protocol.TBinaryProtocol.readAll(TBinaryProtocol.java:429)
	at org.apache.thrift.protocol.TBinaryProtocol.readI32(TBinaryProtocol.java:318)
	at org.apache.thrift.protocol.TBinaryProtocol.readMessageBegin(TBinaryProtocol.java:219)
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:77)
	at org.apache.hive.service.rpc.thrift.TCLIService$Client.recv_CloseSession(TCLIService.java:191)
	at org.apache.hive.service.rpc.thrift.TCLIService$Client.CloseSession(TCLIService.java:178)
	at org.apache.kyuubi.client.KyuubiSyncThriftClient.$anonfun$closeSession$1(KyuubiSyncThriftClient.scala:67)
	at org.apache.kyuubi.client.KyuubiSyncThriftClient.withLockAcquired(KyuubiSyncThriftClient.scala:47)
	at org.apache.kyuubi.client.KyuubiSyncThriftClient.closeSession(KyuubiSyncThriftClient.scala:67)
	at org.apache.kyuubi.session.KyuubiSessionImpl.close(KyuubiSessionImpl.scala:86)
	... 12 more
2021-08-02 09:41:50.953 INFO service.FrontendService: Finished closing SessionHandle [f3545c54-2e94-4090-aaa6-4397e653bb72]
2021-08-02 09:41:50.957 INFO service.FrontendService: Session [SessionHandle [f3545c54-2e94-4090-aaa6-4397e653bb72]] disconnected without closing properly, close it now
2021-08-02 09:41:50.963 INFO service.FrontendService: Session [SessionHandle [f3545c54-2e94-4090-aaa6-4397e653bb72]] disconnected without closing properly, close it now
2021-08-02 09:41:50.964 WARN service.FrontendService: Failed closing session
org.apache.kyuubi.KyuubiSQLException: Invalid SessionHandle [f3545c54-2e94-4090-aaa6-4397e653bb72]
	at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:68)
	at org.apache.kyuubi.session.SessionManager.closeSession(SessionManager.scala:71)
	at org.apache.kyuubi.service.AbstractBackendService.closeSession(AbstractBackendService.scala:49)
	at org.apache.kyuubi.service.FrontendService$FeTServerEventHandler.deleteContext(FrontendService.scala:529)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:300)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
2021-08-02 09:42:30.908 INFO server.ZooKeeperServer: Expiring session 0x1000da7829f0002, timeout of 60000ms exceeded
2021-08-02 09:42:30.909 INFO server.PrepRequestProcessor: Processed session termination for sessionid: 0x1000da7829f0002
```



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
