### PR TITLE
Add logCaptureThreadReleased flag

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -126,13 +126,14 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper {
   test("log capture should release after close") {
     val process = new FakeSparkProcessBuilder(KyuubiConf())
     try {
+      assert(process.logCaptureThreadReleased)
       val subProcess = process.start
-      assert(!process.logCaptureThread.isInterrupted)
+      assert(!process.logCaptureThreadReleased)
       subProcess.waitFor(3, TimeUnit.SECONDS)
     } finally {
       process.close()
     }
-    assert(process.logCaptureThread.isInterrupted)
+    assert(process.logCaptureThreadReleased)
   }
 
   test(s"sub process log should be overwritten") {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -133,7 +133,9 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper {
     } finally {
       process.close()
     }
-    assert(process.logCaptureThreadReleased)
+    eventually(timeout(3.seconds), interval(100.milliseconds)) {
+      assert(process.logCaptureThreadReleased)
+    }
   }
 
   test(s"sub process log should be overwritten") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`isInterrupted` is always false if some `InterruptedException` are throwed. So we should use a new flag to check if log capture thread is released.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
