### PR TITLE
Improve paddingTo8Byte perf

### DIFF
--- a/dev/kyuubi-extension-spark-common/benchmarks/ZorderCoreBenchmark-results.txt
+++ b/dev/kyuubi-extension-spark-common/benchmarks/ZorderCoreBenchmark-results.txt
@@ -9,3 +9,10 @@ Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
 3 long columns benchmark                           3029           3133         111          0.3        3028.7       0.5X
 4 long columns benchmark                           3789           3848          89          0.3        3789.0       0.4X
 
+Java HotSpot(TM) 64-Bit Server VM 1.8.0_271-b09 on Mac OS X 10.16
+Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
+10000000 iterations paddingTo8Byte benchmark:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
+----------------------------------------------------------------------------------------------------------------------------
+2 length benchmark                                      167            170           3         59.9          16.7       1.0X
+16 length benchmark                                     162            164           3         61.7          16.2       1.0X
+

--- a/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/zorder/ZorderBytesUtils.scala
+++ b/dev/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/zorder/ZorderBytesUtils.scala
@@ -152,28 +152,18 @@ object ZorderBytesUtils {
   }
 
   def paddingTo8Byte(a: Array[Byte]): Array[Byte] = {
-    if (a.length == 8) {
-      return a
+    val len = a.length
+    if (len == 8) {
+      a
+    } else if (len > 8) {
+      val result = new Array[Byte](8)
+      System.arraycopy(a, 0, result, 0, 8)
+      result
+    } else {
+      val result = new Array[Byte](8)
+      System.arraycopy(a, 0, result, 8 - len, len)
+      result
     }
-    if (a.length > 8) {
-      val result = new Array[Byte](8);
-      a.copyToArray(result)
-      return result
-    }
-    val paddingSize = 8 - a.length;
-    val emptyArray = Array.ofDim[Byte](paddingSize)
-    arrayConcat(emptyArray, a)
-  }
-
-  def arrayConcat(bytes: Array[Byte]*): Array[Byte] = {
-    val length = bytes.foldLeft(0)(_ + _.length)
-    val result = new Array[Byte](length)
-    var pos = 0
-    bytes.foreach(arr => {
-      arr.copyToArray(result, pos)
-      pos += arr.length
-    })
-    result
   }
 
   def defaultValue(dataType: DataType): Array[Byte] = toByte {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Add a new benchmark for `paddingTo8Byte` method

Before this PR:
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_271-b09 on Mac OS X 10.16
Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
10000000 iterations paddingTo8Byte benchmark:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------
2 length benchmark                                     2112           2180          78          4.7         211.2       1.0X
16 length benchmark                                     454            459           6         22.0          45.4       4.6X
```

After this PR:
```
Java HotSpot(TM) 64-Bit Server VM 1.8.0_271-b09 on Mac OS X 10.16
Intel(R) Core(TM) i7-4770HQ CPU @ 2.20GHz
10000000 iterations paddingTo8Byte benchmark:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------
2 length benchmark                                      167            170           3         59.9          16.7       1.0X
16 length benchmark                                     162            164           3         61.7          16.2       1.0X
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
