### PR TITLE
Bump Hudi 0.10.0

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/HudiMetadataTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/HudiMetadataTests.scala
@@ -120,17 +120,22 @@ trait HudiMetadataTests extends HiveJDBCTestHelper with HudiSuiteMixin {
     val cols = dataTypes.zipWithIndex.map { case (dt, idx) => s"c$idx" -> dt }
     val (colNames, _) = cols.unzip
 
-    val reservedCols = Seq(
+    val metadataCols = Seq(
       "_hoodie_commit_time",
       "_hoodie_commit_seqno",
       "_hoodie_record_key",
       "_hoodie_partition_path",
       "_hoodie_file_name")
 
+    val defaultPkCol = "uuid"
+
+    val reservedCols = metadataCols :+ defaultPkCol
+
     val tableName = "hudi_get_col_operation"
     val ddl =
       s"""
          |CREATE TABLE IF NOT EXISTS $catalog.$defaultSchema.$tableName (
+         |  $defaultPkCol string,
          |  ${cols.map { case (cn, dt) => cn + " " + dt }.mkString(",\n")}
          |)
          |USING hudi""".stripMargin

--- a/pom.xml
+++ b/pom.xml
@@ -795,6 +795,10 @@
                 <version>${hudi.version}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>org.scala-lang</groupId>
+                        <artifactId>scala-library</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.apache.hudi</groupId>
                         <artifactId>hudi-timeline-service</artifactId>
                     </exclusion>
@@ -838,6 +842,10 @@
                 <artifactId>hudi-spark_${scala.binary.version}</artifactId>
                 <version>${hudi.version}</version>
                 <exclusions>
+                    <exclusion>
+                        <groupId>org.scala-lang</groupId>
+                        <artifactId>scala-library</artifactId>
+                    </exclusion>
                     <exclusion>
                         <groupId>org.apache.hudi</groupId>
                         <artifactId>hudi-spark-common_2.11</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -1686,7 +1686,7 @@
             <properties>
                 <spark.version>3.1.2</spark.version>
                 <delta.version>1.0.0</delta.version>
-                <maven.plugin.scalatest.exclude.tags>org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.HudiTest</maven.plugin.scalatest.exclude.tags>
+                <maven.plugin.scalatest.exclude.tags>org.apache.kyuubi.tags.ExtendedSQLTest</maven.plugin.scalatest.exclude.tags>
             </properties>
             <modules>
                 <module>dev/kyuubi-extension-spark-common</module>

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <hadoop.version>3.3.1</hadoop.version>
         <hadoop.binary.version>3.2</hadoop.binary.version>
         <hive.version>2.3.9</hive.version>
-        <hudi.version>0.9.0</hudi.version>
+        <hudi.version>0.10.0</hudi.version>
         <iceberg.name>iceberg-spark3-runtime</iceberg.name>
         <iceberg.version>0.12.1</iceberg.version>
         <jackson.version>2.12.5</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -778,6 +778,12 @@
 
             <!-- Hudi dependency  -->
             <dependency>
+                <groupId>org.apache.hadoop</groupId>
+                <artifactId>hadoop-common</artifactId>
+                <version>${hadoop.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>org.apache.parquet</groupId>
                 <artifactId>parquet-avro</artifactId>
                 <version>${parquet.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1677,7 +1677,7 @@
             <properties>
                 <spark.version>3.0.3</spark.version>
                 <delta.version>0.8.0</delta.version>
-                <maven.plugin.scalatest.exclude.tags>org.apache.kyuubi.tags.ExtendedSQLTest</maven.plugin.scalatest.exclude.tags>
+                <maven.plugin.scalatest.exclude.tags>org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.HudiTest</maven.plugin.scalatest.exclude.tags>
             </properties>
         </profile>
 

--- a/pom.xml
+++ b/pom.xml
@@ -826,6 +826,10 @@
                         <groupId>org.apache.orc</groupId>
                         <artifactId>*</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.hudi</groupId>
+                        <artifactId>hudi-aws</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -777,6 +777,21 @@
             </dependency>
 
             <!-- Hudi dependency  -->
+            <!--
+              We don't use hadoop-common directly, it's only for suppressing exception:
+                 Failed to execute goal org.apache.maven.plugins:maven-shade-plugin:3.2.4:shade (default) on project
+                 kyuubi-spark-sql-engine_2.12: Error creating shaded jar: Could not resolve following dependencies:
+                 [jdk.tools:jdk.tools:jar:1.6 (system)]
+
+              The issue only occurs on GitHub Action environment with Hudi 0.10.0 and JDK 11.
+              After few days digging, only found one place introduces jdk.tools,
+
+              - org.apache.hudi:hudi-common:jar:0.10.0:test
+                - org.apache.hbase:hbase-server:jar:1.2.3:test
+                  - org.apache.hadoop:hadoop-common:jar:2.5.1:test
+                    - org.apache.hadoop:hadoop-annotations:jar:2.5.1:test
+                      - jdk.tools:jdk.tools:jar:1.6:system
+            -->
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
@@ -1695,6 +1710,7 @@
             <properties>
                 <spark.version>3.0.3</spark.version>
                 <delta.version>0.8.0</delta.version>
+                <!-- Hudi 0.10.0 still support Spark 3.0, but need build by user with specific profile -->
                 <maven.plugin.scalatest.exclude.tags>org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.HudiTest</maven.plugin.scalatest.exclude.tags>
             </properties>
         </profile>


### PR DESCRIPTION
### _Why are the changes needed?_

https://hudi.apache.org/releases/release-0.10.0

Switch test from Hudi 0.9.0 & Spark 3.0 to Hudi 1.10.0 & Spark 3.1. Drop test of Spark 3.0 because

1. Hudi 1.10.0 claims to support Spark 3.0 but requires to build by self with specific maven profile, the published jar only support Spark 3.1
2. Hudi has lots of transitive deps and there are different in different versions, it's hard to maintain multi hudi versions.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
