### PR TITLE
Reduce EventLoggingService.onEvent time to one with compiled state

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -91,9 +91,8 @@ class ExecuteStatement(
       spark.sparkContext.addSparkListener(operationListener)
       result = spark.sql(statement)
       // TODO( #921): COMPILED need consider eagerly executed commands
-      setState(OperationState.COMPILED)
       statementEvent.queryExecution = result.queryExecution.toString()
-      EventLoggingService.onEvent(statementEvent)
+      setState(OperationState.COMPILED)
       debug(result.queryExecution)
       iter = new ArrayFetchIterator(result.collect())
       setState(OperationState.FINISHED)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`setState`  has already call `EventLoggingService.onEvent`, so we don't need to call `EventLoggingService.onEvent` twice with compiled state .

```
  override def setState(newState: OperationState): Unit = {
    super.setState(newState)
    statementEvent.state = newState.toString
    statementEvent.stateTime = lastAccessTime
    EventLoggingService.onEvent(statementEvent)
  }
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
