### PR TITLE
Add forcedMaxOutputRows rule for limitation to avoid huge output unexpectly

### DIFF
--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -97,9 +97,8 @@ object KyuubiSQLConf {
 
   val WATCHDOG_FORCED_MAXOUTPUTROWS =
     buildConf("spark.sql.watchdog.forcedMaxOutputRows")
-      .doc("Add MaxOutputRows rule for output rows limitation " +
-        "to avoid huge output rows of non-limit query unexpectedly, " +
-        "it's a optional, it's optional that works with defined")
+      .doc("Add ForcedMaxOutputRows rule to avoid huge output rows of non-limit query " +
+        "unexpectedly, it's optional that works with defined")
       .version("1.4.0")
       .intConf
       .createOptional

--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -94,4 +94,13 @@ object KyuubiSQLConf {
       .version("1.4.0")
       .intConf
       .createOptional
+
+  val WATCHDOG_FORCED_MAXOUTPUTROWS =
+    buildConf("spark.sql.watchdog.forcedMaxOutputRows")
+      .doc("Add MaxOutputRows rule for output rows limitation " +
+        "to avoid huge output rows of non-limit query unexpectedly, " +
+        "it's a optional, it's optional that works with defined")
+      .version("1.4.0")
+      .intConf
+      .createOptional
 }

--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.sql
 import org.apache.spark.sql.SparkSessionExtensions
 
 import org.apache.kyuubi.sql.sqlclassification.KyuubiSqlClassification
-import org.apache.kyuubi.sql.watchdog.MaxHivePartitionStrategy
+import org.apache.kyuubi.sql.watchdog.{ForcedMaxOutputRowsRule, MaxHivePartitionStrategy}
 import org.apache.kyuubi.sql.zorder.{InsertZorderBeforeWritingDatasource, InsertZorderBeforeWritingHive}
 import org.apache.kyuubi.sql.zorder.ResolveZorder
 import org.apache.kyuubi.sql.zorder.ZorderSparkSqlExtensionsParser
@@ -53,5 +53,6 @@ class KyuubiSparkSQLExtension extends (SparkSessionExtensions => Unit) {
     extensions.injectQueryStagePrepRule(_ => InsertShuffleNodeBeforeJoin)
     extensions.injectQueryStagePrepRule(FinalStageConfigIsolation(_))
     extensions.injectPlannerStrategy(MaxHivePartitionStrategy)
+    extensions.injectPostHocResolutionRule(ForcedMaxOutputRowsRule)
   }
 }

--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.SparkSessionExtensions
 
 import org.apache.kyuubi.sql.sqlclassification.KyuubiSqlClassification
 import org.apache.kyuubi.sql.watchdog.MaxHivePartitionStrategy
-import org.apache.kyuubi.sql.zorder.{InsertZorderBeforeWritingDatasource, InsertZorderBeforeWritingHive, ResolveZorder, ZorderSparkSqlExtensionsParser}
+import org.apache.kyuubi.sql.zorder.{InsertZorderBeforeWritingDatasource, InsertZorderBeforeWritingHive}
 import org.apache.kyuubi.sql.zorder.ResolveZorder
 import org.apache.kyuubi.sql.zorder.ZorderSparkSqlExtensionsParser
 

