### PR TITLE
Respect kyuubi.authentication

### DIFF
--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -50,7 +50,7 @@ kyuubi\.authentication<br>\.sasl\.qop|<div style='width: 80pt;word-wrap: break-w
 
 #### Using KERBEROS
 
-If you are deploying Kyuubi with a kerberized Hadoop cluster, it is strongly recommended that `kyuubi.authentication` should be set to `KERBEROS` too.
+If you are deploying Kyuubi with a kerberized Hadoop cluster which means your `core-site.xml` contains a property with key: `hadoop.security.authentication` and value: `kerberos`, you should also set `kyuubi.authentication` to `KERBEROS`.
 
 Kerberos is a network authentication protocol that provides the tools of authentication and strong cryptography over the network.
 The Kerberos protocol uses strong cryptography so that a client or a server can prove its identity to its server or client across an insecure network connection.

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HadoopCredentialsManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HadoopCredentialsManager.scala
@@ -177,6 +177,9 @@ class HadoopCredentialsManager private (name: String) extends AbstractService(na
    * @param sessionId KyuubiSession id
    */
   def removeSessionCredentialsEpoch(sessionId: String): Unit = {
+    if (renewalExecutor.isEmpty) {
+      return
+    }
     sessionCredentialsEpochMap.remove(sessionId)
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.session
 
 import com.codahale.metrics.MetricRegistry
+import org.apache.hadoop.security.UserGroupInformation
 import org.apache.hive.service.rpc.thrift.TProtocolVersion
 
 import org.apache.kyuubi.KyuubiSQLException
@@ -36,7 +37,9 @@ class KyuubiSessionManager private (name: String) extends SessionManager(name) {
   val credentialsManager = new HadoopCredentialsManager()
 
   override def initialize(conf: KyuubiConf): Unit = {
-    addService(credentialsManager)
+    if (UserGroupInformation.isSecurityEnabled) {
+      addService(credentialsManager)
+    }
     _operationLogRoot = Some(conf.get(SERVER_OPERATION_LOG_DIR_ROOT))
     super.initialize(conf)
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/KinitAuxiliaryServiceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/KinitAuxiliaryServiceSuite.scala
@@ -40,6 +40,7 @@ class KinitAuxiliaryServiceSuite extends KerberizedTestHelper {
     tryWithSecurityEnabled {
       val service = new KinitAuxiliaryService()
       val conf = KyuubiConf()
+      conf.set(KyuubiConf.AUTHENTICATION_METHOD.key, "kerberos")
       val e = intercept[IllegalArgumentException](service.initialize(conf))
       assert(e.getMessage === "requirement failed: principal or keytab is missing")
       conf.set(KyuubiConf.SERVER_PRINCIPAL, testPrincipal)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To respect the [docs](https://kyuubi.apache.org/docs/latest/security/authentication.html#using-kerberos). We should do kinit if user specify the `kyuubi.anthentication`. Otherwise the user of ugi will be the linux user.

And if we start kyuubi with no anthentication, some warn logging will be print:
```
2021-11-22 13:20:56.028 WARN credentials.HadoopCredentialsManager: Service hadoopfs does not require a token. Check your configuration to see if security is disabled or not.
2021-11-22 13:20:56.241 WARN credentials.HadoopCredentialsManager: Service hive does not require a token. Check your configuration to see if security is disabled or not.
2021-11-22 13:20:56.245 WARN credentials.HadoopCredentialsManager: No delegation token is required by services.
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
