### PR TITLE
[KYUUBI #1005] ServiceDiscoverySuite fails if hostname contains uppercase letter

### DIFF
--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/ServiceDiscoverySuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/ServiceDiscoverySuite.scala
@@ -23,6 +23,7 @@ import javax.security.auth.login.Configuration
 
 import scala.collection.JavaConverters._
 
+import org.apache.hadoop.util.StringUtils
 import org.apache.zookeeper.ZooDefs
 import org.scalatest.time.SpanSugar._
 
@@ -125,8 +126,8 @@ class ServiceDiscoverySuite extends KerberizedTestHelper {
       assert(entries.head.getLoginModuleName === "com.sun.security.auth.module.Krb5LoginModule")
       val options = entries.head.getOptions.asScala.toMap
 
-      assert(options("principal") ===
-        s"kentyao/${InetAddress.getLocalHost.getCanonicalHostName}@apache.org")
+      val hostname = StringUtils.toLowerCase(InetAddress.getLocalHost.getCanonicalHostName)
+      assert(options("principal") === s"kentyao/$hostname@apache.org")
       assert(options("useKeyTab").toString.toBoolean)
 
       conf.set(KyuubiConf.SERVER_KEYTAB, keytab.getName)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Executing test case "ServiceDiscoverySuite @set up zookeeper auth" on a Linux host named "KYUUBI" fails.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
