### PR TITLE
[TEST] DataLake suites should clean up withKyuubiConf instead of extraConfigs

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkDeltaOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkDeltaOperationSuite.scala
@@ -23,12 +23,14 @@ import org.apache.kyuubi.tags.DeltaTest
 
 @DeltaTest
 class SparkDeltaOperationSuite extends WithSparkSQLEngine with BasicDeltaJDBCTests {
+
   override protected def jdbcUrl: String = getJdbcUrl
+
   override def withKyuubiConf: Map[String, String] = extraConfigs
 
   override def afterAll(): Unit = {
     super.afterAll()
-    for ((k, _) <- extraConfigs) {
+    for ((k, _) <- withKyuubiConf) {
       System.clearProperty(k)
     }
   }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkHudiOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkHudiOperationSuite.scala
@@ -23,13 +23,14 @@ import org.apache.kyuubi.tags.HudiTest
 
 @HudiTest
 class SparkHudiOperationSuite extends WithSparkSQLEngine with BasicHudiJDBCTests {
+
   override protected def jdbcUrl: String = getJdbcUrl
 
   override def withKyuubiConf: Map[String, String] = extraConfigs
 
   override def afterAll(): Unit = {
     super.afterAll()
-    for ((k, _) <- extraConfigs) {
+    for ((k, _) <- withKyuubiConf) {
       System.clearProperty(k)
     }
   }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkIcebergOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkIcebergOperationSuite.scala
@@ -23,12 +23,14 @@ import org.apache.kyuubi.tags.IcebergTest
 
 @IcebergTest
 class SparkIcebergOperationSuite extends WithSparkSQLEngine with BasicIcebergJDBCTests {
+
   override protected def jdbcUrl: String = getJdbcUrl
+
   override def withKyuubiConf: Map[String, String] = extraConfigs
 
   override def afterAll(): Unit = {
     super.afterAll()
-    for ((k, _) <- extraConfigs) {
+    for ((k, _) <- withKyuubiConf) {
       System.clearProperty(k)
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Keep consistent with
```
    withKyuubiConf.foreach { case (k, v) =>
      System.setProperty(k, v)
      kyuubiConf.set(k, v)
    }
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
