### PR TITLE
[KYUUBI #1429][TASK-1] Move ui package from org.apache.spark to org.apache.spark.ui

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -22,9 +22,8 @@ import java.util.concurrent.CountDownLatch
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.SparkConf
+import org.apache.spark.{ui, SparkConf}
 import org.apache.spark.kyuubi.SparkSQLEngineListener
-import org.apache.spark.kyuubi.ui.EngineTab
 import org.apache.spark.sql.SparkSession
 
 import org.apache.kyuubi.{KyuubiException, Logging}
@@ -134,7 +133,7 @@ object SparkSQLEngine extends Logging {
       }
       try {
         engine.start()
-        EngineTab(engine)
+        ui.EngineTab(engine)
         val event = EngineEvent(engine)
         info(event)
         EventLoggingService.onEvent(event)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.kyuubi.ui
+package org.apache.spark.ui
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
@@ -26,13 +26,11 @@ import scala.collection.JavaConverters.mapAsScalaMapConverter
 import scala.xml.{Node, Unparsed}
 
 import org.apache.commons.text.StringEscapeUtils
-import org.apache.spark.kyuubi.ui.TableSourceUtil._
-import org.apache.spark.ui.{PagedDataSource, PagedTable, UIUtils, WebUIPage}
+import org.apache.spark.ui.TableSourceUtil._
 import org.apache.spark.ui.UIUtils._
 
 import org.apache.kyuubi.Utils
-import org.apache.kyuubi.engine.spark.events.SessionEvent
-import org.apache.kyuubi.engine.spark.events.SparkStatementEvent
+import org.apache.kyuubi.engine.spark.events.{SessionEvent, SparkStatementEvent}
 
 case class EnginePage(parent: EngineTab) extends WebUIPage("") {
   private val store = parent.engine.store
@@ -401,7 +399,7 @@ private class SessionStatsTableDataSource(
       case "User" => Ordering.by(_.username)
       case "Client IP" => Ordering.by(_.ip)
       case "Session ID" => Ordering.by(_.sessionId)
-      case "Start Time" => Ordering by (_.startTime)
+      case "Start Time" => Ordering.by(_.startTime)
       case "Finish Time" => Ordering.by(_.endTime)
       case "Duration" => Ordering.by(_.duration)
       case "Total Statements" => Ordering.by(_.totalOperations)
@@ -435,7 +433,7 @@ private class StatementStatsTableDataSource(
     val ordering: Ordering[SparkStatementEvent] = sortColumn match {
       case "User" => Ordering.by(_.username)
       case "Statement ID" => Ordering.by(_.statementId)
-      case "Create Time" => Ordering by (_.createTime)
+      case "Create Time" => Ordering.by(_.createTime)
       case "Finish Time" => Ordering.by(_.completeTime)
       case "Duration" => Ordering.by(_.duration)
       case "Statement" => Ordering.by(_.statement)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineSessionPage.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.kyuubi.ui
+package org.apache.spark.ui
 
 import java.util.Date
 import javax.servlet.http.HttpServletRequest
@@ -23,7 +23,6 @@ import javax.servlet.http.HttpServletRequest
 import scala.xml.Node
 
 import org.apache.spark.internal.Logging
-import org.apache.spark.ui._
 import org.apache.spark.ui.UIUtils._
 import org.apache.spark.util.Utils
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineTab.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineTab.scala
@@ -21,8 +21,6 @@ import javax.servlet.http.HttpServletRequest
 
 import scala.util.control.NonFatal
 
-import org.apache.spark.ui.SparkUITab
-
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.spark.SparkSQLEngine

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineTab.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineTab.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.kyuubi.ui
+package org.apache.spark.ui
 
 import javax.servlet.http.HttpServletRequest
 

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/ui/EngineTabSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/ui/EngineTabSuite.scala
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package org.apache.spark.kyuubi.ui
+package org.apache.spark.ui
 
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClients


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In order to compaible with both Spark-2 and Spark-3, we should respect package `ui`, since https://github.com/apache/spark/pull/22645, some class cope changed from package `ui` to `spark`.

### _How was this patch tested?_
Pass CI