### PR TITLE
[KYUUBI #1113] Fix error fetching results after run PlanOnlyStatement

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/PlanOnlyStatement.scala
@@ -24,6 +24,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.kyuubi.config.KyuubiConf.OperationModes.{ANALYZE, OperationMode, OPTIMIZE, PARSE}
 import org.apache.kyuubi.engine.spark.{ArrayFetchIterator, IterableFetchIterator}
 import org.apache.kyuubi.operation.OperationType
+import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.Session
 
 /**
@@ -35,6 +36,10 @@ class PlanOnlyStatement(
     protected override val statement: String,
     mode: OperationMode)
   extends SparkOperation(spark, OperationType.EXECUTE_STATEMENT, session) {
+
+  private val operationLog: OperationLog =
+    OperationLog.createOperationLog(session.handle, getHandle)
+  override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   override protected def resultSchema: StructType = if (result == null) {
     new StructType().add("plan", "string")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->


**RUN QUERY**
```
set kyuubi.operation.plan.only.mode=ANALYZE;
select 1;
```

**ERROR MSG**
```
2021-09-16 15:19:57.278 INFO operation.PlanOnlyStatement: Processing anonymous's query[015cbe32-c872-407c-b6a8-d3be6b43d745]: INITIALIZED_STATE -> RUNNING_STATE, statement: set kyuubi.operation.plan.only.mode=ANALYZE
2021-09-16 15:19:57.293 INFO operation.PlanOnlyStatement: Processing anonymous's query[015cbe32-c872-407c-b6a8-d3be6b43d745]: RUNNING_STATE -> FINISHED_STATE, statement: set kyuubi.operation.plan.only.mode=ANALYZE, time taken: 0.015 seconds
2021-09-16 15:19:57.309 WARN spark.SparkThriftFrontendService: Error fetching results: 
org.apache.kyuubi.KyuubiSQLException: OperationHandle [type=EXECUTE_STATEMENT, identifier: 015cbe32-c872-407c-b6a8-d3be6b43d745] failed to generate operation log
	at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:69)
	at org.apache.kyuubi.operation.OperationManager.$anonfun$getOperationLogRowSet$2(OperationManager.scala:125)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.kyuubi.operation.OperationManager.getOperationLogRowSet(OperationManager.scala:125)
	at org.apache.kyuubi.session.AbstractSession.fetchResults(AbstractSession.scala:193)
	at org.apache.kyuubi.service.AbstractBackendService.fetchResults(AbstractBackendService.scala:164)
	at org.apache.kyuubi.service.ThriftFrontendService.FetchResults(ThriftFrontendService.scala:479)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1837)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1822)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
	at org.apache.kyuubi.service.authentication.TSetIpAddressProcessor.process(TSetIpAddressProcessor.scala:36)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:310)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
2021-09-16 15:19:57.313 WARN spark.SparkThriftFrontendService: Error fetching results: 
org.apache.kyuubi.KyuubiSQLException: OperationHandle [type=EXECUTE_STATEMENT, identifier: 015cbe32-c872-407c-b6a8-d3be6b43d745] failed to generate operation log
	at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:69)
	at org.apache.kyuubi.operation.OperationManager.$anonfun$getOperationLogRowSet$2(OperationManager.scala:125)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.kyuubi.operation.OperationManager.getOperationLogRowSet(OperationManager.scala:125)
	at org.apache.kyuubi.session.AbstractSession.fetchResults(AbstractSession.scala:193)
	at org.apache.kyuubi.service.AbstractBackendService.fetchResults(AbstractBackendService.scala:164)
	at org.apache.kyuubi.service.ThriftFrontendService.FetchResults(ThriftFrontendService.scala:479)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1837)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1822)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:38)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
	at org.apache.kyuubi.service.authentication.TSetIpAddressProcessor.process(TSetIpAddressProcessor.scala:36)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:310)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
