### PR TITLE
[KYUUBI #933] Enhance the detection mechanism for engine startup

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCli.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCli.scala
@@ -94,7 +94,7 @@ private[kyuubi] class ServiceControlCli extends Logging {
           currentServerNodes.foreach { sn =>
             info(s"Exposing server instance:${sn.instance} with version:${sn.version}" +
               s" from $fromNamespace to $toNamespace")
-            val newNode = createZkServiceNode(
+            val newNode = createServiceNode(
               kyuubiConf, zc, args.cliArgs.namespace, sn.instance, sn.version, true)
             exposedServiceNodes += sn.copy(
               namespace = toNamespace,

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
@@ -159,7 +159,8 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
 
   test("test render zookeeper service node info") {
     val title = "test render"
-    val nodes = Seq(ServiceNodeInfo("/kyuubi", "serviceNode", "localhost", 10000, Some("version")))
+    val nodes = Seq(
+      ServiceNodeInfo("/kyuubi", "serviceNode", "localhost", 10000, Some("version"), None))
     val renderedInfo = renderServiceNodesInfo(title, nodes, true)
     val expected = {
       s"\n               $title               " +
@@ -187,8 +188,8 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
     System.setProperty(HA_ZK_NAMESPACE.key, uniqueNamespace)
 
     withZkClient(conf) { framework =>
-      createZkServiceNode(conf, framework, uniqueNamespace, "localhost:10000")
-      createZkServiceNode(conf, framework, uniqueNamespace, "localhost:10001")
+      createServiceNode(conf, framework, uniqueNamespace, "localhost:10000")
+      createServiceNode(conf, framework, uniqueNamespace, "localhost:10001")
 
       val newNamespace = getUniqueNamespace()
       val args = Array(
@@ -198,8 +199,8 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       )
 
       val expectedCreatedNodes = Seq(
-        ServiceNodeInfo(s"/$newNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION)),
-        ServiceNodeInfo(s"/$newNamespace", "", "localhost", 10001, Some(KYUUBI_VERSION))
+        ServiceNodeInfo(s"/$newNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION), None),
+        ServiceNodeInfo(s"/$newNamespace", "", "localhost", 10001, Some(KYUUBI_VERSION), None)
       )
 
       testPrematureExit(args, getRenderedNodesInfoWithoutTitle(expectedCreatedNodes, false))
@@ -244,8 +245,8 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       .set(KyuubiConf.FRONTEND_BIND_PORT, 0)
 
     withZkClient(conf) { framework =>
-      createZkServiceNode(conf, framework, uniqueNamespace, "localhost:10000")
-      createZkServiceNode(conf, framework, uniqueNamespace, "localhost:10001")
+      createServiceNode(conf, framework, uniqueNamespace, "localhost:10000")
+      createServiceNode(conf, framework, uniqueNamespace, "localhost:10001")
 
       val args = Array(
         "list", "server",
@@ -254,8 +255,8 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       )
 
       val expectedNodes = Seq(
-        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION)),
-        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10001, Some(KYUUBI_VERSION))
+        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION), None),
+        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10001, Some(KYUUBI_VERSION), None)
       )
 
       testPrematureExit(args, getRenderedNodesInfoWithoutTitle(expectedNodes, false))
@@ -272,8 +273,8 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       .set(KyuubiConf.FRONTEND_BIND_PORT, 0)
 
     withZkClient(conf) { framework =>
-      createZkServiceNode(conf, framework, uniqueNamespace, "localhost:10000")
-      createZkServiceNode(conf, framework, uniqueNamespace, "localhost:10001")
+      createServiceNode(conf, framework, uniqueNamespace, "localhost:10000")
+      createServiceNode(conf, framework, uniqueNamespace, "localhost:10001")
 
       val args = Array(
         "get", "server",
@@ -284,7 +285,7 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       )
 
       val expectedNodes = Seq(
-        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION))
+        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION), None)
       )
 
       testPrematureExit(args, getRenderedNodesInfoWithoutTitle(expectedNodes, false))
@@ -302,8 +303,8 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
 
     withZkClient(conf) { framework =>
       withZkClient(conf) { zc =>
-        createZkServiceNode(conf, zc, uniqueNamespace, "localhost:10000", external = true)
-        createZkServiceNode(conf, zc, uniqueNamespace, "localhost:10001", external = true)
+        createServiceNode(conf, zc, uniqueNamespace, "localhost:10000", external = true)
+        createServiceNode(conf, zc, uniqueNamespace, "localhost:10001", external = true)
       }
 
       val args = Array(
@@ -315,7 +316,7 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       )
 
       val expectedDeletedNodes = Seq(
-        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION))
+        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION), None)
       )
 
       testPrematureExit(args, getRenderedNodesInfoWithoutTitle(expectedDeletedNodes, false))
