### PR TITLE
Added support a zookeeper shell

### DIFF
--- a/bin/kyuubi-zookeeper-shell
+++ b/bin/kyuubi-zookeeper-shell
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+## Zookeeper Shell Client Entrance
+CLASS="org.apache.zookeeper.ZooKeeperMain"
+
+export KYUUBI_HOME="$(cd "$(dirname "$0")"/..; pwd)"
+
+. "${KYUUBI_HOME}/bin/load-kyuubi-env.sh" -s
+
+if [[ -z ${JAVA_HOME} ]]; then
+  echo "Error: JAVA_HOME IS NOT SET! CANNOT PROCEED."
+  exit 1
+fi
+
+RUNNER="${JAVA_HOME}/bin/java"
+
+## Find the Kyuubi Jar
+if [[ -z "$KYUUBI_JAR_DIR" ]]; then
+  KYUUBI_JAR_DIR="$KYUUBI_HOME/jars"
+  if [[ ! -d ${KYUUBI_JAR_DIR} ]]; then
+  echo -e "\nCandidate Kyuubi lib $KYUUBI_JAR_DIR doesn't exist, searching development environment..."
+    KYUUBI_JAR_DIR="$KYUUBI_HOME/kyuubi-assembly/target/scala-${KYUUBI_SCALA_VERSION}/jars"
+  fi
+fi
+
+KYUUBI_CLASSPATH="${KYUUBI_JAR_DIR}/*:${KYUUBI_CONF_DIR}:${HADOOP_CONF_DIR}"
+
+exec ${RUNNER} ${KYUUBI_JAVA_OPTS} -cp ${KYUUBI_CLASSPATH} $CLASS "$@"


### PR DESCRIPTION
### _Why are the changes needed?_
It is useful to support a zookeeper shell so that we can view some metadata if necessary. For example:
```
$ bin/kyuubi-zookeeper-shell -server localhost:2181
Connecting to localhost:2181
Welcome to ZooKeeper!
...
ls /
[zookeeper, kyuubi]
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request