### PR TITLE
Checking admin ACL before killing spark engine

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/ui/EngineTab.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/ui/EngineTab.scala
@@ -56,7 +56,7 @@ case class EngineTab(engine: SparkSQLEngine)
               classOf[String],
               classOf[HttpServlet],
               classOf[String])
-            .invoke("/kyuubi/stop", createStopKyuubiServlet(), "")
+            .invoke("/kyuubi/stop", createKyuubiStopServlet(), "")
         )
     } catch {
       case NonFatal(e) =>
@@ -65,7 +65,7 @@ case class EngineTab(engine: SparkSQLEngine)
     }
   }
 
-  private def createStopKyuubiServlet(): HttpServlet = {
+  def createKyuubiStopServlet(): HttpServlet = {
     new HttpServlet {
       override def doGet(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
         handleKillRequest(req, resp)
@@ -75,7 +75,7 @@ case class EngineTab(engine: SparkSQLEngine)
         handleKillRequest(req, resp)
       }
 
-      private def handleKillRequest(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+      def handleKillRequest(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
         val securityManager = SparkEnv.get.securityManager
         val requestUser = req.getRemoteUser
         if (securityManager.checkAdminPermissions(requestUser)) {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/ui/EngineTab.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/ui/EngineTab.scala
@@ -19,8 +19,10 @@ package org.apache.spark.kyuubi.ui
 
 import javax.servlet.http.HttpServletRequest
 
-import org.apache.spark.ui.SparkUITab
 import scala.util.control.NonFatal
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.ui.SparkUITab
 
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
@@ -66,7 +68,9 @@ case class EngineTab(engine: SparkSQLEngine)
   }
 
   def handleKillRequest(request: HttpServletRequest): Unit = {
-    if (killEnabled && engine != null && engine.getServiceState != ServiceState.STOPPED) {
+    val securityManager = SparkEnv.get.securityManager
+    if (securityManager.checkAdminPermissions(request.getRemoteUser) &&
+      killEnabled && engine != null && engine.getServiceState != ServiceState.STOPPED) {
       engine.stop()
     }
   }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/ui/EngineTab.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/ui/EngineTab.scala
@@ -18,16 +18,15 @@
 package org.apache.spark.kyuubi.ui
 
 import javax.servlet.http.{HttpServlet, HttpServletRequest, HttpServletResponse}
-
 import scala.util.control.NonFatal
-
 import org.apache.spark.SparkEnv
 import org.apache.spark.ui.SparkUITab
-
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.spark.SparkSQLEngine
 import org.apache.kyuubi.service.ServiceState
+
+import java.net.URL
 
 /**
  * Note that [[SparkUITab]] is private for Spark
@@ -82,6 +81,7 @@ case class EngineTab(engine: SparkSQLEngine)
           if (killEnabled && engine != null && engine.getServiceState != ServiceState.STOPPED) {
             engine.stop()
           }
+          resp.setStatus(HttpServletResponse.SC_OK)
         } else {
           resp.sendError(HttpServletResponse.SC_FORBIDDEN,
             s"User $requestUser is allowed to stop this engine, please check `spark.admin.acls`")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Checking whether the request user is admin before killing engine.




### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="1315" alt="Screen Shot 2021-09-04 at 2 43 43 AM" src="https://user-images.githubusercontent.com/6757692/132052576-26a03c3a-9062-4730-82a4-799fb70689c4.png">

<img width="1315" alt="Screen Shot 2021-09-04 at 2 46 13 AM" src="https://user-images.githubusercontent.com/6757692/132052822-0d0e4640-27bf-474a-be92-36081a4e658d.png">

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