@@ -332,8 +333,8 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       .set(KyuubiConf.FRONTEND_BIND_PORT, 0)
 
     withZkClient(conf) { framework =>
-      createZkServiceNode(conf, framework, uniqueNamespace, "localhost:10000")
-      createZkServiceNode(conf, framework, uniqueNamespace, "localhost:10001")
+      createServiceNode(conf, framework, uniqueNamespace, "localhost:10000")
+      createServiceNode(conf, framework, uniqueNamespace, "localhost:10001")
 
       val args = Array(
         "list", "server",
@@ -343,8 +344,8 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       )
 
       val expectedNodes = Seq(
-        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION)),
-        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10001, Some(KYUUBI_VERSION))
+        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10000, Some(KYUUBI_VERSION), None),
+        ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10001, Some(KYUUBI_VERSION), None)
       )
 
       testPrematureExit(args, getRenderedNodesInfoWithoutTitle(expectedNodes, true))

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
@@ -103,7 +103,7 @@ object HighAvailabilityConf {
   // This option will not be exposed to the user.
   val HA_ZK_ENGINE_SESSION_ID: OptionalConfigEntry[String] =
     ConfigBuilder("kyuubi.ha.engine.session.id")
-    .version("1.3.0")
+    .version("1.4.0")
     .stringConf
     .createOptional
 }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
@@ -21,7 +21,7 @@ import java.time.Duration
 
 import org.apache.hadoop.security.UserGroupInformation
 
