### PR TITLE
[KYUUBI #1176][FOLLOWUP] Fix NoAuth when engine disable acl

### DIFF
--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/ServiceDiscoverySuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/ServiceDiscoverySuite.scala
@@ -116,6 +116,12 @@ class ServiceDiscoverySuite extends KerberizedTestHelper {
     val serverACL = new ZooKeeperACLProvider(serverConf).getDefaultAcl
     assertACL(expectedEnableACL, serverACL)
 
+    serverConf.set(HA_ZK_ACL_ENGINE_ENABLED, false)
+    assertACL(expectedEnableACL, new ZooKeeperACLProvider(serverConf)
+      .getAclForPath(serverConf.get(HA_ZK_NAMESPACE)))
+    assertACL(expectedNoACL, new ZooKeeperACLProvider(serverConf)
+      .getAclForPath(serverConf.get(HA_ZK_NAMESPACE) + "_USER"))
+
     val engineConf = serverConf.clone.set(HA_ZK_ENGINE_REF_ID, "ref")
     engineConf.set(HA_ZK_ACL_ENGINE_ENABLED, false)
     val engineACL = new ZooKeeperACLProvider(engineConf).getDefaultAcl


### PR DESCRIPTION
### _Why are the changes needed?_
The `EngineRef` of the server uses `InterProcessSemaphoreMutex`, which will create a znode with acl, causing the engine to be unable to write to the znode (`KeeperErrorCode = NoAuth`)

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
