### PR TITLE
[KYUUBI #1164] Grep WARN in dependency.sh

### DIFF
--- a/build/dependency.sh
+++ b/build/dependency.sh
@@ -33,7 +33,7 @@ DEP="${PWD}"/dev/dependencyList
 
 function build_classpath() {
   $MVN dependency:build-classpath -pl :kyuubi-assembly_2.12 |\
-    grep -v "INFO" | \
+    grep -v "INFO\|WARN" | \
     tr ":" "\n" | \
     awk -F '/' '{
       artifact_id=$(NF-2);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When MVN dependency has WARN log, ./build/dependency.sh --replace will exit with execption:
```
awk: trying to access out of range field -1
 input record number 1, file 
 source line number 2
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
