### PR TITLE
[BUILD] Detected dependency list change only on JDK 8

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -90,6 +90,7 @@ jobs:
         if: ${{ matrix.codecov == 'true' }}
         run: bash <(curl -s https://codecov.io/bash)
       - name: Detected Dependency List Change
+        if: ${{ matrix.java == 8 }}
         run: build/dependency.sh
       - name: Upload test logs
         if: failure()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There is a profile named `jdk11+` in `jersey-common` that will be activated on `jdk[11,)`, it will add a new dependency and cause the dependency list check to fail.

```
      <profile>
            <id>jdk11+</id>
            <activation>
                <jdk>[11,)</jdk>
            </activation>
            <dependencies>
                <dependency>
                    <groupId>com.sun.activation</groupId>
                    <artifactId>jakarta.activation</artifactId>
                </dependency>
            </dependencies>
      ...
      </profile>
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
