### PR TITLE
Turn off debugging in dist scripts

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -26,7 +26,6 @@
 
 set -o pipefail
 set -e
-set -x
 
 KYUUBI_HOME="$(cd "`dirname "$0"`/.."; pwd)"
 DISTDIR="$KYUUBI_HOME/dist"
@@ -234,4 +233,5 @@ if [[ "$MAKE_TGZ" == "true" ]]; then
   cp -r "$DISTDIR" "$TARDIR"
   tar czf "$TARDIR_NAME.tgz" -C "$KYUUBI_HOME" "$TARDIR_NAME"
   rm -rf "$TARDIR"
+  echo "The Kyuubi tarball $TARDIR_NAME is successfully generated in $KYUUBI_HOME."
 fi

--- a/build/release/collect-licenses.sh
+++ b/build/release/collect-licenses.sh
@@ -26,7 +26,6 @@
 
 set -o pipefail
 set -e
-set -x
 
 SRC=${1:-.}
 DST=${2:-licenses-output}


### PR DESCRIPTION
### _Why are the changes needed?_
`set -x` is currently used in dist scripts for debugging and the console looks a bit messy, it seems better to turn it off and users can enable it themselves if necessary.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request