### PR TITLE
Enable scalafmt check in spotless

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/HiveJDBCTestHelper.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/HiveJDBCTestHelper.scala
@@ -37,17 +37,17 @@ trait HiveJDBCTestHelper extends JDBCTestHelper {
 
   protected def matchAllPatterns = Seq("", "*", "%", null, ".*", "_*", "_%", ".%")
 
-  protected override lazy val user: String = Utils.currentUser
-  protected override val password = "anonymous"
+  override protected lazy val user: String = Utils.currentUser
+  override protected val password = "anonymous"
   private var _sessionConfigs: Map[String, String] = Map.empty
   private var _jdbcConfigs: Map[String, String] = Map.empty
   private var _jdbcVars: Map[String, String] = Map.empty
 
-  protected override def sessionConfigs: Map[String, String] = _sessionConfigs
+  override protected def sessionConfigs: Map[String, String] = _sessionConfigs
 
-  protected override def jdbcConfigs: Map[String, String] = _jdbcConfigs
+  override protected def jdbcConfigs: Map[String, String] = _jdbcConfigs
 
-  protected override def jdbcVars: Map[String, String] = _jdbcVars
+  override protected def jdbcVars: Map[String, String] = _jdbcVars
 
   def withSessionConf[T](
       sessionConfigs: Map[String, String] = Map.empty)(
@@ -64,7 +64,7 @@ trait HiveJDBCTestHelper extends JDBCTestHelper {
     }
   }
 
-  protected override def jdbcUrlWithConf(jdbcUrl: String): String = {
+  override protected def jdbcUrlWithConf(jdbcUrl: String): String = {
     val sessionConfStr = sessionConfigs.map(kv => kv._1 + "=" + kv._2).mkString(";")
     val jdbcConfStr =
       if (jdbcConfigs.isEmpty) {

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/JDBCTestHelper.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/JDBCTestHelper.scala
@@ -52,7 +52,7 @@ trait JDBCTestHelper extends KyuubiFunSuite {
   }
 
   def withMultipleConnectionJdbcStatement(
-    tableNames: String*)(fs: (Statement => Unit)*): Unit = {
+      tableNames: String*)(fs: (Statement => Unit)*): Unit = {
     val connections = fs.map { _ => DriverManager.getConnection(jdbcUrlWithConf, user, password) }
     val statements = connections.map(_.createStatement())
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLCommandHandler.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLCommandHandler.scala
@@ -42,7 +42,7 @@ object MySQLCommandHandler {
 class MySQLCommandHandler(be: BackendService, execPool: ThreadPoolExecutor)
   extends SimpleChannelInboundHandler[MySQLCommandPacket] with Logging {
 
-  private implicit val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(execPool)
+  implicit private val ec: ExecutionContextExecutor = ExecutionContext.fromExecutor(execPool)
 
   @volatile private var closed: Boolean = false
 
@@ -131,31 +131,27 @@ class MySQLCommandHandler(be: BackendService, execPool: ThreadPoolExecutor)
 
   def handlePing(
       ctx: ChannelHandlerContext,
-      pkg: MySQLComPingPacket
-  ): Seq[MySQLPacket] = {
+      pkg: MySQLComPingPacket): Seq[MySQLPacket] = {
     MySQLOKPacket(1) :: Nil
   }
 
   def handleInitDb(
       ctx: ChannelHandlerContext,
-      pkg: MySQLComInitDbPacket
-  ): Seq[MySQLPacket] = {
+      pkg: MySQLComInitDbPacket): Seq[MySQLPacket] = {
     beExecuteStatement(ctx, s"use ${pkg.database}")
     MySQLOKPacket(1) :: Nil
   }
 
   def handleQuit(
       ctx: ChannelHandlerContext,
-      pkg: MySQLComQuitPacket
-  ): Seq[MySQLPacket] = {
+      pkg: MySQLComQuitPacket): Seq[MySQLPacket] = {
     closeSession(ctx)
     MySQLOKPacket(1) :: Nil
   }
 
   def handleQuery(
       ctx: ChannelHandlerContext,
-      pkg: MySQLComQueryPacket
-  ): Seq[MySQLPacket] = {
+      pkg: MySQLComQueryPacket): Seq[MySQLPacket] = {
     debug(s"Receive query: ${pkg.sql}")
     executeStatement(ctx, pkg.sql).toPackets
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLQueryResult.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLQueryResult.scala
@@ -58,8 +58,7 @@ trait MySQLQueryResult {
 
 class MySQLSimpleQueryResult(
     schema: Seq[MySQLField],
-    rows: Seq[Seq[Any]]
-) extends MySQLQueryResult {
+    rows: Seq[Seq[Any]]) extends MySQLQueryResult {
 
   override def colCount: Int = schema.size
 
@@ -87,8 +86,7 @@ class MySQLSimpleQueryResult(
 
 class MySQLThriftQueryResult(
     schema: TTableSchema,
-    rows: TRowSet
-) extends MySQLQueryResult {
+    rows: TRowSet) extends MySQLQueryResult {
 
   override def colCount: Int = schema.getColumnsSize
 
@@ -102,8 +100,7 @@ class MySQLThriftQueryResult(
 
   private def tColDescToMySQL(
       tCol: TColumnDesc,
-      sequenceId: Int
-  ): MySQLColumnDefinition41Packet = {
+      sequenceId: Int): MySQLColumnDefinition41Packet = {
     val tType = tCol.getTypeDesc
     val dataType = tTypeDescToMySQL(tType)
     val decimals = 0 // TODO

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/mysql/MySQLJDBCTestHelper.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/mysql/MySQLJDBCTestHelper.scala
@@ -31,11 +31,11 @@ trait MySQLJDBCTestHelper extends JDBCTestHelper {
   private val _jdbcConfigs: Map[String, String] = Map(
     "useSSL" -> "false")
 
-  protected override def sessionConfigs: Map[String, String] = Map.empty
+  override protected def sessionConfigs: Map[String, String] = Map.empty
 
-  protected override def jdbcConfigs: Map[String, String] = _jdbcConfigs
+  override protected def jdbcConfigs: Map[String, String] = _jdbcConfigs
 
-  protected override def jdbcVars: Map[String, String] = Map.empty
+  override protected def jdbcVars: Map[String, String] = Map.empty
 
   protected def jdbcUrlWithConf(jdbcUrl: String): String = {
     val jdbcConfStr =

--- a/pom.xml
+++ b/pom.xml
@@ -1348,12 +1348,21 @@
                                 <include>src/main/java/**/*.java</include>
                                 <include>src/test/java/**/*.java</include>
                             </includes>
-
                             <googleJavaFormat>
                                 <version>1.7</version>
                                 <style>GOOGLE</style>
                             </googleJavaFormat>
                         </java>
+                        <scala>
+                            <includes>
+                                <include>src/main/scala/**/*.scala</include>
+                                <include>src/test/scala/**/*.scala</include>
+                            </includes>
+                            <scalafmt>
+                                <version>3.1.1</version>
+                                <file>${maven.multiModuleProjectDirectory}/.scalafmt.conf</file>
+                            </scalafmt>
+                        </scala>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
### _Why are the changes needed?_

fail compile if violating scalafmt rules.

```
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.17.4:check (default) on project kyuubi-common_2.12: The following files had format violations:
[ERROR]     src/test/scala/org/apache/kyuubi/operation/JDBCTestHelper.scala
[ERROR]         @@ -52,7 +52,7 @@
[ERROR]          ··}
[ERROR]          
[ERROR]          ··def·withMultipleConnectionJdbcStatement(
[ERROR]         -····tableNames:·String*)(fs:·(Statement·=>·Unit)*):·Unit·=·{
[ERROR]         +······tableNames:·String*)(fs:·(Statement·=>·Unit)*):·Unit·=·{
[ERROR]          ····val·connections·=·fs.map·{·_·=>·DriverManager.getConnection(jdbcUrlWithConf,·user,·password)·}
[ERROR]          ····val·statements·=·connections.map(_.createStatement())
[ERROR]          
[ERROR] Run 'mvn spotless:apply' to fix these violations.
```
Can auto-fix by `dev/reformat` or `build/mvn spotless:apply`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
