### PR TITLE
fix tool cleaner process bug

### DIFF
--- a/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
+++ b/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
@@ -163,7 +163,7 @@ object KubernetesSparkBlockCleaner extends Logging {
 
       used.toInt > (100 - freeSpaceThreshold)
     } catch {
-      case e: RuntimeException =>
+      case NonFatal(e) =>
         error(s"An error occurs when querying the disk $dir capacity, " +
           s"return true to make sure the disk space will not overruns: ${e.getMessage}")
         true

--- a/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
+++ b/tools/spark-block-cleaner/src/main/scala/org/apache/kyuubi/tools/KubernetesSparkBlockCleaner.scala
@@ -165,7 +165,7 @@ object KubernetesSparkBlockCleaner extends Logging {
     } catch {
       case e: RuntimeException =>
         error(s"An error occurs when querying the disk $dir capacity, " +
-          s"return true to make sure there are no problems: ${e.getMessage}")
+          s"return true to make sure the disk space will not overruns: ${e.getMessage}")
         true
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When using the tool to help clean up spark on K8s residual cache files, I encountered unreported sleep conditions.
After analysis, it was found that the SSD mounted when `needToDeepClean` was run encountered an incorrect catch exception.
Now, `Try Catch` is added to ensure the normal operation of the function, and deep cleaning is performed by default if a problem occurs. In this case, the disk space still overruns after the cleaning opportunity is missed.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
