### PR TITLE
Fix build error when project path contains `kyuubi-`

### DIFF
--- a/build/release/collect-licenses.sh
+++ b/build/release/collect-licenses.sh
@@ -43,12 +43,14 @@ if [ "${SRC}" = "-h" ]; then
 	exit 0
 fi
 
-for jar_file in $(find -L "${SRC}" -name "*.jar" | grep -v "kyuubi-")
+for jar_file in $(find -L "${SRC}" -name "*.jar")
 do
-	DIR="${TMP}/$(basename -- "${jar_file}" .jar)"
-	mkdir -p "${DIR}"
-	JAR=$(realpath "${jar_file}")
-	(cd "${DIR}" && jar xf ${JAR} META-INF/NOTICE META-INF/licenses)
+  if [[ $(basename $jar_file) != kyuubi-* ]]; then
+    DIR="${TMP}/$(basename -- "${jar_file}" .jar)"
+	  mkdir -p "${DIR}"
+	  JAR=$(realpath "${jar_file}")
+	  (cd "${DIR}" && jar xf ${JAR} META-INF/NOTICE META-INF/licenses)
+  fi
 done
 
 NOTICE="${DST}/NOTICE"

--- a/build/release/collect-licenses.sh
+++ b/build/release/collect-licenses.sh
@@ -39,8 +39,8 @@ USAGE="$0 <SOURCE_DIRECTORY:-.> <OUTPUT_DIRECTORY:-licenses-output>"
 source "$KYUUBI_DIR/build/util.sh"
 
 if [ "${SRC}" = "-h" ]; then
-	echo "${USAGE}"
-	exit 0
+  echo "${USAGE}"
+  exit 0
 fi
 
 for jar_file in $(find -L "${SRC}" -name "*.jar")

--- a/build/release/collect-licenses.sh
+++ b/build/release/collect-licenses.sh
@@ -47,9 +47,9 @@ for jar_file in $(find -L "${SRC}" -name "*.jar")
 do
   if [[ $(basename $jar_file) != kyuubi-* ]]; then
     DIR="${TMP}/$(basename -- "${jar_file}" .jar)"
-	  mkdir -p "${DIR}"
-	  JAR=$(realpath "${jar_file}")
-	  (cd "${DIR}" && jar xf ${JAR} META-INF/NOTICE META-INF/licenses)
+    mkdir -p "${DIR}"
+    JAR=$(realpath "${jar_file}")
+    (cd "${DIR}" && jar xf ${JAR} META-INF/NOTICE META-INF/licenses)
   fi
 done
 

--- a/build/release/collect-licenses.sh
+++ b/build/release/collect-licenses.sh
@@ -45,7 +45,7 @@ fi
 
 for jar_file in $(find -L "${SRC}" -name "*.jar")
 do
-  if [[ $(basename $jar_file) != kyuubi-* ]]; then
+  if [[ "$(basename ${jar_file})" != "kyuubi-"* ]]; then
     DIR="${TMP}/$(basename -- "${jar_file}" .jar)"
     mkdir -p "${DIR}"
     JAR=$(realpath "${jar_file}")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
The building will fail if the project name contains `kyuubi-`.
For example: for our jenkins job, its name is `kyuubi-binary-build`, and the TMP dir won't be created because all the jar files are filtered because their absolute path contains `kyuubi-`.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
