### PR TITLE
[KYUUBI #902] Wrong operation statistics on kyuubi page

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -64,7 +64,7 @@ class ExecuteStatement(
 
   private val kyuubiStatementInfo = KyuubiStatementInfo(
     statementId, statement, spark.sparkContext.applicationId,
-    session.getTypeInfo.identifier, Map(state -> lastAccessTime))
+    session.handle.identifier, Map(state -> lastAccessTime))
   KyuubiStatementMonitor.putStatementInfoIntoQueue(kyuubiStatementInfo)
 
   override protected def resultSchema: StructType = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When serveral sql statements finished, wrong statistics of operations are displayed on kyuubi page.
```
1 session(s) are online, running 5 operations
```

![image](https://user-images.githubusercontent.com/86483005/128631227-9bbb30f3-25ad-4c18-90f9-dd63da0cff1b.png)

**ROOT CAUSE**
When run each statement, will run `getTypeInfo` internally.


**SparkSQL Engine Log**
```
2021-08-08 14:31:40.086 INFO log.OperationLog: Creating operation log file /tmp/hadoop-08fa33a4-0aee-4556-865e-bb9866f3fb3a/operation_logs/b9ba0414-4960-4e3a-b31c-717b9dcdd1e1/84e35aea-f84e-4da1-a827-97e818062d78
2021-08-08 14:31:40.087 INFO operation.GetTypeInfo: Processing hadoop's query[2714ab78-b9f6-4fd2-ac43-dc9d0ac52157]: INITIALIZED_STATE -> RUNNING_STATE, statement: GET_TYPE_INFO
2021-08-08 14:31:40.088 INFO operation.GetTypeInfo: Processing hadoop's query[2714ab78-b9f6-4fd2-ac43-dc9d0ac52157]: RUNNING_STATE -> FINISHED_STATE, statement: GET_TYPE_INFO, time taken: 0.001 seconds
2021-08-08 14:31:40.088 INFO monitor.KyuubiStatementMonitor: Add kyuubiStatementInfo into queue is [true], statementId is [84e35aea-f84e-4da1-a827-97e818062d78]
2021-08-08 14:31:40.088 INFO operation.ExecuteStatement: s statemendId 84e35aea-f84e-4da1-a827-97e818062d78, sessionId: b9ba0414-4960-4e3a-b31c-717b9dcdd1e1
2021-08-08 14:31:40.088 INFO operation.ExecuteStatement: s statemendId 84e35aea-f84e-4da1-a827-97e818062d78, sessionId: b9ba0414-4960-4e3a-b31c-717b9dcdd1e1
2021-08-08 14:31:40.088 INFO operation.ExecuteStatement: s statemendId 84e35aea-f84e-4da1-a827-97e818062d78, sessionId: b9ba0414-4960-4e3a-b31c-717b9dcdd1e1
2021-08-08 14:31:40.088 INFO operation.ExecuteStatement: Processing hadoop's query[84e35aea-f84e-4da1-a827-97e818062d78]: INITIALIZED_STATE -> PENDING_STATE, statement: select 1
2021-08-08 14:31:40.089 INFO operation.ExecuteStatement: Processing hadoop's query[84e35aea-f84e-4da1-a827-97e818062d78]: PENDING_STATE -> RUNNING_STATE, statement: select 1
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/tools/testing.html#running-tests) locally before make a pull request
