### PR TITLE
Support setting zk chroot path when initialize cluster

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ZooKeeperClientProvider.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ZooKeeperClientProvider.scala
@@ -22,14 +22,10 @@ import javax.security.auth.login.Configuration
 
 import org.apache.curator.framework.{CuratorFramework, CuratorFrameworkFactory}
 import org.apache.curator.retry._
-import org.apache.curator.utils.ZKPaths
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.hadoop.security.token.delegation.ZKDelegationTokenSecretManager.JaasConfiguration
-import org.apache.zookeeper.CreateMode.PERSISTENT
-import org.apache.zookeeper.KeeperException
-import org.apache.zookeeper.KeeperException.NodeExistsException
 
-import org.apache.kyuubi.{KyuubiException, Logging}
+import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.util.KyuubiHadoopUtils
@@ -58,35 +54,6 @@ object ZooKeeperClientProvider extends Logging {
         new BoundedExponentialBackoffRetry(baseSleepTime, maxSleepTime, maxRetries)
       case UNTIL_ELAPSED => new RetryUntilElapsed(maxSleepTime, baseSleepTime)
       case _ => new ExponentialBackoffRetry(baseSleepTime, maxRetries)
-    }
-    val chrootIndex = connectionStr.indexOf("/")
-    val chrootOption = {
-      if (chrootIndex > 0) Some(connectionStr.substring(chrootIndex))
-      else None
-    }
-    // make sure zookeeper chroot path exists
-    chrootOption.foreach { chroot =>
-      val zkConnectionForChrootCreation = connectionStr.substring(0, chrootIndex)
-      val clonedConf = KyuubiConf(false)
-      clonedConf.set(HA_ZK_QUORUM, zkConnectionForChrootCreation)
-      val zkClient = buildZookeeperClient(clonedConf)
-      zkClient.start()
-      if (zkClient.checkExists().forPath(chroot) == null) {
-        val chrootPath = ZKPaths.makePath(null, chroot)
-        try {
-          zkClient
-            .create()
-            .creatingParentsIfNeeded()
-            .withMode(PERSISTENT)
-            .forPath(chrootPath)
-        } catch {
-          case _: NodeExistsException => // do nothing
-          case e: KeeperException =>
-            throw new KyuubiException(s"Failed to create chroot path '$chrootPath'", e)
-        }
-        info(s"Created zookeeper chroot path $chrootPath")
-      }
-      zkClient.close()
     }
     val builder = CuratorFrameworkFactory.builder()
       .connectString(connectionStr)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.server
 
+import java.util
+
 import scala.util.Properties
 
 import org.apache.curator.utils.ZKPaths
@@ -50,6 +52,14 @@ object KyuubiServer extends Logging {
     } else {
       // create chroot path if necessary
       val connectionStr = conf.get(HA_ZK_QUORUM)
+      val addresses = connectionStr.split(",")
+      val slashOption = util.Arrays.copyOfRange(addresses, 0, addresses.length -1)
+        .toList
+        .find(_.contains("/"))
+      if (slashOption.isDefined) {
+        throw new IllegalArgumentException(s"Illegal zookeeper quorum '$connectionStr', " +
+          s"the chroot path started with / is only allowed at the end!")
+      }
       val chrootIndex = connectionStr.indexOf("/")
       val chrootOption = {
         if (chrootIndex > 0) Some(connectionStr.substring(chrootIndex))

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -19,7 +19,11 @@ package org.apache.kyuubi.server
 
 import scala.util.Properties
 
+import org.apache.curator.utils.ZKPaths
 import org.apache.hadoop.security.UserGroupInformation
+import org.apache.zookeeper.CreateMode.PERSISTENT
+import org.apache.zookeeper.KeeperException
+import org.apache.zookeeper.KeeperException.NodeExistsException
 
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
@@ -27,6 +31,7 @@ import org.apache.kyuubi.config.KyuubiConf.{FRONTEND_PROTOCOLS, FrontendProtocol
 import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols._
 import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.ha.client.{ServiceDiscovery, ZooKeeperAuthTypes}
+import org.apache.kyuubi.ha.client.ZooKeeperClientProvider._
 import org.apache.kyuubi.metrics.{MetricsConf, MetricsSystem}
 import org.apache.kyuubi.service.{AbstractBackendService, AbstractFrontendService, Serverable}
 import org.apache.kyuubi.util.{KyuubiHadoopUtils, SignalRegister}
@@ -42,6 +47,35 @@ object KyuubiServer extends Logging {
       zkServer.start()
       conf.set(HA_ZK_QUORUM, zkServer.getConnectString)
       conf.set(HA_ZK_AUTH_TYPE, ZooKeeperAuthTypes.NONE.toString)
+    } else {
+      // create chroot path if necessary
+      val connectionStr = conf.get(HA_ZK_QUORUM)
+      val chrootIndex = connectionStr.indexOf("/")
+      val chrootOption = {
+        if (chrootIndex > 0) Some(connectionStr.substring(chrootIndex))
+        else None
+      }
+      chrootOption.foreach { chroot =>
+        val zkConnectionForChrootCreation = connectionStr.substring(0, chrootIndex)
+        val overrideQuorumConf = conf.clone.set(HA_ZK_QUORUM, zkConnectionForChrootCreation)
+        withZkClient(overrideQuorumConf) { zkClient =>
+          if (zkClient.checkExists().forPath(chroot) == null) {
+            val chrootPath = ZKPaths.makePath(null, chroot)
+            try {
+              zkClient
+                .create()
+                .creatingParentsIfNeeded()
+                .withMode(PERSISTENT)
+                .forPath(chrootPath)
+            } catch {
+              case _: NodeExistsException => // do nothing
+              case e: KeeperException =>
+                throw new KyuubiException(s"Failed to create chroot path '$chrootPath'", e)
+            }
+          }
+        }
+        info(s"Created zookeeper chroot path $chroot")
+      }
     }
 
     val server = new KyuubiServer()


### PR DESCRIPTION
### _Why are the changes needed?_
Users may encounter the following exception when trying to set `kyuubi.ha.zookeeper.quorum` to `localhost:2181/lakehouse` with chroot path `/lakehouse` nonexisted:
```
2021-11-10 10:56:34.510 ERROR server.KyuubiThriftBinaryFrontendService: Error starting service KyuubiServiceDiscovery
org.apache.kyuubi.KyuubiException: Failed to create namespace '/kyuubi'
        at org.apache.kyuubi.ha.client.ServiceDiscovery$.createServiceNode(ServiceDiscovery.scala:225)
        at org.apache.kyuubi.ha.client.ServiceDiscovery.start(ServiceDiscovery.scala:101)
......
Caused by: org.apache.zookeeper.KeeperException$NoNodeException: KeeperErrorCode = NoNode for /kyuubi
        at org.apache.zookeeper.KeeperException.create(KeeperException.java:114)
......
```
It is wonderful to support this since zookeeper connection with chroot path is generally recommended in production environments. With this feture the znodes in zookeeper likes below:
```
[zk: localhost:2181(CONNECTED) 28] ls /lakehouse
[kyuubi, kyuubi_USER, kyuubi_USER_SPARK_SQL]
```
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
