### PR TITLE
[KYUUBI #1397] Move bind host and port to configmap

### DIFF
--- a/docker/helm/templates/kyuubi-configmap.yaml
+++ b/docker/helm/templates/kyuubi-configmap.yaml
@@ -45,5 +45,7 @@ data:
     #
     # kyuubi.authentication           NONE
     #
+    kyuubi.frontend.bind.host={{ .Values.server.bind.host }}
+    kyuubi.frontend.bind.port={{ .Values.server.bind.port }}
 
     # Details in https://kyuubi.apache.org/docs/latest/deployment/settings.html

--- a/docker/helm/templates/kyuubi-deployment.yaml
+++ b/docker/helm/templates/kyuubi-deployment.yaml
@@ -39,9 +39,6 @@ spec:
         - name: kyuubi-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-          env:
-            - name: KYUUBI_JAVA_OPTS
-              value: -Dkyuubi.frontend.bind.host={{ .Values.server.bind.host }} -Dkyuubi.frontend.bind.port={{ .Values.server.bind.port }}
           ports:
             - name: frontend-port
               containerPort: {{ .Values.server.bind.port }}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Setting `frontend.bind.host` and `frontend.bind.port` in `kyuubi-configmap.yaml`, instead of put them in ENV.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
