### PR TITLE
Support add repartition for OptimizedCreateHiveTableAsSelectCommand

### DIFF
--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiAnalysis.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiAnalysis.scala
@@ -18,17 +18,15 @@
 package org.apache.kyuubi.sql
 
 import java.util.Random
-
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, Literal, Multiply, Rand}
 import org.apache.spark.sql.catalyst.plans.logical._
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command.CreateDataSourceTableAsSelectCommand
 import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationCommand
-import org.apache.spark.sql.hive.execution.{CreateHiveTableAsSelectCommand, InsertIntoHiveTable}
+import org.apache.spark.sql.hive.execution.{CreateHiveTableAsSelectCommand, InsertIntoHiveTable, OptimizedCreateHiveTableAsSelectCommand}
 import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.types.IntegerType
-
 import org.apache.kyuubi.sql.RepartitionBeforeWriteHelper._
 
 /**
@@ -128,6 +126,26 @@ case class RepartitionBeforeWriteHive(session: SparkSession) extends Rule[Logica
       }
 
     case c @ CreateHiveTableAsSelectCommand(table, query, _, _)
+      if query.resolved && table.bucketSpec.isEmpty && canInsertRepartitionByExpression(query) =>
+      val dynamicPartitionColumns =
+        query.output.filter(attr => table.partitionColumnNames.contains(attr.name))
+      if (dynamicPartitionColumns.isEmpty) {
+        c.copy(query =
+          RepartitionByExpression(
+            Seq.empty,
+            query,
+            conf.getConf(KyuubiSQLConf.INSERT_REPARTITION_NUM)))
+      } else {
+        val extended = dynamicPartitionColumns ++ dynamicPartitionExtraExpression(
+          conf.getConf(KyuubiSQLConf.DYNAMIC_PARTITION_INSERTION_REPARTITION_NUM))
+        c.copy(query =
+          RepartitionByExpression(
+            extended,
+            query,
+            conf.getConf(KyuubiSQLConf.INSERT_REPARTITION_NUM)))
+      }
+
+    case c @ OptimizedCreateHiveTableAsSelectCommand(table, query, _, _)
       if query.resolved && table.bucketSpec.isEmpty && canInsertRepartitionByExpression(query) =>
       val dynamicPartitionColumns =
         query.output.filter(attr => table.partitionColumnNames.contains(attr.name))

--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiAnalysis.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiAnalysis.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.sql
 
 import java.util.Random
+
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.{Cast, Expression, Literal, Multiply, Rand}
 import org.apache.spark.sql.catalyst.plans.logical._
@@ -27,6 +28,7 @@ import org.apache.spark.sql.execution.datasources.InsertIntoHadoopFsRelationComm
 import org.apache.spark.sql.hive.execution.{CreateHiveTableAsSelectCommand, InsertIntoHiveTable, OptimizedCreateHiveTableAsSelectCommand}
 import org.apache.spark.sql.internal.StaticSQLConf
 import org.apache.spark.sql.types.IntegerType
+
 import org.apache.kyuubi.sql.RepartitionBeforeWriteHelper._
 
 /**

--- a/dev/kyuubi-extension-spark-3-1/src/test/scala/org/apache/spark/sql/KyuubiExtensionSuite.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/test/scala/org/apache/spark/sql/KyuubiExtensionSuite.scala
@@ -403,20 +403,18 @@ class KyuubiExtensionSuite extends QueryTest with SQLTestUtils with AdaptiveSpar
   }
 
   test("OptimizedCreateHiveTableAsSelectCommand") {
-    withTempView("v") {
-      withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> "true",
-        HiveUtils.CONVERT_METASTORE_CTAS.key -> "true") {
-        withTable("t") {
-          val df = sql(s"CREATE TABLE t STORED AS parquet AS SELECT 1 as a")
-          val ctas = df.queryExecution.analyzed.collect {
-            case _: OptimizedCreateHiveTableAsSelectCommand => true
-          }
-          assert(ctas.size == 1)
-          val repartition = df.queryExecution.analyzed.collect {
-            case _: RepartitionByExpression => true
-          }
-          assert(repartition.size == 1)
+    withSQLConf(HiveUtils.CONVERT_METASTORE_PARQUET.key -> "true",
+      HiveUtils.CONVERT_METASTORE_CTAS.key -> "true") {
+      withTable("t") {
+        val df = sql(s"CREATE TABLE t STORED AS parquet AS SELECT 1 as a")
+        val ctas = df.queryExecution.analyzed.collect {
+          case _: OptimizedCreateHiveTableAsSelectCommand => true
         }
+        assert(ctas.size == 1)
+        val repartition = df.queryExecution.analyzed.collect {
+          case _: RepartitionByExpression => true
+        }
+        assert(repartition.size == 1)
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We missed a ctas node `OptimizedCreateHiveTableAsSelectCommand`. This PR aims to support add repartition for `OptimizedCreateHiveTableAsSelectCommand`.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
