### PR TITLE
Skip zorder if only requires one column

### DIFF
--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/zorder/InsertZorderBeforeWriting.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/zorder/InsertZorderBeforeWriting.scala
@@ -135,8 +135,13 @@ trait InsertZorderHelper extends Rule[LogicalPlan] {
       plan
     } else {
       val bound = cols.map(attrs(_))
+      val orderExpr = if (bound.length == 1) {
+        bound.head
+      } else {
+        Zorder(bound)
+      }
       Sort(
-        SortOrder(Zorder(bound), Ascending, NullsLast, Seq.empty) :: Nil,
+        SortOrder(orderExpr, Ascending, NullsLast, Seq.empty) :: Nil,
         true,
         plan
       )

--- a/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/zorder/ZorderSqlAstBuilder.scala
+++ b/dev/kyuubi-extension-spark-3-1/src/main/scala/org/apache/kyuubi/sql/zorder/ZorderSqlAstBuilder.scala
@@ -76,9 +76,14 @@ class ZorderSqlAstBuilder extends ZorderSqlExtensionsBaseVisitor[AnyRef] {
       .map(UnresolvedAttribute(_))
       .toSeq
 
+    val orderExpr = if (zorderCols.length == 1) {
+      zorderCols.head
+    } else {
+      Zorder(zorderCols)
+    }
     val query =
       Sort(
-        SortOrder(Zorder(zorderCols), Ascending, NullsLast, Seq.empty) :: Nil,
+        SortOrder(orderExpr, Ascending, NullsLast, Seq.empty) :: Nil,
         true,
         Project(Seq(UnresolvedStar(None)), tableWithFilter))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Improve the perf.

If user only requires one column as zorde columns, it has no meaning to wrap a zorder expression.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
