### PR TITLE
[KYUUBI #1056] [BUG] Log error if no current spark sql engine is created.

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -159,8 +159,7 @@ object SparkSQLEngine extends Logging {
         countDownLatch.await()
       } catch {
         case e: KyuubiException => currentEngine match {
-          case Some(_) =>
-            val engine = currentEngine.get
+          case Some(engine) =>
             engine.stop()
             val event = EngineEvent(engine).copy(diagnostic = e.getMessage)
             EventLoggingService.onEvent(event)


### PR DESCRIPTION
Issue:  https://github.com/apache/incubator-kyuubi/issues/1056

### _Why are the changes needed?_
Log an error message if no current spark sql engine is created.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