-import org.apache.kyuubi.config.{ConfigBuilder, ConfigEntry, KyuubiConf}
+import org.apache.kyuubi.config.{ConfigBuilder, ConfigEntry, KyuubiConf, OptionalConfigEntry}
 import org.apache.kyuubi.ha.client.RetryPolicies
 
 object HighAvailabilityConf {
@@ -101,7 +101,8 @@ object HighAvailabilityConf {
     .createWithDefault(Duration.ofSeconds(120).toMillis)
 
   // This option will not be exposed to the user.
-  val HA_ZK_ENGINE_SESSION_ID: ConfigEntry[String] = ConfigBuilder("kyuubi.ha.engine.session.id")
+  val HA_ZK_ENGINE_SESSION_ID: OptionalConfigEntry[String] =
+    ConfigBuilder("kyuubi.ha.engine.session.id")
     .version("1.3.0")
     .stringConf
     .createOptional

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
@@ -99,4 +99,10 @@ object HighAvailabilityConf {
     .timeConf
     .checkValue(_ > 0, "Must be positive")
     .createWithDefault(Duration.ofSeconds(120).toMillis)
+
+  // This option will not be exposed to the user.
+  val HA_ZK_ENGINE_SESSION_ID: ConfigEntry[String] = ConfigBuilder("kyuubi.ha.engine.session.id")
+    .version("1.2.0")
+    .stringConf
+    .createWithDefault("-1")
 }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
@@ -102,7 +102,7 @@ object HighAvailabilityConf {
 
   // This option will not be exposed to the user.
   val HA_ZK_ENGINE_SESSION_ID: ConfigEntry[String] = ConfigBuilder("kyuubi.ha.engine.session.id")
-    .version("1.2.0")
+    .version("1.3.0")
     .stringConf
-    .createWithDefault("-1")
+    .createOptional
 }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
@@ -100,9 +100,11 @@ object HighAvailabilityConf {
     .checkValue(_ > 0, "Must be positive")
     .createWithDefault(Duration.ofSeconds(120).toMillis)
 
-  // This option will not be exposed to the user.
   val HA_ZK_ENGINE_SESSION_ID: OptionalConfigEntry[String] =
-    ConfigBuilder("kyuubi.ha.engine.session.id")
+    buildConf("ha.engine.session.id")
+    .doc("The sessionId will be attached to zookeeper node when engine started, " +
+      "and the kyuubi server will check it cyclically.")
+    .internal
     .version("1.4.0")
     .stringConf
     .createOptional

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -161,11 +161,11 @@ object ServiceDiscovery extends Logging {
     zkEnsemble != null && zkEnsemble.nonEmpty
   }
 
-  def getServerHost(zkClient: CuratorFramework, namespace: String): Option[ServiceNodeInfo] = {
+  def getServerHost(zkClient: CuratorFramework, namespace: String): Option[(String, Int)] = {
     // TODO: use last one because to avoid touching some maybe-crashed engines
     // We need a big improvement here.
     getServiceNodesInfo(zkClient, namespace, Some(1), silent = true) match {
-      case Seq(sn) => Some(sn)
+      case Seq(sn) => Some((sn.host, sn.port))
       case _ => None
     }
   }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -256,6 +256,6 @@ case class ServiceNodeInfo(
     host: String,
     port: Int,
     version: Option[String],
-    sessionId: Option[String]) {
+    createSessionId: Option[String]) {
   def instance: String = s"$host:$port"
 }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -170,6 +170,15 @@ object ServiceDiscovery extends Logging {
     }
   }
 
+  def getEngineBySessionId(
+     zkClient: CuratorFramework,
+     namespace: String,
+     sessionId: String): Option[(String, Int)] = {
+    getServiceNodesInfo(zkClient, namespace, silent = true)
+      .find(_.createSessionId.exists(_.equals(sessionId)))
+      .map(data => (data.host, data.port))
+  }
+
   def getServiceNodesInfo(
       zkClient: CuratorFramework,
       namespace: String,
@@ -217,7 +226,7 @@ object ServiceDiscovery extends Logging {
         throw new KyuubiException(s"Failed to create namespace '$ns'", e)
     }
 
-    val session = conf.getOption(HA_ZK_ENGINE_SESSION_ID.key)
+    val session = conf.get(HA_ZK_ENGINE_SESSION_ID)
       .map(sid => s"session=$sid;").getOrElse("")
     val pathPrefix = ZKPaths.makePath(
       namespace,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -126,7 +126,7 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
   }
 
   private def create(zkClient: CuratorFramework): (String, Int) = tryWithLock(zkClient) {
-    var engineRef = getEngineBySessionId(zkClient)
+    var engineRef = getEngineBySessionId(zkClient, engineSpace, sessionId)
     // Get the engine address ahead if another process has succeeded
     if (engineRef.nonEmpty) return engineRef.get
 
@@ -162,7 +162,7 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
             s"Timeout($timeout ms) to launched Spark with $builder",
             builder.getError)
         }
-        engineRef = getEngineBySessionId(zkClient)
+        engineRef = getEngineBySessionId(zkClient, engineSpace, sessionId)
       }
       engineRef.get
     } finally {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -126,7 +126,8 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
   }
 
   private def create(zkClient: CuratorFramework): (String, Int) = tryWithLock(zkClient) {
-    var engineRef = getEngineBySessionId(zkClient, engineSpace, sessionId)
+    // TODO: improve this after support engine pool
+    var engineRef = getServerHost(zkClient, engineSpace)
     // Get the engine address ahead if another process has succeeded
     if (engineRef.nonEmpty) return engineRef.get
 
@@ -177,7 +178,6 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
    */
   def getOrCreate(zkClient: CuratorFramework): (String, Int) = {
     getServerHost(zkClient, engineSpace)
-      .map(data => (data.host, data.port))
       .getOrElse {
         create(zkClient)
       }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -181,9 +181,11 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
    * Get the engine ref from engine space first first or create a new one
    */
   def getOrCreate(zkClient: CuratorFramework): (String, Int) = {
-    get(zkClient).getOrElse {
-      create(zkClient)
-    }
+    getServerHost(zkClient, engineSpace)
+      .map(data => (data.host, data.port))
+      .getOrElse {
+        create(zkClient)
+      }
   }
 }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -33,6 +33,7 @@ import org.apache.kyuubi.engine.spark.SparkProcessBuilder
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_ENGINE_SESSION_ID
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_NAMESPACE
 import org.apache.kyuubi.ha.client.ServiceDiscovery.getServerHost
+import org.apache.kyuubi.ha.client.ServiceDiscovery.getServiceNodesInfo
 import org.apache.kyuubi.metrics.MetricsConstants.{ENGINE_FAIL, ENGINE_TIMEOUT, ENGINE_TOTAL}
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.session.SessionHandle
@@ -125,8 +126,8 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
   }
 
   private def get(zkClient: CuratorFramework): Option[(String, Int)] = {
-    getServerHost(zkClient, engineSpace)
-      .filter(_.createSessionId.exists(_.equals(sessionId)))
+    getServiceNodesInfo(zkClient, engineSpace, silent = true)
+      .find(_.createSessionId.exists(_.equals(sessionId)))
       .map(data => (data.host, data.port))
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -32,8 +32,8 @@ import org.apache.kyuubi.engine.ShareLevel.{CONNECTION, SERVER, ShareLevel}
 import org.apache.kyuubi.engine.spark.SparkProcessBuilder
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_ENGINE_SESSION_ID
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_NAMESPACE
+import org.apache.kyuubi.ha.client.ServiceDiscovery.getEngineBySessionId
 import org.apache.kyuubi.ha.client.ServiceDiscovery.getServerHost
-import org.apache.kyuubi.ha.client.ServiceDiscovery.getServiceNodesInfo
 import org.apache.kyuubi.metrics.MetricsConstants.{ENGINE_FAIL, ENGINE_TIMEOUT, ENGINE_TOTAL}
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.session.SessionHandle
@@ -123,12 +123,6 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
           case _: Exception =>
         }
       }
