### PR TITLE
[WIP][KYUUBI #915] Renew DelegationTokens for user after user connected to Kyuubi Server

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -243,6 +243,17 @@ kyuubi\.operation<br>\.scheduler\.pool|<div style='width: 65pt;word-wrap: break-
 kyuubi\.operation<br>\.status\.polling<br>\.timeout|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>PT5S</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>Timeout(ms) for long polling asynchronous running sql query's status</div>|<div style='width: 30pt'>duration</div>|<div style='width: 20pt'>1.0.0</div>
 
 
+### Security
+
+Key | Default | Meaning | Type | Since
+--- | --- | --- | --- | ---
+kyuubi\.security<br>\.credentials\.hadoopfs<br>\.enabled|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>true</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>Whether to renew HadoopFS DelegationToken</div>|<div style='width: 30pt'>boolean</div>|<div style='width: 20pt'>1.4.0</div>
+kyuubi\.security<br>\.credentials\.hadoopfs<br>\.urls|<div style='width: 65pt;word-wrap: break-word;white-space: normal'></div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>Extra Hadoop filesystem URLs for which to request delegation tokens. The filesystem that hosts fs.defaultFS does not need to be listed here.</div>|<div style='width: 30pt'>seq</div>|<div style='width: 20pt'>1.4.0</div>
+kyuubi\.security<br>\.credentials\.hive<br>\.enabled|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>true</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>Whether to renew HiveMetaStore DelegationToken</div>|<div style='width: 30pt'>boolean</div>|<div style='width: 20pt'>1.4.0</div>
+kyuubi\.security<br>\.credentials\.renewal<br>\.interval|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>PT1H</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>How often Kyuubi renews one user's DelegationTokens</div>|<div style='width: 30pt'>duration</div>|<div style='width: 20pt'>1.4.0</div>
+kyuubi\.security<br>\.credentials\.renewal<br>\.retryWait|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>PT1M</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>How long to wait before retrying to fetch new credentials after a failure.</div>|<div style='width: 30pt'>duration</div>|<div style='width: 20pt'>1.4.0</div>
+
+
 ### Session
 
 Key | Default | Meaning | Type | Since

--- a/docs/security/index.rst
+++ b/docs/security/index.rst
@@ -25,5 +25,6 @@ Kyuubi Security Overview
 
     Authentication <authentication>
     kinit
+    proxyuser
     authorization
 

--- a/docs/security/proxyuser.md
+++ b/docs/security/proxyuser.md
@@ -1,0 +1,52 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+<div align=center>
+
+![](../imgs/kyuubi_logo.png)
+
+</div>
+
+# Hadoop DelegationToken Manager
+
+When working with a kerberos-enabled cluster, Kyuubi renews cluster services' delegation tokens 
+periodically through a Hadoop DelegationToken Manager for client users.  
+
+## Configurations
+
+### Cluster Services
+In order to renew DelegationTokens, Hadoop client configurations and Hive metastore configurations are needed.  
+For Hadoop client configurations, set `HADOOP_CONF_DIR` in `$KYUUBI_HOME/conf/kyuubi-env.sh` if it hasn't been set yet, e.g.
+
+```bash
+$ echo "export HADOOP_CONF_DIR=/path/to/hadoop/conf" >> $KYUUBI_HOME/conf/kyuubi-env.sh
+```
+For Hive metastore configurations, either set [Via kyuubi-defaults.conf](../deployment/hive_metastore.md#Via kyuubi-defaults.conf)
+or [Via hive-site.xml](../deployment/hive_metastore.md#Via hive-site.xml).  
+Note that when set [Via kyuubi-defaults.conf](../deployment/hive_metastore.md#Via kyuubi-defaults.conf),
+only _**Hive primitive configurations**_, e.g. `hive.metastore.uris`, are honored.
+
+
+### DelegationToken Renewal
+
+Key | Default | Meaning | Type | Since
+--- | --- | --- | --- | ---
+kyuubi\.security<br>\.credentials\.hadoopfs<br>\.enabled|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>true</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>Whether to renew HadoopFS DelegationToken</div>|<div style='width: 30pt'>boolean</div>|<div style='width: 20pt'>1.4.0</div>
+kyuubi\.security<br>\.credentials\.hadoopfs<br>\.urls|<div style='width: 65pt;word-wrap: break-word;white-space: normal'></div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>Extra Hadoop filesystem URLs for which to request delegation tokens. The filesystem that hosts fs.defaultFS does not need to be listed here.</div>|<div style='width: 30pt'>seq</div>|<div style='width: 20pt'>1.4.0</div>
+kyuubi\.security<br>\.credentials\.hive<br>\.enabled|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>true</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>Whether to renew HiveMetaStore DelegationToken</div>|<div style='width: 30pt'>boolean</div>|<div style='width: 20pt'>1.4.0</div>
+kyuubi\.security<br>\.credentials\.renewal<br>\.interval|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>PT1H</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>How often Kyuubi renews one user's DelegationTokens</div>|<div style='width: 30pt'>duration</div>|<div style='width: 20pt'>1.4.0</div>
+kyuubi\.security<br>\.credentials\.renewal<br>\.retryWait|<div style='width: 65pt;word-wrap: break-word;white-space: normal'>PT1M</div>|<div style='width: 170pt;word-wrap: break-word;white-space: normal'>How long to wait before retrying to fetch new credentials after a failure.</div>|<div style='width: 30pt'>duration</div>|<div style='width: 20pt'>1.4.0</div>

--- a/externals/kyuubi-spark-sql-engine/pom.xml
+++ b/externals/kyuubi-spark-sql-engine/pom.xml
@@ -127,6 +127,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- override dependency in kyuubi-common -->
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-metastore</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-runtime</artifactId>

--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -31,6 +31,20 @@
     <packaging>jar</packaging>
     <name>Kyuubi Project Common</name>
 
+    <properties>
+        <commons-logging.version>1.1.3</commons-logging.version>
+        <!-- hive-metastore test dependencies begin -->
+        <derby.version>10.10.2.0</derby.version>
+        <datanucleus-api-jdo.version>4.2.4</datanucleus-api-jdo.version>
+        <datanucleus-core.version>4.1.17</datanucleus-core.version>
+        <datanucleus-rdbms.version>4.1.19</datanucleus-rdbms.version>
+        <datanucleus-jdo.version>3.2.0-m3</datanucleus-jdo.version>
+        <antlr.version>3.5.2</antlr.version>
+        <jdo-api.version>3.0.1</jdo-api.version>
+        <servlet-api.version>3.1.0</servlet-api.version>
+        <!-- hive-metastore test dependencies end -->
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.scala-lang</groupId>
@@ -60,7 +74,6 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-runtime</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>
@@ -81,6 +94,22 @@
         <dependency>
             <groupId>org.apache.hive</groupId>
             <artifactId>hive-service-rpc</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-metastore</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>
@@ -109,6 +138,103 @@
             <artifactId>unboundid-ldapsdk</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-minicluster</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Required by MiniDFSCluster -->
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>${commons-logging.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>avalon-framework</groupId>
+                    <artifactId>avalon-framework</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>logkit</groupId>
+                    <artifactId>logkit</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>javax.servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- hive-metastore test dependencies begin -->
+        <dependency>
+            <groupId>org.apache.hive</groupId>
+            <artifactId>hive-exec</artifactId>
+            <version>${hive.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.pentaho</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.derby</groupId>
+            <artifactId>derby</artifactId>
+            <version>${derby.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.datanucleus</groupId>
+            <artifactId>datanucleus-api-jdo</artifactId>
+            <version>${datanucleus-api-jdo.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.datanucleus</groupId>
+            <artifactId>datanucleus-core</artifactId>
+            <version>${datanucleus-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.datanucleus</groupId>
+            <artifactId>datanucleus-rdbms</artifactId>
+            <version>${datanucleus-rdbms.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.jdo</groupId>
+            <artifactId>jdo-api</artifactId>
+            <version>${jdo-api.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.datanucleus</groupId>
+            <artifactId>javax.jdo</artifactId>
+            <version>${datanucleus-jdo.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr-runtime</artifactId>
+            <version>${antlr.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>${servlet-api.version}</version>
+        </dependency>
+        <!-- hive-metastore test dependencies end -->
     </dependencies>
 
     <build>

--- a/kyuubi-common/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
+++ b/kyuubi-common/src/main/resources/META-INF/services/org.apache.hadoop.security.token.TokenIdentifier
@@ -1,0 +1,18 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.kyuubi.security.hive.DelegationTokenIdentifier

--- a/kyuubi-common/src/main/resources/META-INF/services/org.apache.kyuubi.security.HadoopDelegationTokenProvider
+++ b/kyuubi-common/src/main/resources/META-INF/services/org.apache.kyuubi.security.HadoopDelegationTokenProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.kyuubi.security.HadoopFSDelegationTokenProvider
+org.apache.kyuubi.security.hive.HiveDelegationTokenProvider

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -230,6 +230,42 @@ object KyuubiConf {
     .timeConf
     .createWithDefault(Duration.ofHours(3).toMillis)
 
+  val CREDENTIALS_RENEWAL_INTERVAL: ConfigEntry[Long] =
+    buildConf("security.credentials.renewal.interval")
+      .doc("How often Kyuubi renews one user's DelegationTokens")
+      .version("1.4.0")
+      .timeConf
+      .createWithDefault(Duration.ofHours(1).toMillis)
+
+  val CREDENTIALS_RENEWAL_RETRY_WAIT: ConfigEntry[Long] =
+    buildConf("security.credentials.renewal.retryWait")
+      .doc("How long to wait before retrying to fetch new credentials after a failure.")
+      .version("1.4.0")
+      .timeConf
+      .createWithDefault(Duration.ofMinutes(1).toMillis)
+
+  val CREDENTIALS_HIVE_ENABLED: ConfigEntry[Boolean] =
+    buildConf("security.credentials.hive.enabled")
+      .doc("Whether to renew HiveMetaStore DelegationToken")
+      .version("1.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  val CREDENTIALS_HADOOP_FS_ENABLED: ConfigEntry[Boolean] =
+    buildConf("security.credentials.hadoopfs.enabled")
+      .doc("Whether to renew HadoopFS DelegationToken")
+      .version("1.4.0")
+      .booleanConf
+      .createWithDefault(true)
+
+  val CREDENTIALS_HADOOP_FS_URLS: ConfigEntry[Seq[String]] = KyuubiConf
+    .buildConf("security.credentials.hadoopfs.urls")
+    .doc("Extra Hadoop filesystem URLs for which to request delegation tokens. " +
+      "The filesystem that hosts fs.defaultFS does not need to be listed here.")
+    .version("1.4.0")
+    .stringConf
+    .toSequence()
+    .createWithDefault(Nil)
 
   /////////////////////////////////////////////////////////////////////////////////////////////////
   //                              Frontend Service Configuration                                 //

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/security/CredentialsRef.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/security/CredentialsRef.scala
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security
+
+import org.apache.hadoop.security.Credentials
+
+import org.apache.kyuubi.util.KyuubiHadoopUtils
+
+class CredentialsRef(appUser: String) {
+
+  @volatile
+  private var epoch = -1L
+
+  private var credentials: Credentials = _
+  private var encodedCredentials: String = _
+
+  def getEpoch: Long = epoch
+
+  def getAppUser: String = appUser
+
+  def getCredentials: Credentials = credentials
+
+  def getEncodedCredentials: String = {
+    encodedCredentials
+  }
+
+  def updateCredentials(creds: Credentials): Unit = {
+    credentials = creds
+    encodedCredentials = KyuubiHadoopUtils.encodeWritable(creds)
+    epoch += 1
+  }
+
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/security/HadoopDelegationTokenManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/security/HadoopDelegationTokenManager.scala
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security
+
+import java.time.Duration
+import java.util.ServiceLoader
+import java.util.concurrent._
+
+import scala.collection.mutable
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.security.Credentials
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.util.ThreadUtils
+
+class HadoopDelegationTokenManager(kyuubiConf: KyuubiConf, hadoopConf: Configuration)
+    extends Logging {
+
+  private val delegationTokenProviders = loadProviders()
+  debug("Using the following builtin delegation token providers: " +
+    s"${delegationTokenProviders.keys.mkString(", ")}.")
+
+  private val credentialsMap = new ConcurrentHashMap[String, CredentialsRef]()
+  private val renewalInterval = kyuubiConf.get(CREDENTIALS_RENEWAL_INTERVAL)
+  private val renewalRetryWait = kyuubiConf.get(CREDENTIALS_RENEWAL_RETRY_WAIT)
+  private var renewalExecutor: ScheduledExecutorService = _
+
+  def start(): Unit = {
+    renewalExecutor =
+      ThreadUtils.newDaemonSingleThreadScheduledExecutor("Delegation Token Renewal Thread")
+  }
+
+  def stop(): Unit = {
+    if (renewalExecutor != null) {
+      renewalExecutor.shutdownNow()
+      try {
+        renewalExecutor.awaitTermination(10, TimeUnit.SECONDS)
+      } catch {
+        case _: InterruptedException =>
+      }
+    }
+  }
+
+  def obtainDelegationTokensRef(appUser: String): CredentialsRef = {
+    require(renewalExecutor != null, "renewalExecutor should be initialized")
+
+    val credsRef = credentialsMap.computeIfAbsent(appUser, appUser => new CredentialsRef(appUser))
+
+    if (credsRef.getEpoch == -1) {
+      credsRef synchronized {
+        if (credsRef.getEpoch == -1) {
+          val task = new Runnable {
+            override def run(): Unit = {
+              credsRef.updateCredentials(obtainDelegationTokens(appUser))
+              scheduleRenewal(credsRef, renewalInterval)
+            }
+          }
+          renewalExecutor.schedule(task, 0, TimeUnit.MILLISECONDS).get()
+        }
+      }
+    }
+    credsRef
+  }
+
+  // Visible for testing.
+  def isProviderLoaded(serviceName: String): Boolean = {
+    delegationTokenProviders.contains(serviceName)
+  }
+
+  private def scheduleRenewal(credentialsRef: CredentialsRef, delay: Long): Future[_] = {
+    val _delay = math.max(0, delay)
+    info(s"Scheduling renewal in ${Duration.ofMillis(_delay)}.")
+
+    val renewalTask = new Runnable {
+      override def run(): Unit = {
+        try {
+          val creds = obtainDelegationTokens(credentialsRef.getAppUser)
+          credentialsRef.updateCredentials(creds)
+          scheduleRenewal(credentialsRef, renewalInterval)
+        } catch {
+          case _: InterruptedException =>
+          // Server is shutting down
+          case e: Exception =>
+            val duration = Duration.ofMillis(renewalRetryWait)
+            warn(s"Failed to update tokens, will try again in ${duration}", e)
+            scheduleRenewal(credentialsRef, renewalRetryWait)
+        }
+      }
+    }
+
+    renewalExecutor.schedule(renewalTask, _delay, TimeUnit.MILLISECONDS)
+  }
+
+  private def obtainDelegationTokens(appUser: String): Credentials = {
+    val creds = new Credentials()
+    delegationTokenProviders.values
+      .foreach { provider =>
+        if (provider.delegationTokensRequired(hadoopConf)) {
+          provider.obtainDelegationTokens(hadoopConf, kyuubiConf, appUser, creds)
+        } else {
+          debug(s"Service ${provider.serviceName} does not require a token." +
+            s" Check your configuration to see if security is disabled or not.")
+        }
+      }
+    creds
+  }
+
+  private def loadProviders(): Map[String, HadoopDelegationTokenProvider] = {
+    val loader =
+      ServiceLoader.load(classOf[HadoopDelegationTokenProvider], getClass.getClassLoader)
+    val providers = mutable.ArrayBuffer[HadoopDelegationTokenProvider]()
+
+    val iterator = loader.iterator
+    while (iterator.hasNext) {
+      try {
+        providers += iterator.next
+      } catch {
+        case t: Throwable =>
+          warn(s"Failed to load built in provider.", t)
+      }
+    }
+
+    // Filter out providers for which kyuubi.security.credentials.{service}.enabled is false.
+    providers
+      .filter { p => HadoopDelegationTokenManager.isServiceEnabled(kyuubiConf, p.serviceName) }
+      .map { p => (p.serviceName, p) }
+      .toMap
+  }
+
+}
+
+object HadoopDelegationTokenManager {
+  private val providerEnabledConfig = "kyuubi.security.credentials.%s.enabled"
+
+  def isServiceEnabled(kyuubiConf: KyuubiConf, serviceName: String): Boolean = {
+    val key = providerEnabledConfig.format(serviceName)
+    kyuubiConf
+      .getOption(key)
+      .map(_.toBoolean)
+      .getOrElse(true)
+  }
+
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/security/HadoopDelegationTokenProvider.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/security/HadoopDelegationTokenProvider.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.security.Credentials
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.config.KyuubiConf
+
+trait HadoopDelegationTokenProvider extends Logging {
+
+  /**
+   * Name of the service to provide delegation tokens. This name should be unique. Kyuubi will
+   * internally use this name to differentiate delegation token providers.
+   */
+  def serviceName: String
+
+  /**
+   * Returns true if delegation tokens are required for this service. By default, it is based on
+   * whether Hadoop security is enabled.
+   */
+  def delegationTokensRequired(hadoopConf: Configuration): Boolean
+
+  /**
+   * Obtain delegation tokens for this service.
+   *
+   * @param hadoopConf Configuration of current Hadoop Compatible system.
+   * @param owner      DelegationToken owner.
+   * @param creds      Credentials to add tokens and security keys to.
+   */
+  def obtainDelegationTokens(
+      hadoopConf: Configuration,
+      kyuubiConf: KyuubiConf,
+      owner: String,
+      creds: Credentials): Unit
+
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/security/HadoopFSDelegationTokenProvider.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/security/HadoopFSDelegationTokenProvider.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security
+
+import java.lang.reflect.UndeclaredThrowableException
+import java.security.PrivilegedExceptionAction
+import java.util.concurrent.ConcurrentHashMap
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.security.HadoopFSDelegationTokenProvider.doAsProxyUser
+
+class HadoopFSDelegationTokenProvider extends HadoopDelegationTokenProvider with Logging {
+
+  override val serviceName: String = "hadoopfs"
+
+  override def delegationTokensRequired(hadoopConf: Configuration): Boolean = {
+    UserGroupInformation.isSecurityEnabled
+  }
+
+  override def obtainDelegationTokens(
+      hadoopConf: Configuration,
+      kyuubiConf: KyuubiConf,
+      owner: String,
+      creds: Credentials): Unit =
+    doAsProxyUser(owner) {
+      val fileSystems =
+        HadoopFSDelegationTokenProvider.hadoopFSsToAccess(kyuubiConf, hadoopConf)
+      fileSystems.foreach { fs =>
+        info(s"getting token for: $fs")
+        fs.addDelegationTokens(null, creds)
+      }
+    }
+
+}
+
+private[security] object HadoopFSDelegationTokenProvider {
+
+  val proxyUserCache = new ConcurrentHashMap[String, UserGroupInformation]()
+
+  def hadoopFSsToAccess(kyuubiConf: KyuubiConf, hadoopConf: Configuration): Set[FileSystem] = {
+    val defaultFS = FileSystem.get(hadoopConf)
+    val filesystemsToAccess = kyuubiConf
+      .get(KyuubiConf.CREDENTIALS_HADOOP_FS_URLS)
+      .map(new Path(_).getFileSystem(hadoopConf))
+      .toSet
+
+    filesystemsToAccess + defaultFS
+  }
+
+  def doAsProxyUser[T](proxyUser: String)(f: => T): T = {
+    val ugi = proxyUserCache.computeIfAbsent(
+      proxyUser,
+      proxyUser =>
+        UserGroupInformation
+          .createProxyUser(proxyUser, UserGroupInformation.getCurrentUser))
+
+    // For some reason the Scala-generated anonymous class ends up causing an
+    // UndeclaredThrowableException, even if you annotate the method with @throws.
+    try {
+      ugi.doAs(new PrivilegedExceptionAction[T] {
+        override def run(): T = f
+      })
+    } catch {
+      case e: UndeclaredThrowableException => throw Option(e.getCause).getOrElse(e)
+    }
+  }
+
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/security/hive/DelegationTokenIdentifier.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/security/hive/DelegationTokenIdentifier.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security.hive
+
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
+
+/**
+ * A delegation token identifier that is specific to Hive.
+ * @param owner    the effective username of the token owner
+ * @param renewer  the username of the renewer
+ * @param realUser the real username of the token owner
+ */
+class DelegationTokenIdentifier(owner: Text, renewer: Text, realUser: Text)
+    extends AbstractDelegationTokenIdentifier(owner, renewer, realUser) {
+
+  /**
+   * Create an empty delegation token identifier for reading into.
+   */
+  def this() = this(null, null, null)
+
+  override def getKind: Text = DelegationTokenIdentifier.HIVE_DELEGATION_KIND
+}
+
+object DelegationTokenIdentifier {
+  val HIVE_DELEGATION_KIND = new Text("HIVE_DELEGATION_TOKEN")
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/security/hive/HadoopThriftAuthBridgeClient.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/security/hive/HadoopThriftAuthBridgeClient.scala
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security.hive
+
+import java.io.IOException
+import java.security.PrivilegedExceptionAction
+import java.util.{Map => JMap}
+import javax.security.sasl.SaslException
+
+import org.apache.hadoop.security.{SaslRpcServer, SecurityUtil, UserGroupInformation}
+import org.apache.hadoop.security.SaslRpcServer.AuthMethod._
+import org.apache.thrift.transport.{TSaslClientTransport, TTransport, TTransportException}
+
+import org.apache.kyuubi.Logging
+
+class HadoopThriftAuthBridgeClient extends Logging {
+
+  /**
+   * Create a client-side SASL transport that wraps an underlying transport.
+   *
+   * @param principalConfig     The Kerberos principal of the target server.
+   * @param underlyingTransport The underlying transport mechanism, usually a TSocket.
+   * @param saslProps           the sasl properties to create the client with
+   */
+  @throws[IOException]
+  def createClientTransport(
+    principalConfig: String,
+    host: String,
+    underlyingTransport: TTransport,
+    saslProps: JMap[String, String]): TTransport = {
+    val serverPrincipal: String = SecurityUtil.getServerPrincipal(principalConfig, host)
+    val names: Array[String] = SaslRpcServer.splitKerberosName(serverPrincipal)
+    if (names.length != 3) {
+      throw new IOException(
+        "Kerberos principal name does NOT have the expected hostname part: " + serverPrincipal)
+    }
+    try {
+      UserGroupInformation.getCurrentUser.doAs(
+        new PrivilegedExceptionAction[TUGIAssumingTransport]() {
+          @throws[IOException]
+          override def run: TUGIAssumingTransport = {
+            val saslTransport = new TSaslClientTransport(
+              KERBEROS.getMechanismName,
+              null,
+              names(0),
+              names(1),
+              saslProps,
+              null,
+              underlyingTransport)
+            new TUGIAssumingTransport(saslTransport, UserGroupInformation.getCurrentUser)
+          }
+        })
+    } catch {
+      case se@(_: InterruptedException | _: SaslException) =>
+        throw new IOException("Could not instantiate SASL transport", se)
+    }
+  }
+}
+
+/**
+ * The Thrift SASL transports call Sasl.createSaslServer and Sasl.createSaslClient inside open().
+ * So, we need to assume the correct UGI when the transport is opened so that the SASL mechanisms
+ * have access to the right principal. This transport wraps the Sasl transports to set up the
+ * right UGI context for open().
+ *
+ * This is used on the client side, where the API explicitly opens a transport to the server.
+ */
+class TUGIAssumingTransport(wrapped: TTransport, ugi: UserGroupInformation)
+    extends TFilterTransport(wrapped) {
+
+  @throws[TTransportException]
+  override def open(): Unit = {
+    try {
+      ugi.doAs(new PrivilegedExceptionAction[Unit]() {
+        override def run: Unit = {
+          try wrapped.open()
+          catch {
+            case tte: TTransportException =>
+              // Wrap the transport exception in an RTE, since UGI.doAs() then goes
+              // and unwraps this for us out of the doAs block. We then unwrap one
+              // more time in our catch clause to get back the TTE. (ugh)
+              throw new RuntimeException(tte)
+          }
+        }
+      })
+    } catch {
+      case ioe: IOException =>
+        throw new RuntimeException("Received an ioe we never threw!", ioe)
+      case ie: InterruptedException =>
+        throw new RuntimeException("Received an ie we never threw!", ie)
+      case rte: RuntimeException =>
+        if (rte.getCause.isInstanceOf[TTransportException]) {
+          throw rte.getCause.asInstanceOf[TTransportException]
+        } else {
+          throw rte
+        }
+    }
+  }
+
+}
+
+class TFilterTransport(val wrapped: TTransport) extends TTransport {
+
+  @throws[TTransportException]
+  override def open(): Unit = wrapped.open()
+
+  override def isOpen: Boolean = wrapped.isOpen
+
+  override def peek: Boolean = wrapped.peek
+
+  override def close(): Unit = wrapped.close()
+
+  @throws[TTransportException]
+  override def read(buf: Array[Byte], off: Int, len: Int): Int = wrapped.read(buf, off, len)
+
+  @throws[TTransportException]
+  override def readAll(buf: Array[Byte], off: Int, len: Int): Int = wrapped.readAll(buf, off, len)
+
+  @throws[TTransportException]
+  override def write(buf: Array[Byte]): Unit = wrapped.write(buf)
+
+  @throws[TTransportException]
+  override def write(buf: Array[Byte], off: Int, len: Int): Unit = wrapped.write(buf, off, len)
+
+  @throws[TTransportException]
+  override def flush(): Unit = wrapped.flush()
+
+  override def getBuffer: Array[Byte] = wrapped.getBuffer
+
+  override def getBufferPosition: Int = wrapped.getBufferPosition
+
+  override def getBytesRemainingInBuffer: Int = wrapped.getBytesRemainingInBuffer
+
+  override def consumeBuffer(len: Int): Unit = wrapped.consumeBuffer(len)
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/security/hive/HiveDelegationTokenIssuer.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/security/hive/HiveDelegationTokenIssuer.scala
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security.hive
+
+import java.net.URI
+import java.util.concurrent.TimeUnit
+
+import scala.util.Random
+
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars
+import org.apache.hadoop.hive.metastore.api.{MetaException, ThriftHiveMetastore}
+import org.apache.hadoop.security.SaslPropertiesResolver
+import org.apache.hadoop.util.StringUtils
+import org.apache.thrift.protocol.{TBinaryProtocol, TCompactProtocol}
+import org.apache.thrift.transport.{TSocket, TTransport}
+
+import org.apache.kyuubi.Logging
+
+class HiveDelegationTokenIssuer(conf: HiveConf) extends Logging {
+
+  private var client: ThriftHiveMetastore.Iface = _
+  private var transport: TTransport = _
+
+  private val metastoreUris: Seq[URI] = {
+    val metastoreUrisStr = conf.getVar(ConfVars.METASTOREURIS)
+    require(metastoreUrisStr.nonEmpty, "MetaStoreURIs not found in conf file")
+
+    val uris = conf
+      .getVar(ConfVars.METASTOREURIS)
+      .split(",")
+      .map { s =>
+        val uri = new URI(s)
+        if (uri.getScheme == null) {
+          throw new IllegalArgumentException("URI: " + s + " does not have a scheme")
+        }
+        uri
+      }
+    Random.shuffle(uris.toSeq)
+  }
+
+  private val useSasl: Boolean = conf.getBoolVar(ConfVars.METASTORE_USE_THRIFT_SASL)
+  if (!useSasl) {
+    warn(s"Delegation token not supported when ${ConfVars.METASTORE_USE_THRIFT_SASL} is false")
+  }
+
+  open()
+
+  private def open(): Unit = {
+    if (!useSasl) {
+      return
+    }
+
+    val useCompactProtocol = conf.getBoolVar(ConfVars.METASTORE_USE_THRIFT_COMPACT_PROTOCOL)
+    val clientSocketTimeout =
+      conf.getTimeVar(ConfVars.METASTORE_CLIENT_SOCKET_TIMEOUT, TimeUnit.MILLISECONDS).toInt
+
+    var exception: Throwable = null
+    val connected = metastoreUris.exists { store =>
+      info("Trying to connect to metastore with URI " + store)
+
+      try {
+        transport =
+          // Wrap thrift connection with SASL for secure connection.
+          createSASLTransport(store, clientSocketTimeout)
+      } catch {
+        case e: Throwable =>
+          exception = e
+          error("Couldn't create client transport", e)
+      }
+
+      var succeeded = false
+      if (transport != null) {
+        val protocol =
+          if (useCompactProtocol) {
+            new TCompactProtocol(transport)
+          } else {
+            new TBinaryProtocol(transport)
+          }
+        client = new ThriftHiveMetastore.Client(protocol)
+        try {
+          if (!transport.isOpen) {
+            transport.open()
+          }
+          succeeded = true
+        } catch {
+          case e: Throwable =>
+            exception = e
+            warn("Failed to connect to the MetaStore Server...", e)
+        }
+      }
+      succeeded
+    }
+
+    if (!connected) {
+      throw new MetaException(
+        "Could not connect to meta store using any of the URIs provided." +
+          " Most recent failure: " + StringUtils.stringifyException(exception))
+    }
+  }
+
+  private def createSASLTransport(store: URI, clientSocketTimeout: Int): TTransport = {
+    val authBridge: HadoopThriftAuthBridgeClient = new HadoopThriftAuthBridgeClient()
+    val tSocket = new TSocket(store.getHost, store.getPort, clientSocketTimeout)
+
+    val saslProperties = SaslPropertiesResolver.getInstance(conf).getDefaultProperties
+    val principalConfig = conf.getVar(HiveConf.ConfVars.METASTORE_KERBEROS_PRINCIPAL)
+    authBridge.createClientTransport(
+      principalConfig,
+      store.getHost,
+      tSocket,
+      saslProperties)
+  }
+
+  def getDelegationToken(owner: String, renewer: String): String = {
+    if (!useSasl) {
+      return null
+    }
+    client.get_delegation_token(owner, renewer)
+  }
+
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/security/hive/HiveDelegationTokenProvider.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/security/hive/HiveDelegationTokenProvider.scala
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security.hive
+
+import scala.util.control.NonFatal
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+import org.apache.hadoop.security.token.Token
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.security.HadoopDelegationTokenProvider
+
+class HiveDelegationTokenProvider extends HadoopDelegationTokenProvider with Logging {
+
+  private var issuer: HiveDelegationTokenIssuer = _
+
+  override def serviceName: String = "hive"
+
+  private def hiveConf(hadoopConf: Configuration): Configuration = {
+    try {
+      new HiveConf(hadoopConf, classOf[HiveConf])
+    } catch {
+      case NonFatal(e) =>
+        warn("Fail to create Hive Configuration", e)
+        hadoopConf
+    }
+  }
+
+  override def delegationTokensRequired(hadoopConf: Configuration): Boolean = {
+    val conf = hiveConf(hadoopConf)
+    UserGroupInformation.isSecurityEnabled &&
+    conf.getTrimmed("hive.metastore.uris", "").nonEmpty &&
+    conf.getBoolean("hive.metastore.sasl.enabled", false)
+  }
+
+  override def obtainDelegationTokens(
+      hadoopConf: Configuration,
+      kyuubiConf: KyuubiConf,
+      owner: String,
+      creds: Credentials): Unit = {
+    val conf = hiveConf(hadoopConf)
+
+    val principalKey = "hive.metastore.kerberos.principal"
+    val principal = conf.getTrimmed(principalKey, "")
+    require(principal.nonEmpty, s"Hive principal $principalKey undefined")
+    val metastoreUri = conf.getTrimmed("hive.metastore.uris", "")
+    require(metastoreUri.nonEmpty, "Hive metastore uri undefined")
+
+    debug(s"Getting Hive delegation token for $owner against $principal at $metastoreUri")
+
+    if (issuer == null) {
+      issuer = new HiveDelegationTokenIssuer(new HiveConf(conf, classOf[HiveConf]))
+    }
+    val tokenStr = issuer.getDelegationToken(owner, principal)
+    val hive2Token = new Token[DelegationTokenIdentifier]()
+    hive2Token.decodeFromUrlString(tokenStr)
+    debug(s"Get Token from hive metastore: ${hive2Token.toString}")
+    creds.addToken(tokenAlias, hive2Token)
+  }
+
+  private def tokenAlias: Text = new Text("hive.server2.delegation.token")
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/KyuubiHadoopUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/KyuubiHadoopUtils.scala
@@ -17,7 +17,9 @@
 
 package org.apache.kyuubi.util
 
+import org.apache.commons.codec.binary.Base64
 import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.io.{DataInputBuffer, DataOutputBuffer, Writable}
 import org.apache.hadoop.security.SecurityUtil
 
 import org.apache.kyuubi.config.KyuubiConf
@@ -33,4 +35,22 @@ object KyuubiHadoopUtils {
   def getServerPrincipal(principal: String): String = {
     SecurityUtil.getServerPrincipal(principal, "0.0.0.0")
   }
+
+  def encodeWritable(obj: Writable): String = {
+    val buf = new DataOutputBuffer
+    obj.write(buf)
+    val encoder = new Base64(0, null, false)
+    val raw = new Array[Byte](buf.getLength)
+    System.arraycopy(buf.getData, 0, raw, 0, buf.getLength)
+    encoder.encodeToString(raw)
+  }
+
+  def decodeWritable(obj: Writable, newValue: String): Unit = {
+    val decoder = new Base64(0, null, false)
+    val buf = new DataInputBuffer
+    val decoded = decoder.decode(newValue)
+    buf.reset(decoded, decoded.length)
+    obj.readFields(buf)
+  }
+
 }

--- a/kyuubi-common/src/test/resources/META-INF/services/org.apache.kyuubi.security.HadoopDelegationTokenProvider
+++ b/kyuubi-common/src/test/resources/META-INF/services/org.apache.kyuubi.security.HadoopDelegationTokenProvider
@@ -1,0 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.apache.kyuubi.security.ExceptionThrowingDelegationTokenProvider
+org.apache.kyuubi.security.UnstableDelegationTokenProvider

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/KerberizedTestHelper.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/KerberizedTestHelper.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi
 
 import java.io.File
 import java.nio.charset.StandardCharsets
-import java.nio.file.Files
+import java.nio.file.{Files, Paths}
 
 import scala.io.{Codec, Source}
 import scala.util.control.NonFatal
@@ -30,23 +30,31 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.scalatest.time.SpanSugar._
 
 trait KerberizedTestHelper extends KyuubiFunSuite {
+
   val baseDir: File = Utils.createTempDir(
-    this.getClass.getProtectionDomain.getCodeSource.getLocation.getPath, "kyuubi-kdc").toFile
+    Paths.get(this.getClass.getProtectionDomain.getCodeSource.getLocation.toURI).toString,
+    "kyuubi-kdc").toFile
+
   val kdcConf = MiniKdc.createConf()
   val hostName = "localhost"
   kdcConf.setProperty(MiniKdc.INSTANCE, this.getClass.getSimpleName)
-  kdcConf.setProperty(MiniKdc.ORG_NAME, this.getClass.getSimpleName)
+  // MiniKdc keeps realm config in enum object `KdcServerOption.KDC_REALM`.
+  // Multiple kdcs will be launched when testing if they are defined in the same package.
+  // Using same realms here to avoid authentication failure.
+  kdcConf.setProperty(MiniKdc.ORG_NAME, classOf[KerberizedTestHelper].getSimpleName)
   kdcConf.setProperty(MiniKdc.ORG_DOMAIN, "COM")
   kdcConf.setProperty(MiniKdc.KDC_BIND_ADDRESS, hostName)
   kdcConf.setProperty(MiniKdc.KDC_PORT, "0")
   kdcConf.setProperty(MiniKdc.DEBUG, "true")
 
   private var kdc: MiniKdc = _
+  private var krb5ConfPath: String = _
 
   eventually(timeout(60.seconds), interval(1.second)) {
     try {
       kdc = new MiniKdc(kdcConf, baseDir)
       kdc.start()
+      krb5ConfPath = kdc.getKrb5conf.getAbsolutePath
     } catch {
       case NonFatal(e) =>
         if (kdc != null) {
@@ -61,7 +69,6 @@ trait KerberizedTestHelper extends KyuubiFunSuite {
   protected val testKeytab: String = keytabFile.getAbsolutePath
   protected var testPrincipal = s"client/$hostName"
   kdc.createPrincipal(keytabFile, testPrincipal)
-
 
   /**
    * Forked from Apache Spark
@@ -124,7 +131,7 @@ trait KerberizedTestHelper extends KyuubiFunSuite {
     val authType = "hadoop.security.authentication"
     try {
       conf.set(authType, "KERBEROS")
-      System.setProperty("java.security.krb5.conf", kdc.getKrb5conf.getAbsolutePath)
+      System.setProperty("java.security.krb5.conf", krb5ConfPath)
       UserGroupInformation.setConfiguration(conf)
       assert(UserGroupInformation.isSecurityEnabled)
       block
@@ -136,4 +143,5 @@ trait KerberizedTestHelper extends KyuubiFunSuite {
       assert(!UserGroupInformation.isSecurityEnabled)
     }
   }
+
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/WithSecuredDFSService.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/WithSecuredDFSService.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.security.UserGroupInformation
+
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.service.MiniDFSService
+
+trait WithSecuredDFSService extends KerberizedTestHelper {
+
+  private val miniDFSService = new MiniDFSService(newSecuredConf())
+
+  private def newSecuredConf(): Configuration = {
+    val hdfsConf = new Configuration()
+    hdfsConf.set("ignore.secure.ports.for.testing", "true")
+    hdfsConf.set("hadoop.security.authentication", "kerberos")
+    hdfsConf.set("dfs.block.access.token.enable", "true")
+    hdfsConf.set("dfs.namenode.keytab.file", testKeytab)
+    hdfsConf.set("dfs.namenode.kerberos.principal", testPrincipal)
+    hdfsConf.set("dfs.namenode.kerberos.internal.spnego.principal", testPrincipal)
+    hdfsConf.set("dfs.web.authentication.kerberos.principal", testPrincipal)
+
+    hdfsConf.set("dfs.datanode.address", "0.0.0.0:1025")
+    hdfsConf.set("dfs.datanode.kerberos.principal", testPrincipal)
+    hdfsConf.set("dfs.datanode.keytab.file", testKeytab)
+
+    hdfsConf
+  }
+
+  override def beforeAll(): Unit = {
+    tryWithSecurityEnabled {
+      UserGroupInformation.loginUserFromKeytab(testPrincipal, testKeytab)
+      miniDFSService.initialize(new KyuubiConf(false))
+      miniDFSService.start()
+    }
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    miniDFSService.stop()
+    super.afterAll()
+  }
+
+  def getHadoopConf(): Configuration = miniDFSService.getHadoopConf
+}

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/security/HadoopDelegationTokenManagerSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/security/HadoopDelegationTokenManagerSuite.scala
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.security.Credentials
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
+import org.apache.kyuubi.KyuubiFunSuite
+import org.apache.kyuubi.config.KyuubiConf
+
+class HadoopDelegationTokenManagerSuite extends KyuubiFunSuite {
+
+  test("default configuration") {
+    ExceptionThrowingDelegationTokenProvider.constructed = false
+    val manager = new HadoopDelegationTokenManager(new KyuubiConf(false), new Configuration())
+    assert(manager.isProviderLoaded("hadoopfs"))
+    assert(manager.isProviderLoaded("hive"))
+    assert(manager.isProviderLoaded("unstable"))
+    // This checks that providers are loaded independently and they have no effect on each other
+    assert(ExceptionThrowingDelegationTokenProvider.constructed)
+    assert(!manager.isProviderLoaded("throw"))
+  }
+
+  test("disable hadoopfs credential provider") {
+    val kyuubiConf =
+      new KyuubiConf(false).set("kyuubi.security.credentials.hadoopfs.enabled", "false")
+    val manager = new HadoopDelegationTokenManager(kyuubiConf, new Configuration())
+    assert(!manager.isProviderLoaded("hadoopfs"))
+  }
+
+  test("obtain delegation tokens and schedule update") {
+    val conf = new KyuubiConf(false)
+      .set(KyuubiConf.CREDENTIALS_RENEWAL_INTERVAL, 1000L)
+    val manager = new HadoopDelegationTokenManager(conf, new Configuration())
+    manager.start()
+
+    try {
+      val credentialsRef = manager.obtainDelegationTokensRef("who")
+      assert(credentialsRef.getEpoch == 0)
+
+      // Tolerate 100 ms delay
+      eventually(timeout(1100.milliseconds), interval(100.milliseconds)) {
+        assert(credentialsRef.getEpoch == 1)
+      }
+    } finally {
+      manager.stop()
+    }
+  }
+
+  test("schedule retry when failed to update") {
+    val kyuubiConf = new KyuubiConf(false)
+      .set(KyuubiConf.CREDENTIALS_RENEWAL_INTERVAL, 1000L)
+      .set(KyuubiConf.CREDENTIALS_RENEWAL_RETRY_WAIT, 1000L)
+    val manager = new HadoopDelegationTokenManager(kyuubiConf, new Configuration())
+    manager.start()
+
+    try {
+      val credentialsRef = manager.obtainDelegationTokensRef("who")
+      assert(credentialsRef.getEpoch == 0)
+
+      UnstableDelegationTokenProvider.throwException = true
+      // Tolerate 100 ms delay
+      eventually(timeout(2100.milliseconds), interval(100.milliseconds)) {
+        // At least 1 scheduled call and 1 scheduled retrying call have take place.
+        assert(UnstableDelegationTokenProvider.exceptionCount == 2)
+      }
+      assert(credentialsRef.getEpoch == 0)
+    } finally {
+      UnstableDelegationTokenProvider.throwException = false
+      manager.stop()
+    }
+  }
+}
+
+private class ExceptionThrowingDelegationTokenProvider extends HadoopDelegationTokenProvider {
+  ExceptionThrowingDelegationTokenProvider.constructed = true
+  throw new IllegalArgumentException
+
+  override def serviceName: String = "throw"
+
+  override def delegationTokensRequired(hadoopConf: Configuration): Boolean =
+    throw new IllegalArgumentException
+
+  override def obtainDelegationTokens(
+      hadoopConf: Configuration,
+      kyuubiConf: KyuubiConf,
+      owner: String,
+      creds: Credentials): Unit = throw new IllegalArgumentException
+
+}
+
+private object ExceptionThrowingDelegationTokenProvider {
+  var constructed = false
+}
+
+private class UnstableDelegationTokenProvider extends HadoopDelegationTokenProvider {
+
+  override def serviceName: String = "unstable"
+
+  override def delegationTokensRequired(hadoopConf: Configuration): Boolean = true
+
+  override def obtainDelegationTokens(
+      hadoopConf: Configuration,
+      kyuubiConf: KyuubiConf,
+      owner: String,
+      creds: Credentials): Unit = {
+    if (UnstableDelegationTokenProvider.throwException) {
+      UnstableDelegationTokenProvider.exceptionCount += 1
+      throw new IllegalArgumentException
+    }
+  }
+
+}
+
+private object UnstableDelegationTokenProvider {
+
+  @volatile
+  var throwException: Boolean = false
+
+  @volatile
+  var exceptionCount = 0
+
+}

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/security/HadoopFsDelegationTokenProviderSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/security/HadoopFsDelegationTokenProviderSuite.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security
+
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+import org.apache.hadoop.security.token.Token
+import org.apache.hadoop.security.token.delegation.AbstractDelegationTokenIdentifier
+
+import org.apache.kyuubi.WithSecuredDFSService
+import org.apache.kyuubi.config.KyuubiConf
+
+class HadoopFsDelegationTokenProviderSuite extends WithSecuredDFSService {
+
+  test("obtain hadoopfs delegation tokens") {
+    tryWithSecurityEnabled {
+      UserGroupInformation.loginUserFromKeytab(testPrincipal, testKeytab)
+
+      val hdfsConf = getHadoopConf()
+      val owner = "who"
+      val credentials = new Credentials()
+      val provider = new HadoopFSDelegationTokenProvider
+      provider.obtainDelegationTokens(
+        hdfsConf,
+        new KyuubiConf(false),
+        owner,
+        credentials)
+
+      val token = credentials
+        .getToken(new Text(FileSystem.get(hdfsConf).getCanonicalServiceName))
+        .asInstanceOf[Token[AbstractDelegationTokenIdentifier]]
+      assert(token != null)
+
+      val tokenIdent = token.decodeIdentifier()
+      assertResult(DelegationTokenIdentifier.HDFS_DELEGATION_KIND)(token.getKind)
+      assertResult(new Text(owner))(tokenIdent.getOwner)
+      val currentUserName = UserGroupInformation.getCurrentUser.getUserName
+      assertResult(new Text(currentUserName))(tokenIdent.getRealUser)
+    }
+  }
+}

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/security/hive/HiveDelegationTokenProviderSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/security/hive/HiveDelegationTokenProviderSuite.scala
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.security.hive
+
+import java.io.{File, FileOutputStream}
+import java.net.URLClassLoader
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.locks.ReentrantLock
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+import org.apache.commons.io.FileUtils
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hive.conf.HiveConf
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars._
+import org.apache.hadoop.hive.metastore.{HiveMetaException, HiveMetaStore}
+import org.apache.hadoop.hive.thrift.{HadoopThriftAuthBridge, HadoopThriftAuthBridge23}
+import org.apache.hadoop.io.Text
+import org.apache.hadoop.security.{Credentials, UserGroupInformation}
+import org.apache.thrift.TProcessor
+import org.apache.thrift.protocol.TProtocol
+
+import org.apache.kyuubi.{KerberizedTestHelper, Logging, Utils}
+import org.apache.kyuubi.config.KyuubiConf
+
+class HiveDelegationTokenProviderSuite extends KerberizedTestHelper {
+
+  private val hadoopConfDir: File = Utils.createTempDir().toFile
+  private var hiveConf: HiveConf = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+
+    tryWithSecurityEnabled {
+      UserGroupInformation.loginUserFromKeytab(testPrincipal, testKeytab)
+
+      // HiveMetaStore will load proxy user config from Thread#contextClasLoader for each request.
+      // So we create a URLClassLoader with core-site.xml and set it as HiveMetaStore request thread
+      // context classloader.
+      val conf = new Configuration(false)
+      conf.set("hadoop.security.authentication", "kerberos")
+      val realUser = UserGroupInformation.getCurrentUser.getShortUserName
+      conf.set(s"hadoop.proxyuser.$realUser.groups", "*")
+      conf.set(s"hadoop.proxyuser.$realUser.hosts", "*")
+
+      val xml = new File(hadoopConfDir, "core-site.xml")
+      val os = new FileOutputStream(xml)
+      try {
+        conf.writeXml(os)
+      } finally {
+        os.close()
+      }
+
+      val classloader =
+        new URLClassLoader(
+          Array(hadoopConfDir.toURI.toURL),
+          classOf[Configuration].getClassLoader)
+
+      val metaServer = new LocalMetaServer(classloader)
+
+      hiveConf = metaServer.getHiveConf
+      hiveConf.setVar(METASTORE_USE_THRIFT_SASL, "true")
+      hiveConf.setVar(METASTORE_KERBEROS_PRINCIPAL, testPrincipal)
+      hiveConf.setVar(METASTORE_KERBEROS_KEYTAB_FILE, testKeytab)
+      metaServer.start()
+    }
+  }
+
+  override def afterAll(): Unit = {
+    FileUtils.deleteDirectory(hadoopConfDir)
+  }
+
+  test("obtain hive delegation token") {
+    tryWithSecurityEnabled {
+      UserGroupInformation.loginUserFromKeytab(testPrincipal, testKeytab)
+
+      val owner = "who"
+      val credentials = new Credentials
+      val provider = new HiveDelegationTokenProvider
+      provider.obtainDelegationTokens(
+        hiveConf,
+        new KyuubiConf(false),
+        owner,
+        credentials)
+
+      val token = credentials.getAllTokens.asScala
+        .filter(_.getKind == DelegationTokenIdentifier.HIVE_DELEGATION_KIND)
+        .head
+      assert(token != null)
+
+      val tokenIdent = token.decodeIdentifier().asInstanceOf[DelegationTokenIdentifier]
+      assertResult(DelegationTokenIdentifier.HIVE_DELEGATION_KIND)(token.getKind)
+      assertResult(new Text(owner))(tokenIdent.getOwner)
+      val currentUserName = UserGroupInformation.getCurrentUser.getUserName
+      assertResult(new Text(currentUserName))(tokenIdent.getRealUser)
+    }
+  }
+}
+
+class LocalMetaServer(serverContextClassLoader: ClassLoader) extends Logging {
+  private val port = 20101
+  private val hiveConf = new HiveConf()
+  hiveConf.setVar(METASTOREURIS, "thrift://localhost:" + port)
+  hiveConf.setVar(METASTORE_SCHEMA_VERIFICATION, "false")
+  hiveConf.set("datanucleus.schema.autoCreateTables", "true")
+
+  def start(): Unit = {
+    val startLock = new ReentrantLock
+    val startCondition = startLock.newCondition
+    val startedServing = new AtomicBoolean(false)
+    val startFailed = new AtomicBoolean(false)
+
+    Future {
+      try {
+        HiveMetaStore.startMetaStore(
+          port,
+          new HadoopThriftAuthBridgeWithServerContextClassLoader(
+            serverContextClassLoader),
+          hiveConf,
+          startLock,
+          startCondition,
+          startedServing)
+      } catch {
+        case t: Throwable =>
+          error("Failed to start LocalMetaServer", t)
+          startFailed.set(true)
+      }
+    }
+
+    val deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(30)
+    while (!startedServing.get() && !startFailed.get() && System.currentTimeMillis() < deadline) {
+      Thread.sleep(100)
+    }
+
+    if (startFailed.get()) {
+      throw new HiveMetaException("Failed to start LocalMetaServer")
+    } else if (!startedServing.get() && System.currentTimeMillis() >= deadline) {
+      throw new HiveMetaException("LocalMetaServer did not start in 30 seconds")
+    }
+  }
+
+  def getHiveConf: HiveConf = hiveConf
+}
+
+class HadoopThriftAuthBridgeWithServerContextClassLoader(classloader: ClassLoader)
+    extends HadoopThriftAuthBridge23 {
+
+  override def createServer(
+      keytabFile: String,
+      principalConf: String): HadoopThriftAuthBridge.Server = {
+    new Server(keytabFile, principalConf)
+  }
+
+  class Server(keytabFile: String, principalConf: String)
+      extends HadoopThriftAuthBridge.Server(keytabFile, principalConf) {
+
+    override def wrapProcessor(processor: TProcessor): TProcessor = {
+      new SetThreadContextClassLoaderProcess(super.wrapProcessor(processor))
+    }
+
+  }
+
+  class SetThreadContextClassLoaderProcess(wrapped: TProcessor) extends TProcessor {
+
+    override def process(in: TProtocol, out: TProtocol): Boolean = {
+      val origin = Thread.currentThread().getContextClassLoader
+      try {
+        Thread.currentThread().setContextClassLoader(classloader)
+        wrapped.process(in, out)
+      } finally {
+        Thread.currentThread().setContextClassLoader(origin)
+      }
+    }
+
+  }
+
+}

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/MiniDFSService.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/MiniDFSService.scala
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.service
+
+import java.io.File
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.hdfs.MiniDFSCluster
+import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys
+import org.apache.hadoop.security.UserGroupInformation
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.config.KyuubiConf
+
+class MiniDFSService(name: String, hdfsConf: Configuration)
+    extends AbstractService(name)
+    with Logging {
+  private var hdfsConfDir: File = _
+  private var hdfsCluster: MiniDFSCluster = _
+
+  def this(hdfsConf: Configuration = new Configuration()) =
+    this(classOf[MiniDFSService].getSimpleName, hdfsConf)
+
+  override def initialize(conf: KyuubiConf): Unit = {
+    // Set bind host to localhost to avoid java.net.BindException
+    hdfsConf.set("dfs.namenode.rpc-bind-host", "localhost")
+
+    // enable proxy
+    val currentUser = UserGroupInformation.getCurrentUser.getShortUserName
+    hdfsConf.set(s"hadoop.proxyuser.$currentUser.groups", "*")
+    hdfsConf.set(s"hadoop.proxyuser.$currentUser.hosts", "*")
+    super.initialize(conf)
+  }
+
+  override def start(): Unit = {
+    hdfsCluster = new MiniDFSCluster.Builder(hdfsConf)
+      .checkDataNodeAddrConfig(true)
+      .build()
+    info(
+      s"NameNode address in configuration is " +
+        s"${hdfsConf.get(HdfsClientConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY)}")
+    super.start()
+  }
+
+  override def stop(): Unit = {
+    if (hdfsCluster != null) hdfsCluster.shutdown(true)
+    if (hdfsConfDir != null) hdfsConfDir.delete()
+    super.stop()
+  }
+
+  def getHadoopConf: Configuration = hdfsConf
+}

--- a/pom.xml
+++ b/pom.xml
@@ -870,6 +870,12 @@
             </dependency>
 
             <dependency>
+                <groupId>org.apache.hive</groupId>
+                <artifactId>hive-metastore</artifactId>
+                <version>${hive.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-framework</artifactId>
                 <version>${curator.version}</version>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Due to Spark's limitation, a long running SQL engine must be submitted wtih principal and keytab in order to access secured Hadoop cluster. Turn to Kyuubi, this means before using principal and keytab in JDBC url, keytab files need to be deploy on each host where Kyuubi Servers are running.

The umbrellla issue #913 propsed a new way to enable Kyuubi to launch long running SQL engine without principal and keytab provided and this PR corresponds to the first subtask #915.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
