### PR TITLE
[KYUUBI #1190] Enhance error log detection in case lost the exception log

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -122,7 +122,8 @@ trait ProcBuilder {
               line = reader.readLine()
               while (sb.length < maxErrorSize && line != null &&
                 (containsIgnoreCase(line, "Exception:") ||
-                  line.startsWith("\tat ") || line.startsWith("Caused by: "))) {
+                  line.startsWith("\tat ") ||
+                  line.startsWith("Caused by: "))) {
                 sb.append("\n" + line)
                 line = reader.readLine()
               }


### PR DESCRIPTION
### Why are the changes needed?
When line2 is read, it does not contain `at` or `cause by`, so all of the following messages are discarded. 

#1190

```
2021-10-09 09:35:14.528 ERROR spark.SparkSQLEngine: Failed to instantiate SparkSession: org.apache.hadoop.hive.ql.metadata.HiveException: java.lang.RuntimeException: Unable to instantiate org.apache.hadoop.hive.ql.metadata.SessionHiveMetaStoreClient;
org.apache.spark.sql.AnalysisException: org.apache.hadoop.hive.ql.metadata.HiveException: java.lang.RuntimeException: Unable to instantiate org.apache.hadoop.hive.ql.metadata.SessionHiveMetaStoreClient;
	at org.apache.spark.sql.hive.HiveExternalCatalog.withClient(HiveExternalCatalog.scala:113)
	at org.apache.spark.sql.hive.HiveExternalCatalog.databaseExists(HiveExternalCatalog.scala:225)
	at org.apache.spark.sql.internal.SharedState.externalCatalog$lzycompute(SharedState.scala:137)
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