-  }
-
-  private def getEngineBySessionId(zkClient: CuratorFramework): Option[(String, Int)] = {
-    getServiceNodesInfo(zkClient, engineSpace, silent = true)
-      .find(_.createSessionId.exists(_.equals(sessionId)))
-      .map(data => (data.host, data.port))
   }
 
   private def create(zkClient: CuratorFramework): (String, Int) = tryWithLock(zkClient) {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -126,7 +126,7 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
 
   private def get(zkClient: CuratorFramework): Option[(String, Int)] = {
     getServerHost(zkClient, engineSpace)
-      .filter(_.sessionId.exists(_.equals(sessionId)))
+      .filter(_.createSessionId.exists(_.equals(sessionId)))
       .map(data => (data.host, data.port))
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -126,7 +126,7 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
   }
 
   private def create(zkClient: CuratorFramework): (String, Int) = tryWithLock(zkClient) {
-    // TODO: improve this after support engine pool
+    // TODO: improve this after support engine pool. (KYUUBI #918)
     var engineRef = getServerHost(zkClient, engineSpace)
     // Get the engine address ahead if another process has succeeded
     if (engineRef.nonEmpty) return engineRef.get

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -30,6 +30,7 @@ import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_INIT_TIMEOUT, ENGINE_SHARE_LEVEL, ENGINE_SHARE_LEVEL_SUB_DOMAIN}
 import org.apache.kyuubi.engine.ShareLevel.{CONNECTION, SERVER, ShareLevel}
 import org.apache.kyuubi.engine.spark.SparkProcessBuilder
+import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_ENGINE_SESSION_ID
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_NAMESPACE
 import org.apache.kyuubi.ha.client.ServiceDiscovery.getServerHost
 import org.apache.kyuubi.metrics.MetricsConstants.{ENGINE_FAIL, ENGINE_TIMEOUT, ENGINE_TOTAL}
@@ -125,6 +126,8 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
 
   private def get(zkClient: CuratorFramework): Option[(String, Int)] = {
     getServerHost(zkClient, engineSpace)
+      .filter(_.sessionId.exists(_.equals(sessionId)))
+      .map(data => (data.host, data.port))
   }
 
   private def create(zkClient: CuratorFramework): (String, Int) = tryWithLock(zkClient) {
@@ -137,6 +140,7 @@ private[kyuubi] class EngineRef private(conf: KyuubiConf, user: String, sessionI
     conf.set(SparkProcessBuilder.TAG_KEY,
       conf.getOption(SparkProcessBuilder.TAG_KEY).map(_ + ",").getOrElse("") + "KYUUBI")
     conf.set(HA_ZK_NAMESPACE, engineSpace)
+    conf.set(HA_ZK_ENGINE_SESSION_ID, sessionId)
     val builder = new SparkProcessBuilder(appUser, conf)
     MetricsSystem.tracing(_.incCount(ENGINE_TOTAL))
     try {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/InitializeSQLSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/InitializeSQLSuite.scala
@@ -27,12 +27,12 @@ class InitializeSQLSuite extends WithKyuubiServer with JDBCTestUtils {
     KyuubiConf()
       .set(ENGINE_INITIALIZE_SQL.key,
         "CREATE DATABASE IF NOT EXISTS INIT_DB;" +
-          "CREATE TABLE IF NOT EXISTS INIT_DB.test(a int) USING CSV;" +
-          "INSERT OVERWRITE TABLE INIT_DB.test VALUES (1);")
+        "CREATE TABLE IF NOT EXISTS INIT_DB.test(a int) USING CSV;" +
+        "INSERT OVERWRITE TABLE INIT_DB.test VALUES (1);")
       .set(ENGINE_SESSION_INITIALIZE_SQL.key,
         "CREATE DATABASE IF NOT EXISTS INIT_DB;" +
-          "CREATE TABLE IF NOT EXISTS INIT_DB.test(a int) USING CSV;" +
-          "INSERT INTO INIT_DB.test VALUES (2);")
+        "CREATE TABLE IF NOT EXISTS INIT_DB.test(a int) USING CSV;" +
+        "INSERT INTO INIT_DB.test VALUES (2);")
   }
 
   override def afterAll(): Unit = {


### PR DESCRIPTION
### 1. Description

EngineRef use exists znode to determine whether engine started successfully or not(use the last znode), there are inconsistencies in this. So, take an idea to improve the detection mechanism by adding the started sessionid to the znone. `EngineRef` will check the sessionid in a loop after a engine started.

### 2. Here are two options
**Option I, add sesssionid to the data of znode**
![image](https://user-images.githubusercontent.com/86483005/128994276-5c9c7839-0a21-4253-8989-110b88ac0e74.png)

**Option II, add sessionid to the path of znode**
![image](https://user-images.githubusercontent.com/86483005/129527282-46f7f726-e110-4d87-9272-dda9b9f325bf.png)

### 3. Solution

In order to be consistent with the design of server znode, prefer to choose _Option II_ . 

**Demo**
```
/kyuubi
- serviceUri=bigdata:10009;version=1.3.0-SNAPSHOT;sequence=0000000000
/kyuubi_USER/test
- serviceUri=bigdata:39869;version=1.3.0-SNAPSHOT;session=8178069f-0b22-4d06-b1c0-908094769397;sequence=0000000000]
```