### PR TITLE
[K8S] add docker-image-tool.sh & replace Dockerfile

### DIFF
--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# This script builds and pushes docker images when run from a release of Kyuubi
+# with Kubernetes support.
+
+function error {
+  echo "$@" 1>&2
+  exit 1
+}
+
+if [ -z "${KYUUBI_HOME}" ]; then
+  KYUUBI_HOME="$(cd "`dirname "$0"`"/..; pwd)"
+fi
+"${KYUUBI_HOME}/bin/load-kyuubi-env.sh"
+
+CTX_DIR="$KYUUBI_HOME/target/tmp/docker"
+
+function is_dev_build {
+  [ ! -f "$KYUUBI_HOME/RELEASE" ]
+}
+
+function cleanup_ctx_dir {
+  if is_dev_build; then
+    rm -rf "$CTX_DIR"
+  fi
+}
+
+# trap cleanup_ctx_dir EXIT
+
+function image_ref {
+  local image="$1"
+  local add_repo="${2:-1}"
+  if [ $add_repo = 1 ] && [ -n "$REPO" ]; then
+    image="$REPO/$image"
+  fi
+  if [ -n "$TAG" ]; then
+    image="$image:$TAG"
+  fi
+  echo "$image"
+}
+
+function docker_push {
+  local image_name="$1"
+  if [ ! -z $(docker images -q "$(image_ref ${image_name})") ]; then
+    docker push "$(image_ref ${image_name})"
+    if [ $? -ne 0 ]; then
+      error "Failed to push $image_name Docker image."
+    fi
+  else
+    echo "$(image_ref ${image_name}) image not found. Skipping push for this image."
+  fi
+}
+
+function resolve_file {
+  local FILE=$1
+  if [ -n "$FILE" ]; then
+    local DIR=$(dirname $FILE)
+    DIR=$(cd $DIR && pwd)
+    FILE="${DIR}/$(basename $FILE)"
+  fi
+  echo $FILE
+}
+
+# Create a smaller build context for docker in dev builds to make the build faster. Docker
+# uploads all of the current directory to the daemon, and it can get pretty big with dev
+# builds that contain test log files and other artifacts.
+#
+# Note: docker does not support symlinks in the build context.
+function create_dev_build_context {(
+  set -e
+  local BASE_CTX="$CTX_DIR/base"
+  mkdir -r "$BASE_CTX/docker"
+  cp -r "docker/" "$BASE_CTX/docker"
+
+  cp -r "kyuubi-assembly/target/scala-${KYUUBI_SCALA_VERSION}/jars" "$BASE_CTX/jars"
+
+  mkdir -p "$BASE_CTX/externals/engines/spark"
+  cp "$KYUUBI_HOME/externals/kyuubi-spark-sql-engine/target/kyuubi-spark-sql-engine_${KYUUBI_SCALA_VERSION}-${KYUUBI_VERSION}.jar" "$BASE_CTX/externals/engines/spark"
+
+  for other in bin conf; do
+    cp -r "$other" "$BASE_CTX/$other"
+  done
+)}
+
+function img_ctx_dir {
+  if is_dev_build; then
+    echo "$CTX_DIR/$1"
+  else
+    echo "$KYUUBI_HOME"
+  fi
+}
+
+function build {
+  local BUILD_ARGS
+  local KYUUBI_ROOT="$KYUUBI_HOME"
+
+  if is_dev_build; then
+    create_dev_build_context || error "Failed to create docker build context."
+    KYUUBI_ROOT="$CTX_DIR/base"
+  fi
+
+  # Verify that the Docker image content directory is present
+  if [ ! -d "$KYUUBI_ROOT/docker" ]; then
+    error "Cannot find docker image. This script must be run from a runnable distribution of Apache Kyuubi."
+  fi
+
+  # Verify that Kyuubi has actually been built/is a runnable distribution
+  # i.e. the Kyuubi JARs that the Docker files will place into the image are present
+  local TOTAL_JARS=$(ls $KYUUBI_ROOT/jars/kyuubi-* | wc -l)
+  TOTAL_JARS=$(( $TOTAL_JARS ))
+  if [ "${TOTAL_JARS}" -eq 0 ]; then
+    error "Cannot find Kyuubi JARs. This script assumes that Apache Kyuubi has first been built locally or this is a runnable distribution."
+  fi
+
+  local BUILD_ARGS=(${BUILD_PARAMS})
+
+  # If a custom Kyuubi_UID was set add it to build arguments
+  if [ -n "$KYUUBI_UID" ]; then
+    BUILD_ARGS+=(--build-arg kyuubi_uid=$KYUUBI_UID)
+  fi
+
+  local BINDING_BUILD_ARGS=(
+    ${BUILD_ARGS[@]}
+    --build-arg
+    base_img=$(image_ref kyuubi)
+  )
+
+  local BASEDOCKERFILE=${BASEDOCKERFILE:-"docker/Dockerfile"}
+  local ARCHS=${ARCHS:-"--platform linux/amd64,linux/arm64"}
+
+  (cd $(img_ctx_dir base) && docker build $NOCACHEARG "${BUILD_ARGS[@]}" \
+    -t $(image_ref kyuubi) \
+    -f "$BASEDOCKERFILE" .)
+  if [ $? -ne 0 ]; then
+    error "Failed to build Kyuubi JVM Docker image, please refer to Docker build output for details."
+  fi
+  if [ "${CROSS_BUILD}" != "false" ]; then
+  (cd $(img_ctx_dir base) && docker buildx build $ARCHS $NOCACHEARG "${BUILD_ARGS[@]}" --push \
+    -t $(image_ref kyuubi) \
+    -f "$BASEDOCKERFILE" .)
+  fi
+}
+
+function push {
+  docker_push "kyuubi"
+}
+
+function usage {
+  cat <<EOF
+Usage: $0 [options] [command]
+Builds or pushes the built-in Kyuubi Docker image.
+
+Commands:
+  build       Build image. Requires a repository address to be provided if the image will be
+              pushed to a different registry.
+  push        Push a pre-built image to a registry. Requires a repository address to be provided.
+
+Options:
+  -f file               Dockerfile to build for JVM based Jobs. By default builds the Dockerfile shipped with Kyuubi.
+  -r repo               Repository address.
+  -t tag                Tag to apply to the built image, or to identify the image to be pushed.
+  -m                    Use minikube's Docker daemon.
+  -n                    Build docker image with --no-cache
+  -u uid                UID to use in the USER directive to set the user the main Kyuubi process runs as inside the
+                        resulting container
+  -X                    Use docker buildx to cross build. Automatically pushes.
+                        See https://docs.docker.com/buildx/working-with-buildx/ for steps to setup buildx.
+  -b arg                Build arg to build or push the image. For multiple build args, this option needs to
+                        be used separately for each build arg.
+
+Using minikube when building images will do so directly into minikube's Docker daemon.
+There is no need to push the images into minikube in that case, they'll be automatically
+available when running applications inside the minikube cluster.
+
+Check the following documentation for more information on using the minikube Docker daemon:
+
+  https://kubernetes.io/docs/getting-started-guides/minikube/#reusing-the-docker-daemon
+
+Examples:
+  - Build image in minikube with tag "testing"
+    $0 -m -t testing build
+
+  - Build and push image with tag "v1.4.0" to docker.io/myrepo
+    $0 -r docker.io/myrepo -t v1.4.0 build
+    $0 -r docker.io/myrepo -t v1.4.0 push
+
+  - Build and push Spark-3.1.2 image with tag "v3.0.0" to docker.io/myrepo
+    $0 -r docker.io/myrepo -t v3.0.0 -b SPARK_IMAGE=repo/spark:3.1.2 build
+    $0 -r docker.io/myrepo -t v3.0.0 push
+
+  - Build and push Spark-3.1.2 image for multiple archs to docker.io/myrepo
+    $0 -r docker.io/myrepo -t v3.0.0 -X -b SPARK_IMAGE=repo/spark:3.1.2 build
+
+    # Note: buildx, which does cross building, needs to do the push during build
+    # So there is no separate push step with -X
+
+EOF
+}
+
+if [[ "$@" = *--help ]] || [[ "$@" = *-h ]]; then
+  usage
+  exit 0
+fi
+
+REPO=
+TAG=
+BASEDOCKERFILE=
+NOCACHEARG=
+BUILD_PARAMS=
+KYUUBI_UID=
+CROSS_BUILD="false"
+while getopts f:mr:t:Xnb:u: option
+do
+ case "${option}"
+ in
+ f) BASEDOCKERFILE=$(resolve_file ${OPTARG});;
+ r) REPO=${OPTARG};;
+ t) TAG=${OPTARG};;
+ n) NOCACHEARG="--no-cache";;
+ b) BUILD_PARAMS=${BUILD_PARAMS}" --build-arg "${OPTARG};;
+ X) CROSS_BUILD=1;;
+ m)
+   if ! which minikube 1>/dev/null; then
+     error "Cannot find minikube."
+   fi
+   if ! minikube status 1>/dev/null; then
+     error "Cannot contact minikube. Make sure it's running."
+   fi
+   eval $(minikube docker-env --shell bash)
+   ;;
+  u) KYUUBI_UID=${OPTARG};;
+ esac
+done
+
+case "${@: -1}" in
+  build)
+    build
+    ;;
+  push)
+    if [ -z "$REPO" ]; then
+      usage
+      exit 1
+    fi
+    push
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -16,18 +16,43 @@
 #
 
 # Usage:
