### PR TITLE
Refine print environment variables to console

### DIFF
--- a/bin/kyuubi
+++ b/bin/kyuubi
@@ -62,7 +62,7 @@ function kyuubi_rotate_log() {
 
 export KYUUBI_HOME="$(cd "$(dirname "$0")"/..; pwd)"
 
-if [ $1 == "start" ]; then
+if [[ $1 == "start" ]] || [[ $1 == "run" ]]; then
   . "${KYUUBI_HOME}/bin/load-kyuubi-env.sh"
 else
   . "${KYUUBI_HOME}/bin/load-kyuubi-env.sh" -s

--- a/bin/kyuubi
+++ b/bin/kyuubi
@@ -62,7 +62,11 @@ function kyuubi_rotate_log() {
 
 export KYUUBI_HOME="$(cd "$(dirname "$0")"/..; pwd)"
 
-. "${KYUUBI_HOME}/bin/load-kyuubi-env.sh"
+if [ $1 == "start" ]; then
+  . "${KYUUBI_HOME}/bin/load-kyuubi-env.sh"
+else
+  . "${KYUUBI_HOME}/bin/load-kyuubi-env.sh" -s
+fi
 
 if [[ -z ${JAVA_HOME} ]]; then
   echo "Error: JAVA_HOME IS NOT SET! CANNOT PROCEED."


### PR DESCRIPTION
### _Why are the changes needed?_
Currently, the enviroment variables are also printed to console when using `bin/kyuubi status` or `bin/kyuubi stop` like below:
```
$ bin/kyuubi status
Using kyuubi environment file /data01/apache-kyuubi-1.4.0-SNAPSHOT-bin-incubating/conf/kyuubi-env.sh to initialize...
JAVA_HOME: /usr/jdk1.8.0_172
KYUUBI_HOME: /data01/apache-kyuubi-1.4.0-SNAPSHOT-bin-incubating
KYUUBI_CONF_DIR: /data01/apache-kyuubi-1.4.0-SNAPSHOT-bin-incubating/conf
KYUUBI_LOG_DIR: /data01/apache-kyuubi-1.4.0-SNAPSHOT-bin-incubating/logs
KYUUBI_PID_DIR: /data01/apache-kyuubi-1.4.0-SNAPSHOT-bin-incubating/pid
KYUUBI_WORK_DIR_ROOT: /data01/apache-kyuubi-1.4.0-SNAPSHOT-bin-incubating/work
SPARK_HOME: /data01/apache-kyuubi-1.4.0-SNAPSHOT-bin-incubating/externals/spark-3.1.2-bin-hadoop3.2
SPARK_CONF_DIR: /data01/apache-kyuubi-1.4.0-SNAPSHOT-bin-incubating/externals/spark-3.1.2-bin-hadoop3.2/conf
HADOOP_CONF_DIR:
Kyuubi is not running
```
In general, these variables are only needed to display when starting a cluster to keep clean style, something like below:
```
$ bin/kyuubi status
Kyuubi is running (pid: 95472)
$ bin/kyuubi stop
Stopping org.apache.kyuubi.server.KyuubiServer
...
```
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request