### PR TITLE
Refine helm service template to support LoadBalancer type

### DIFF
--- a/docker/helm/templates/kyuubi-configmap.yaml
+++ b/docker/helm/templates/kyuubi-configmap.yaml
@@ -19,6 +19,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kyuubi-defaults
+  labels:
+    app: {{ template "kyuubi.name" . }}
 data:
   kyuubi-defaults.conf: |
     #

--- a/docker/helm/templates/kyuubi-service.yaml
+++ b/docker/helm/templates/kyuubi-service.yaml
@@ -18,13 +18,18 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: kyuubi-nodeport
+  name: kyuubi-svc
+  labels:
+    app: {{ template "kyuubi.name" . }}
+  annotations:
+  {{ toYaml .Values.service.annotations | indent 4 }}
 spec:
   ports:
-    - nodePort: {{ .Values.service.port }}
+    - name: http
+      nodePort: {{ .Values.service.port }}
       port: {{ .Values.server.bind.port }}
       protocol: TCP
-  type: NodePort
+  type: {{ .Values.service.type }}
   selector:
     app: {{ template "kyuubi.name" . }}
     release: {{ .Release.Name }}

--- a/docker/helm/templates/kyuubi-service.yaml
+++ b/docker/helm/templates/kyuubi-service.yaml
@@ -21,8 +21,10 @@ metadata:
   name: kyuubi-svc
   labels:
     app: {{ template "kyuubi.name" . }}
+  {{- with .Values.service.annotations }}
   annotations:
-  {{ toYaml .Values.service.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
     - name: http

--- a/docker/helm/values.yaml
+++ b/docker/helm/values.yaml
@@ -42,6 +42,7 @@ service:
   #   vim kube-apiserver.yaml (usually under path: /etc/kubernetes/manifests/)
   #   add or change line 'service-node-port-range=1-32767' under kube-apiserver
   port: 30009
+  annotations: {}
 
 resources: {}
   # Used to specify resource, default unlimited.


### PR DESCRIPTION
### _Why are the changes needed?_
The helm service template is currently hard-coded with `NodePort`, we should make it configurable to support other service type such as `LoadBalancer`.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request