### PR TITLE
Fix kyuubi download duplicated plugins

### DIFF
--- a/externals/kyuubi-download/pom.xml
+++ b/externals/kyuubi-download/pom.xml
@@ -36,9 +36,6 @@
             <plugin>
                 <groupId>com.googlecode.maven-download-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <configuration>
-                    <skip>${spark.archive.download.skip}</skip>
-                </configuration>
                 <executions>
                     <execution>
                         <id>download-spark-release</id>
@@ -47,6 +44,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
+                            <skip>${spark.archive.download.skip}</skip>
                             <url>${spark.archive.mirror}/${spark.archive.name}</url>
                             <!-- sha512>${spark.archive.sha512}</sha512 -->
                             <outputDirectory>${project.build.directory}</outputDirectory>
@@ -55,17 +53,6 @@
                             <unpack>true</unpack>
                         </configuration>
                     </execution>
-                </executions>
-            </plugin>
-
-            <!-- Download flink archive -->
-            <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <configuration>
-                    <skip>${flink.archive.download.skip}</skip>
-                </configuration>
-                <executions>
                     <execution>
                         <id>download-flink-release</id>
                         <phase>compile</phase>
@@ -73,6 +60,7 @@
                             <goal>wget</goal>
                         </goals>
                         <configuration>
+                            <skip>${flink.archive.download.skip}</skip>
                             <url>${flink.archive.mirror}/${flink.archive.name}</url>
                             <outputDirectory>${project.build.directory}</outputDirectory>
                             <readTimeOut>60000</readTimeOut>


### PR DESCRIPTION
### _Why are the changes needed?_
Fix maven pom.xml issue

```
(apache-kyuubi) ➜  apache-kyuubi git:(mysql-fe-impl) ✗ build/mvn clean install
Using `mvn` from path: /Users/chengpan/.sdkman/candidates/maven/current/bin/mvn
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.kyuubi:kyuubi-download:pom:1.4.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin com.googlecode.maven-download-plugin:download-maven-plugin @ line 62, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
[INFO] ------------------------------------------------------------------------
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request

```
(apache-kyuubi) ➜  apache-kyuubi git:(download) ✗ build/mvn compile -pl :kyuubi-download -Pspark-provided,flink-provided | grep -A 100 'scala-maven-plugin:4.3.0:compile'
Using `mvn` from path: /Users/chengpan/.sdkman/candidates/maven/current/bin/mvn
[INFO] --- scala-maven-plugin:4.3.0:compile (scala-compile-first) @ kyuubi-download ---
[INFO] compile in 0.0 s
[INFO] No sources to compile
[INFO]
[INFO] --- download-maven-plugin:1.6.6:wget (download-spark-release) @ kyuubi-download ---
[INFO] maven-download-plugin:wget skipped
[INFO]
[INFO] --- download-maven-plugin:1.6.6:wget (download-flink-release) @ kyuubi-download ---
[INFO] maven-download-plugin:wget skipped
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.932 s
[INFO] Finished at: 2021-11-15T10:41:05+08:00
[INFO] ------------------------------------------------------------------------
```

```
(apache-kyuubi) ➜  apache-kyuubi git:(download) ✗ build/mvn compile -pl :kyuubi-download -Pflink-provided | grep -A 100 'scala-maven-plugin:4.3.0:compile'
Using `mvn` from path: /Users/chengpan/.sdkman/candidates/maven/current/bin/mvn
[INFO] --- scala-maven-plugin:4.3.0:compile (scala-compile-first) @ kyuubi-download ---
[INFO] compile in 0.0 s
[INFO] No sources to compile
[INFO]
[INFO] --- download-maven-plugin:1.6.6:wget (download-spark-release) @ kyuubi-download ---
[INFO] Expanding: /Users/chengpan/Projects/apache-kyuubi/externals/kyuubi-download/target/spark-3.1.2-bin-hadoop3.2.tgz into /Users/chengpan/Projects/apache-kyuubi/externals/kyuubi-download/target
[INFO]
[INFO] --- download-maven-plugin:1.6.6:wget (download-flink-release) @ kyuubi-download ---
[INFO] maven-download-plugin:wget skipped
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.486 s
[INFO] Finished at: 2021-11-15T10:42:22+08:00
[INFO] ------------------------------------------------------------------------
```

```
(apache-kyuubi) ➜  apache-kyuubi git:(download) ✗ build/mvn compile -pl :kyuubi-download -Pspark-provided | grep -A 100 'scala-maven-plugin:4.3.0:compile'
Using `mvn` from path: /Users/chengpan/.sdkman/candidates/maven/current/bin/mvn
[INFO] --- scala-maven-plugin:4.3.0:compile (scala-compile-first) @ kyuubi-download ---
[INFO] compile in 0.0 s
[INFO] No sources to compile
[INFO]
[INFO] --- download-maven-plugin:1.6.6:wget (download-spark-release) @ kyuubi-download ---
[INFO] maven-download-plugin:wget skipped
[INFO]
[INFO] --- download-maven-plugin:1.6.6:wget (download-flink-release) @ kyuubi-download ---
[INFO] Expanding: /Users/chengpan/Projects/apache-kyuubi/externals/kyuubi-download/target/flink-1.12.5-bin-scala_2.12.tgz into /Users/chengpan/Projects/apache-kyuubi/externals/kyuubi-download/target
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  5.114 s
[INFO] Finished at: 2021-11-15T10:41:53+08:00
[INFO] ------------------------------------------------------------------------
```


