### PR TITLE
[KYUUBI #1478]  Docker-image-tool.sh awareness of incorrectly configured SPARK_HOME 

### DIFF
--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -119,6 +119,9 @@ function build {
   if [[ ! -d "$KYUUBI_ROOT/spark-binary" ]]; then
     mkdir "$KYUUBI_ROOT/spark-binary"
   fi
+  if [[ ! -d "$SPARK_HOME" ]]; then
+    error "Cannot found dir $SPARK_HOME, you must configure SPARK_HOME correct."
+  fi
   cp -r "$SPARK_HOME/" "$KYUUBI_ROOT/spark-binary/"
 
   # Verify that the Docker image content directory is present


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When you use docker-image-tool.sh to help build docker image, you can use a non-existent path as SPARK_HOME.You won't be aware of the problem until Dockerfile does the COPY SPARK_HOME operation.
See #1478 
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
