### PR TITLE
[KYUUBI #1229] Fix met error when debug KyuubiServer in local IDE

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/jdbc/KyuubiHiveDriverSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/jdbc/KyuubiHiveDriverSuite.scala
@@ -22,7 +22,6 @@ import java.util.Properties
 import org.apache.kyuubi.IcebergSuiteMixin
 import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
 import org.apache.kyuubi.engine.spark.shim.SparkCatalogShim
-import org.apache.kyuubi.jdbc.hive.{KyuubiConnection, KyuubiDatabaseMetaData}
 import org.apache.kyuubi.tags.IcebergTest
 
 @IcebergTest
@@ -42,9 +41,9 @@ class KyuubiHiveDriverSuite extends WithSparkSQLEngine with IcebergSuiteMixin {
   test("get tables with kyuubi driver") {
     val driver = new KyuubiHiveDriver()
     val connection = driver.connect(getJdbcUrl, new Properties())
-    assert(connection.isInstanceOf[KyuubiConnection])
+    assert(connection.getClass.getName === "org.apache.kyuubi.jdbc.hive.KyuubiConnection")
     val metaData = connection.getMetaData
-    assert(metaData.isInstanceOf[KyuubiDatabaseMetaData])
+    assert(metaData.getClass.getName === "org.apache.kyuubi.jdbc.hive.KyuubiDatabaseMetaData")
     val statement = connection.createStatement()
     val table1 = s"${SparkCatalogShim.SESSION_CATALOG}.default.kyuubi_hive_jdbc"
     val table2 = s"$catalog.default.hdp_cat_tbl"
@@ -74,9 +73,9 @@ class KyuubiHiveDriverSuite extends WithSparkSQLEngine with IcebergSuiteMixin {
   test("deprecated KyuubiDriver also works") {
     val driver = new KyuubiDriver()
     val connection = driver.connect(getJdbcUrl, new Properties())
-    assert(connection.isInstanceOf[KyuubiConnection])
+    assert(connection.getClass.getName === "org.apache.kyuubi.jdbc.hive.KyuubiConnection")
     val metaData = connection.getMetaData
-    assert(metaData.isInstanceOf[KyuubiDatabaseMetaData])
+    assert(metaData.getClass.getName === "org.apache.kyuubi.jdbc.hive.KyuubiDatabaseMetaData")
     val statement = connection.createStatement()
     try {
       val resultSet = statement.executeQuery(s"SELECT 1")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When debug KyuubiServer in IDEA, IDEA: Intellij IDEA 2021.2(Ultimate Edition)

throw exception
```
/KyuubiHiveDriverSuite.scala:45:36
Class org.apache.hive.jdbc.HiveConnection not found - continuing with a stub.
    assert(connection.isInstanceOf[KyuubiConnection])
```

```
/KyuubiHiveDriverSuite.scala:47:34
Class org.apache.hive.jdbc.HiveDatabaseMetaData not found - continuing with a stub.
    assert(metaData.isInstanceOf[KyuubiDatabaseMetaData])
```

For more detail, please go to https://github.com/apache/incubator-kyuubi/issues/1229

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