-#   1. use ./build/dist to make binary distributions of Kyuubi or download a release
-#   2. Untar it and run the docker command below
-#      docker build -f docker/Dockerfile -t yaooqinn/kyuubi:tagname .
+#   Run the docker command below
+#      docker build \
+#        --build-arg MVN_ARG="-Pspark-3.1,spark-hadoop-3.2" \
+#        --file docker/Dockerfile \
+#        --tag apache/kyuubi:tagname \
+#        .
 #   Options:
-#     -f this docker file
-#     -t the target repo and tag name
-#     more options can be found with -h
-# TODO: REPALCE it with offical spark image iff Apache Spark community deploy
-# Or make one after kyuubi to be setup under ASF
+#     -f, --file  this docker file
+#     -t, --tag   the target repo and tag name
+#     more options can be found with -h, --help
 
-ARG SPARK_IMAGE=yaooqinn/spark:3.0.3
-FROM ${SPARK_IMAGE}
+# Declare the BASE_IMAGE argument in the first line, for more detail
+# see: https://github.com/moby/moby/issues/38379
+ARG BASE_IMAGE=openjdk:8-jdk
+
+FROM maven:3.6-jdk-8 as builder
+
+ARG MVN_ARG
+
+# Pass the environment variable `CI` into container, for internal use only.
+#
+# Continuous integration(aka. CI) services like GitHub Actions, Travis always provide
+# an environment variable `CI` in runners, and we detect this variable to run some
+# specific actions, e.g. run `mvn` in batch mode to suppress noisy logs.
+ARG CI
+ENV CI ${CI}
+
+ADD ../docker /workspace/kyuubi
+WORKDIR /workspace/kyuubi
+
+RUN ./build/dist ${MVN_ARG} && \
+    mv /workspace/kyuubi/dist /opt/kyuubi && \
+    # Removing stuff saves time because docker creates a temporary layer
+    rm -rf ~/.m2 && \
+    rm -rf /workspace/kyuubi
+
+FROM ${BASE_IMAGE}
 
 ARG kyuubi_uid=10009
 
