### PR TITLE
Enabled to preserve symbolic links when copying dist dir

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -244,7 +244,7 @@ if [[ "$MAKE_TGZ" == "true" ]]; then
   TARDIR_NAME="apache-kyuubi-$VERSION-bin$SUFFIX"
   TARDIR="$KYUUBI_HOME/$TARDIR_NAME"
   rm -rf "$TARDIR"
-  cp -r "$DISTDIR" "$TARDIR"
+  cp -R "$DISTDIR" "$TARDIR"
   tar czf "$TARDIR_NAME.tgz" -C "$KYUUBI_HOME" "$TARDIR_NAME"
   rm -rf "$TARDIR"
   echo "The Kyuubi tarball $TARDIR_NAME.tgz is successfully generated in $KYUUBI_HOME."


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Before, the soft symbolic links are not reserved when making copy.

`man cp`
```
 -R    If source_file designates a directory, cp copies the directory and the entire subtree connected at that point.  If the source_file ends in
           a /, the contents of the directory are copied rather than the directory itself.  This option also causes symbolic links to be copied,
           rather than indirected through, and for cp to create special files rather than copying them as normal files.  Created directories have the
           same mode as the corresponding source directory, unmodified by the process' umask.

           In -R mode, cp will continue copying even if errors are detected.

           Note that cp copies hard-linked files as separate files.  If you need to preserve hard links, consider using tar(1), cpio(1), or pax(1)
           instead.

```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
