### PR TITLE
[MINOR] Fix the missing suffix of tarball

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -233,5 +233,5 @@ if [[ "$MAKE_TGZ" == "true" ]]; then
   cp -r "$DISTDIR" "$TARDIR"
   tar czf "$TARDIR_NAME.tgz" -C "$KYUUBI_HOME" "$TARDIR_NAME"
   rm -rf "$TARDIR"
-  echo "The Kyuubi tarball $TARDIR_NAME is successfully generated in $KYUUBI_HOME."
+  echo "The Kyuubi tarball $TARDIR_NAME.tgz is successfully generated in $KYUUBI_HOME."
 fi


### PR DESCRIPTION
### _Why are the changes needed?_
Fixes the missing suffix of tarball, which should be `$TARDIR_NAME.tgz`.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