@@ -38,20 +63,17 @@ ENV KYUUBI_LOG_DIR ${KYUUBI_HOME}/logs
 ENV KYUUBI_PID_DIR ${KYUUBI_HOME}/pid
 ENV KYUUBI_WORK_DIR_ROOT ${KYUUBI_HOME}/work
 
+COPY --from=builder /opt/kyuubi ${KYUUBI_HOME}
+
 RUN set -ex && \
-    sed -i 's/http:\/\/deb.\(.*\)/https:\/\/deb.\1/g' /etc/apt/sources.list && \
     apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
     apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps && \
     useradd -u ${kyuubi_uid} -g root kyuubi && \
     mkdir -p ${KYUUBI_HOME} ${KYUUBI_LOG_DIR} ${KYUUBI_PID_DIR} ${KYUUBI_WORK_DIR_ROOT} && \
     chmod ug+rw -R ${KYUUBI_HOME} && \
     chmod a+rwx -R ${KYUUBI_WORK_DIR_ROOT} && \
     rm -rf /var/cache/apt/*
-
-COPY bin ${KYUUBI_HOME}/bin
-COPY conf ${KYUUBI_HOME}/conf
-COPY jars ${KYUUBI_HOME}/jars
-COPY externals/engines/spark ${KYUUBI_HOME}/externals/engines/spark
 
 WORKDIR ${KYUUBI_HOME}
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
At the beginning, you just want to add a script to help the user build the image.In the process, the Dockerfile of the existing master branch was discovered. Although the multi-layer build method can help to build quickly and easily, it is only limited to source code.
In other words, when the user uses the binary package officially released, the Dockerfile is deactivated.

So, In this PR, we move it(the multi-layer  Dockerfile) to dev. And use the previous Dockerfile.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