--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsRule.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsRule.scala
@@ -19,10 +19,9 @@ package org.apache.kyuubi.sql.watchdog
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.dsl.expressions._
-import org.apache.spark.sql.catalyst.plans.logical.{GlobalLimit, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.plans.logical.{Aggregate, GlobalLimit, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.Origin
-import org.apache.spark.sql.execution.command.InsertIntoDataSourceDirCommand
 
 import org.apache.kyuubi.sql.KyuubiSQLConf
 
@@ -30,25 +29,25 @@ import org.apache.kyuubi.sql.KyuubiSQLConf
 * Add ForcedMaxOutputRows rule for output rows limitation
 * to avoid huge output rows of non_limit query unexpectedly
 * mainly applied to cases as below:
-* case 1:
-*  {{{
-*   INSERT OVERWRITE DIRECTORY (path=STRING)?
-*   USING format OPTIONS ([option1_name "option1_value", option2_name "option2_value", ...])
-*   SELECT ...
-* }}}
 *
-* case 2:
+* case 1:
 * {{{
 *   SELECT [c1, c2, ...]
 * }}}
 *
-* case 3:
+* case 2:
 * {{{
 *   WITH CTE AS (
 *   ...)
 * SELECT [c1, c2, ...] FROM CTE ...
 * }}}
 *
+* case 3 (customize yourself):
+*  {{{
+*   INSERT OVERWRITE DIRECTORY (path=STRING)?
+*   USING format OPTIONS ([option1_name "option1_value", option2_name "option2_value", ...])
+*   SELECT ...
+* }}}
 * The Logical Rule add a GlobalLimit node before root project
 * */
 case class ForcedMaxOutputRowsRule(session: SparkSession) extends Rule[LogicalPlan] {
@@ -58,13 +57,20 @@ case class ForcedMaxOutputRowsRule(session: SparkSession) extends Rule[LogicalPl
     } else {
       conf.getConf(KyuubiSQLConf.WATCHDOG_FORCED_MAXOUTPUTROWS) match {
         case Some(forcedMaxOutputRows) => plan match {
-          case insert@InsertIntoDataSourceDirCommand(_, _, Project(_, _), _) =>
-            insert.copy(query = GlobalLimit(forcedMaxOutputRows, insert.query))
-          case project@Project(_, _) => project.origin match {
-            case Origin(None, None) => GlobalLimit(forcedMaxOutputRows, project)
+          case project: Project => project.origin match {
             case Origin(Some(_), Some(0)) => GlobalLimit(forcedMaxOutputRows, project)
             case _ => project
           }
+          case agg: Aggregate => agg.origin match {
+            case Origin(None, None) => agg.maxRows match {
+              case Some(_) => agg
+              case None => GlobalLimit(forcedMaxOutputRows, agg)
+            }
+            case _ => agg
+          }
+
+          // TODO: Customize your required process node
+
           case _ => plan
         }
         case _ => plan

--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsRule.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsRule.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.sql.watchdog
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.dsl.expressions._
+import org.apache.spark.sql.catalyst.plans.logical.{GlobalLimit, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.Origin
+import org.apache.spark.sql.execution.command.InsertIntoDataSourceDirCommand
+
+import org.apache.kyuubi.sql.KyuubiSQLConf
+
+/*
+* Add ForcedMaxOutputRows rule for output rows limitation
+* to avoid huge output rows of non_limit query unexpectedly
+* mainly applied to cases as below:
+* case 1:
+*  {{{
+*   INSERT OVERWRITE DIRECTORY (path=STRING)?
+*   USING format OPTIONS ([option1_name "option1_value", option2_name "option2_value", ...])
+*   SELECT ...
+* }}}
+*
+* case 2:
+* {{{
+*   SELECT [c1, c2, ...]
+* }}}
+*
+* case 3:
+* {{{
+*   WITH CTE AS (
+*   ...)
+* SELECT [c1, c2, ...] FROM CTE ...
+* }}}
+*
+* The Logical Rule add a GlobalLimit node before root project
+* */
+case class ForcedMaxOutputRowsRule(session: SparkSession) extends Rule[LogicalPlan] {
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (!plan.resolved) {
+      plan
+    } else {
+      conf.getConf(KyuubiSQLConf.WATCHDOG_FORCED_MAXOUTPUTROWS) match {
+        case Some(forcedMaxOutputRows) => plan match {
+          case insert@InsertIntoDataSourceDirCommand(_, _, Project(_, _), _) =>
+            insert.copy(query = GlobalLimit(forcedMaxOutputRows, insert.query))
+          case project@Project(_, _) => project.origin match {
+            case Origin(None, None) => GlobalLimit(forcedMaxOutputRows, project)
+            case Origin(Some(_), Some(0)) => GlobalLimit(forcedMaxOutputRows, project)
+            case _ => project
+          }
+          case _ => plan
+        }
+        case _ => plan
+      }
+    }
+  }
+}

--- a/dev/kyuubi-extension-spark-3-1/src/test/scala/org/apache/spark/sql/KyuubiExtensionSuite.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/test/scala/org/apache/spark/sql/KyuubiExtensionSuite.scala
@@ -1308,29 +1308,29 @@ class KyuubiExtensionSuite extends KyuubiSparkSQLExtensionTest {
 
     withSQLConf(KyuubiSQLConf.WATCHDOG_FORCED_MAXOUTPUTROWS.key -> "10") {
 
-      assert(sql("SELECT * FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2)")
+      assert(sql("SELECT * FROM t1")
         .queryExecution.analyzed.isInstanceOf[GlobalLimit])
 
-      assert(sql("SELECT * FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2) LIMIT 1")
+      assert(sql("SELECT * FROM t1 LIMIT 1")
         .queryExecution.analyzed.asInstanceOf[GlobalLimit].maxRows.contains(1))
 
-      assert(sql("SELECT * FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2) LIMIT 11")
+      assert(sql("SELECT * FROM t1 LIMIT 11")
         .queryExecution.analyzed.asInstanceOf[GlobalLimit].maxRows.contains(10))
 
-      assert(!sql("SELECT count(*) FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2)")
+      assert(!sql("SELECT count(*) FROM t1")
         .queryExecution.analyzed.isInstanceOf[GlobalLimit])
 
       assert(sql(
         """
           |SELECT c1, COUNT(*)
-          |FROM VALUES(1, 'a'), (2, 'b') AS t(c1, c2)
+          |FROM t1
           |GROUP BY c1
           |""".stripMargin).queryExecution.analyzed.isInstanceOf[GlobalLimit])
 
       assert(sql(
         """
           |WITH custom_cte AS (
-          |SELECT * FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2)
+          |SELECT * FROM t1
           |)
           |
           |SELECT * FROM custom_cte
@@ -1340,7 +1340,7 @@ class KyuubiExtensionSuite extends KyuubiSparkSQLExtensionTest {
       assert(sql(
         """
           |WITH custom_cte AS (
-          |SELECT * FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2)
+          |SELECT * FROM t1
           |)
           |
           |SELECT * FROM custom_cte
@@ -1351,7 +1351,7 @@ class KyuubiExtensionSuite extends KyuubiSparkSQLExtensionTest {
       assert(sql(
         """
           |WITH custom_cte AS (
-          |SELECT * FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2)
+          |SELECT * FROM t1
           |)
           |
           |SELECT * FROM custom_cte
@@ -1362,7 +1362,7 @@ class KyuubiExtensionSuite extends KyuubiSparkSQLExtensionTest {
       assert(!sql(
         """
           |WITH custom_cte AS (
-          |SELECT * FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2)
+          |SELECT * FROM t1
           |)
           |
           |SELECT COUNT(*) FROM custom_cte
@@ -1372,7 +1372,7 @@ class KyuubiExtensionSuite extends KyuubiSparkSQLExtensionTest {
       assert(sql(
         """
           |WITH custom_cte AS (
-          |SELECT * FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2)
+          |SELECT * FROM t1
           |)
           |
           |SELECT c1, COUNT(*)
@@ -1384,7 +1384,7 @@ class KyuubiExtensionSuite extends KyuubiSparkSQLExtensionTest {
       assert(sql(
         """
           |WITH custom_cte AS (
-          |SELECT * FROM VALUES(1, 'a'),(2, 'b') AS t(c1, c2)
+          |SELECT * FROM t1
           |)
           |
           |SELECT c1, COUNT(*)


### PR DESCRIPTION
Add MaxOutputRows rule for output rows limitation to avoid huge output unexpectedly
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add
<img width="1440" alt="截屏2021-09-12 下午12 19 28" src="https://user-images.githubusercontent.com/635169/132972063-b12937bb-807a-47bd-8d21-835d83031191.png">
 '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We support the PR feature with limitation that avoid huge output rows in user ad-hoc query unexpected，Generally ad-hoc query seems needle in a Haystack, user pick few computed result data in huge data from warehouse,  we mainly used in below cases:

- CASE 1:
```
SELECT [c1, c2, ...] 
```
- CASE 2:
```
WITH CTE AS (...)
SELECT [c1, c2, ...] FROM Express(CTE) ...
```

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="1440" alt="截屏2021-09-12 下午12 19 28" src="https://user-images.githubusercontent.com/635169/132972078-c4821135-0520-420d-9ab8-24e124f6c6c9.png">


- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
