### PR TITLE
[BUILD] Support passthrough env var CI into build container

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -154,7 +154,8 @@ jobs:
       - name: Build Kyuubi Docker Image
         uses: docker/build-push-action@v2
         with:
-          build-args: CI="GTIHUB_ACTION_DOCKER"
+          # passthrough CI into build container
+          build-args: CI=${CI}
           context: .
           file: docker/Dockerfile
           load: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -141,6 +141,7 @@ jobs:
         run: |
           ./build/mvn clean install -Pspark-3.1 -DskipTests -pl :kyuubi-spark-sql-engine_2.12,:kyuubi-common_2.12,:kyuubi-ha_2.12,:kyuubi-zookeeper_2.12,:kyuubi-spark-monitor_2.12
           ./build/mvn test -Pspark-3.1 -Dtest=none -DwildcardSuites=org.apache.kyuubi.operation.tpcds -Dmaven.plugin.scalatest.exclude.tags=''
+
   minikube-it:
     name: Minikube Integration Test
     runs-on: ubuntu-20.04
@@ -153,6 +154,7 @@ jobs:
       - name: Build Kyuubi Docker Image
         uses: docker/build-push-action@v2
         with:
+          build-args: MVN_ARG="--batch-mode --no-transfer-progress --errors --fail-fast"
           context: .
           file: docker/Dockerfile
           load: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Build Kyuubi Docker Image
         uses: docker/build-push-action@v2
         with:
-          build-args: MVN_ARG="--batch-mode --no-transfer-progress --errors --fail-fast"
+          build-args: CI="GTIHUB_ACTION_DOCKER"
           context: .
           file: docker/Dockerfile
           load: true

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -28,7 +28,10 @@ ARG BASE_IMAGE=openjdk:8-jdk
 
 FROM maven:3.6-jdk-8 as builder
 
+ARG CI
 ARG MVN_ARG
+
+ENV CI $CI
 
 ADD . /workspace/kyuubi
 WORKDIR /workspace/kyuubi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,7 +39,7 @@ ARG MVN_ARG
 #
 # Continuous integration(aka. CI) services like GitHub Actions, Travis always provide
 # an environment variable `CI` in runners, and we detect this variable to run some
-# specific actions, e.g. run `mvn` in batch mode to suppress nosiy logs.
+# specific actions, e.g. run `mvn` in batch mode to suppress noisy logs.
 ARG CI
 ENV CI ${CI}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,11 @@
 
 # Usage:
 #   Run the docker command below
-#      docker build --build-arg MVN_ARG="-Pspark-3.1,spark-hadoop-3.2" -f docker/Dockerfile -t apache/kyuubi:tagname .
+#      docker build \
+#        --build-arg CI="TRUE",MVN_ARG="-Pspark-3.1,spark-hadoop-3.2" \
+#        -f docker/Dockerfile \
+#        -t apache/kyuubi:tagname \
+#        .
 #   Options:
 #     -f this docker file
 #     -t the target repo and tag name

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ FROM maven:3.6-jdk-8 as builder
 ARG CI
 ARG MVN_ARG
 
-ENV CI $CI
+ENV CI ${CI}
 
 ADD . /workspace/kyuubi
 WORKDIR /workspace/kyuubi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -38,7 +38,7 @@ ARG MVN_ARG
 # Pass the environment variable `CI` into container, for internal use only.
 #
 # Continuous integration(aka. CI) services like GitHub Actions, Travis always provide
-# an environment variable `CI` in the context, and we detect this variable to run some
+# an environment variable `CI` in runners, and we detect this variable to run some
 # specific actions, e.g. run `mvn` in batch mode to suppress nosiy logs.
 ARG CI
 ENV CI ${CI}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,23 +18,29 @@
 # Usage:
 #   Run the docker command below
 #      docker build \
-#        --build-arg CI="TRUE",MVN_ARG="-Pspark-3.1,spark-hadoop-3.2" \
-#        -f docker/Dockerfile \
-#        -t apache/kyuubi:tagname \
+#        --build-arg MVN_ARG="-Pspark-3.1,spark-hadoop-3.2" \
+#        --file docker/Dockerfile \
+#        --tag apache/kyuubi:tagname \
 #        .
 #   Options:
-#     -f this docker file
-#     -t the target repo and tag name
-#     more options can be found with -h
+#     -f, --file  this docker file
+#     -t, --tag   the target repo and tag name
+#     more options can be found with -h, --help
 
-# declare the BASE_IMAGE argument in the first line. for more detail see: https://github.com/moby/moby/issues/38379
+# Declare the BASE_IMAGE argument in the first line, for more detail
+# see: https://github.com/moby/moby/issues/38379
 ARG BASE_IMAGE=openjdk:8-jdk
 
 FROM maven:3.6-jdk-8 as builder
 
-ARG CI
 ARG MVN_ARG
 
+# Pass the environment variable `CI` into container, for internal use only.
+#
+# Continuous integration(aka. CI) services like GitHub Actions, Travis always provide
+# an environment variable `CI` in the context, and we detect this variable to run some
+# specific actions, e.g. run `mvn` in batch mode to suppress nosiy logs.
+ARG CI
 ENV CI ${CI}
 
 ADD . /workspace/kyuubi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Continuous integration(aka. CI) services like GitHub Actions, Travis always provide an environment variable `CI` in runners, and we detect this variable to run some specific actions.

In [KYUUBI #742], we add a `CI` env var detection in `build/mvn` to suppress noisy maven logs in CI scenes.

This PR introduces a new build arg `CI` in `docker/Dockerfile`, which is intent to passthrough env var CI into the build container to suppress noisy maven logs in GitHub Action and Travis.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
