### PR TITLE
Avoid RejectedExecutionException if engine is shutdown

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
@@ -198,6 +198,8 @@ abstract class SessionManager(name: String) extends CompositeService(name) {
     }
   }
 
+  def isShutdown: Boolean = shutdown
+
   private def startTimeoutChecker(): Unit = {
     val interval = conf.get(SESSION_CHECK_INTERVAL)
     val timeout = conf.get(SESSION_IDLE_TIMEOUT)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Engine can be shutdown but not stopped when an operation is submitted , then we might get such exception:

```
2021-08-05 14:19:33.787 WARN service.FrontendService: Error executing statement:
org.apache.kyuubi.KyuubiSQLException: Error submitting query in background, query rejected
	at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:68)
	at org.apache.kyuubi.engine.spark.operation.ExecuteStatement.runInternal(ExecuteStatement.scala:124)
	at org.apache.kyuubi.operation.AbstractOperation.run(AbstractOperation.scala:130)
	at org.apache.kyuubi.session.AbstractSession.runOperation(AbstractSession.scala:95)
	at org.apache.kyuubi.session.AbstractSession.$anonfun$executeStatement$1(AbstractSession.scala:123)
	at org.apache.kyuubi.session.AbstractSession.withAcquireRelease(AbstractSession.scala:78)
	at org.apache.kyuubi.session.AbstractSession.executeStatement(AbstractSession.scala:120)
	at org.apache.kyuubi.service.AbstractBackendService.executeStatement(AbstractBackendService.scala:61)
	at org.apache.kyuubi.service.FrontendService.ExecuteStatement(FrontendService.scala:256)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$ExecuteStatement.getResult(TCLIService.java:1557)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$ExecuteStatement.getResult(TCLIService.java:1542)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
	at org.apache.kyuubi.service.authentication.TSetIpAddressProcessor.process(TSetIpAddressProcessor.scala:36)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:310)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.util.concurrent.RejectedExecutionException: Task java.util.concurrent.FutureTask@1202ad6e rejected from java.util.concurrent.ThreadPoolExecutor@a50ca2b[Terminated, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0]

```

It's noisy to print this excption.

### _How was this patch tested?_
Pass CI