### PR TITLE
[KYUUBI#1056] Output error log when currentEngine is None

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -152,6 +152,9 @@ object SparkSQLEngine extends Logging {
       countDownLatch.await()
     } catch {
       case t: Throwable =>
+        if (!currentEngine.isDefined) {
+          error("Create SparkSQL Engine Failed", t)
+        }
         currentEngine.foreach { engine =>
           val status =
             engine.engineStatus.copy(diagnostic = s"Error State SparkSQL Engine ${t.getMessage}")

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -151,10 +151,7 @@ object SparkSQLEngine extends Logging {
       // blocking main thread
       countDownLatch.await()
     } catch {
-      case t: Throwable =>
-        if (!currentEngine.isDefined) {
-          error("Create SparkSQL Engine Failed", t)
-        }
+      case t: Throwable if currentEngine.isDefined =>
         currentEngine.foreach { engine =>
           val status =
             engine.engineStatus.copy(diagnostic = s"Error State SparkSQL Engine ${t.getMessage}")
@@ -162,6 +159,8 @@ object SparkSQLEngine extends Logging {
           error(status, t)
           engine.stop()
         }
+      case t: Throwable =>
+        error("Create SparkSQL Engine Failed", t)
     } finally {
       if (spark != null) {
         spark.stop()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When createSpark in SparkSqlEngine get sparksession or execute initialize.sql failed, we cannot get any error info in logs. At this time, currentEngine is None.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
