### PR TITLE
[KYUUBI #895] Enhance output uses the default spark conf

### DIFF
--- a/bin/kyuubi
+++ b/bin/kyuubi
@@ -76,7 +76,7 @@ if [[ -z ${SPARK_HOME} ]]; then
   exit 1
 else
   if [[ ! -x "${SPARK_HOME}/bin/spark-submit" ]]; then
-    echo echo "Error: INVALID SPARK DISTRIBUTION! CANNOT PROCEED." >&2
+    echo "Error: INVALID SPARK DISTRIBUTION! CANNOT PROCEED." >&2
     exit 1
   fi
 fi

--- a/bin/load-kyuubi-env.sh
+++ b/bin/load-kyuubi-env.sh
@@ -102,7 +102,7 @@ if [ $silent -eq 0 ]; then
   echo "KYUUBI_WORK_DIR_ROOT: ${KYUUBI_WORK_DIR_ROOT}"
 
   echo "SPARK_HOME: ${SPARK_HOME}"
-  echo "SPARK_CONF_DIR: ${SPARK_CONF_DIR}"
+  echo "SPARK_CONF_DIR: ${SPARK_CONF_DIR:-"${SPARK_HOME}/conf"}"
 
   echo "HADOOP_CONF_DIR: ${HADOOP_CONF_DIR}"
 fi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When start the server, If not specified `SPARK_CONF_DIR`, it should output default.
```
KYUUBI_WORK_DIR_ROOT: /root/tmp/kyuubi/work
SPARK_HOME: /root/package/spark-3.1.2-bin-hadoop2.7
SPARK_CONF_DIR:
HADOOP_CONF_DIR: /root/package/hadoop-3.2.0/etc/hadoop
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
