### PR TITLE
[KYUUBI #1184] Support ending with .* to restrict and ingore session config

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/session/SessionManagerSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/session/SessionManagerSuite.scala
@@ -23,6 +23,7 @@ import org.apache.hive.service.rpc.thrift._
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Seconds, Span}
 
+import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.service.ThriftFrontendServiceSuite
 
@@ -34,6 +35,8 @@ class SessionManagerSuite extends ThriftFrontendServiceSuite with Eventually {
     .set(KyuubiConf.SESSION_CHECK_INTERVAL, Duration.ofSeconds(5).toMillis)
     .set(KyuubiConf.SESSION_IDLE_TIMEOUT, Duration.ofSeconds(5).toMillis)
     .set(KyuubiConf.OPERATION_IDLE_TIMEOUT, Duration.ofSeconds(20).toMillis)
+    .set(KyuubiConf.SESSION_CONF_RESTRICT_LIST, Seq("spark.*"))
+    .set(KyuubiConf.SESSION_CONF_IGNORE_LIST, Seq("session.engine.*"))
 
   test("close expired operations") {
     withSessionHandle{ (client, handle) =>
@@ -71,5 +74,21 @@ class SessionManagerSuite extends ThriftFrontendServiceSuite with Eventually {
       }
       assert(sessionManager.getOpenSessionCount == 0)
     }
+  }
+
+  test("test validate and normalize config") {
+    val sessionManager = server.backendService.sessionManager
+    // test restrict
+    intercept[KyuubiSQLException] {
+      sessionManager.validateAndNormalizeConf(Map("spark.driver.memory" -> "2G"))
+    }
+
+    // test ignore
+    val conf = sessionManager.validateAndNormalizeConf(
+      Map(
+        "session.engine.spark.main.resource" -> "org.apahce.kyuubi.test",
+        "session.check.interval" -> "10000"))
+    assert(conf.size == 1)
+    assert(conf("session.check.interval") == "10000")
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Now, restricted and ingored keys must be complete. We can support eding with '.*' to restricted a list of keys.

### _How was this patch tested?_
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
