### PR TITLE
[KYUUBI #1039][FOLLOWUP] Application stop log redirect append to engineLog

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.engine
 
 import java.io.{File, IOException}
+import java.lang.ProcessBuilder.Redirect
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path}
 
@@ -159,8 +160,8 @@ trait ProcBuilder {
             val pb = new ProcessBuilder("/bin/sh", s"$kyuubiHome/bin/stop-application.sh", appId)
             pb.environment()
               .putAll(env.asJava)
-            pb.redirectError(engineLog)
-            pb.redirectOutput(engineLog)
+            pb.redirectError(Redirect.appendTo(engineLog))
+            pb.redirectOutput(Redirect.appendTo(engineLog))
             val process = pb.start()
             process.waitFor() match {
               case id if id != 0 => s"Failed to kill Application $appId, please kill it manually. "


### PR DESCRIPTION
### _Why are the changes needed?_
Now application stop log will overwrite log file `engineLog`, which cause engine logs are lost.
![image](https://user-images.githubusercontent.com/18065113/136765514-6a41d2ce-d3df-4b9b-a6d1-5c9bb51a8e4d.png)
This pr change `overwrite` to `append`.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
