### PR TITLE
[KYUUBI #1473] Exit gracefully when engine idle

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -55,10 +55,8 @@ case class SparkSQLEngine(
     // Start engine self-terminating checker after all services are ready and it can be reached by
     // all servers in engine spaces.
     backendService.sessionManager.startTerminatingChecker(() => {
-      currentEngine match {
-        case Some(engine) =>
-          engine.stop()
-      }
+      assert(currentEngine.isDefined)
+      currentEngine.get.stop()
     })
   }
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
@@ -265,7 +265,7 @@ abstract class SessionManager(name: String) extends CompositeService(name) {
     timeoutChecker.scheduleWithFixedDelay(checkTask, interval, interval, TimeUnit.MILLISECONDS)
   }
 
-  private[kyuubi] def startTerminatingChecker(): Unit = if (!isServer) {
+  private[kyuubi] def startTerminatingChecker(stop: () => Unit): Unit = if (!isServer) {
     // initialize `_latestLogoutTime` at start
     _latestLogoutTime = System.currentTimeMillis()
     val interval = conf.get(ENGINE_CHECK_INTERVAL)
@@ -275,7 +275,7 @@ abstract class SessionManager(name: String) extends CompositeService(name) {
         if (!shutdown &&
           System.currentTimeMillis() - latestLogoutTime > idleTimeout && getOpenSessionCount <= 0) {
           info(s"Idled for more than $idleTimeout ms, terminating")
-          sys.exit(0)
+          stop()
         }
       }
     }


### PR DESCRIPTION
### _Why are the changes needed?_
https://github.com/apache/incubator-kyuubi/issues/1473

It is not graceful to exit when engine is idle, which may cause AM to try again.
The current workaround is to configure `spark.yarn.maxAppAttempts`.

```
yarn.ApplicationMaster: Final app status: FAILED, exitCode: 16, (reason: Shutdown hook called before final status was reported.)
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
