### PR TITLE
[KYUUBI #1480] Fix bug in docker-image-tool & Provider image way to config SPARK instead of local copy

### DIFF
--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -115,14 +115,15 @@ function build {
     KYUUBI_ROOT="$CTX_DIR/base"
   fi
 
-  # cp spark for kyuubi as submit client
-  # if user set -s(spark-provider), use if
-  # else use builtin spark
+  # mkdir spark-binary to cache spark
+  # clean cache if spark-binary exists
   if [[ ! -d "$KYUUBI_ROOT/spark-binary" ]]; then
     mkdir "$KYUUBI_ROOT/spark-binary"
   else
     rm -rf "$KYUUBI_ROOT/spark-binary/*"
   fi
+  # if with spark image means, kyuubi won't copy spark from local.
+  # In this case, we just pass SPARK_HOME without copy.
   if [[ "${WITHSPARKIMAGE}" != "false" ]]; then
     BUILD_ARGS+=(--build-arg spark_home=$SPARK_HOME)
   else

--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -124,10 +124,12 @@ function build {
   else
     rm -rf "$KYUUBI_ROOT/spark-binary/*"
   fi
-  # if with spark image means, kyuubi won't copy spark from local.
-  # In this case, we just pass SPARK_HOME without copy.
-  if [[ "${SPARK_PROVIDED}" != "false" ]]; then
-    BUILD_ARGS+=(--build-arg spark_home=$SPARK_HOME)
+
+  # If SPARK_HOME_IN_DOCKER configured,
+  # Kyuubi won't copy local spark into docker image.
+  # Use SPARK_HOME_IN_DOCKER as SPARK_HOME in docker image.
+  if [[ -n "${SPARK_HOME_IN_DOCKER}" ]]; then
+    BUILD_ARGS+=(--build-arg spark_home_in_docker=$SPARK_HOME_IN_DOCKER)
     BUILD_ARGS+=(--build-arg spark_provided="spark_provided")
   else
     if [[ ! -d "$SPARK_HOME" ]]; then
@@ -232,8 +234,8 @@ NOCACHEARG=
 BUILD_PARAMS=
 KYUUBI_UID=
 CROSS_BUILD="false"
-SPARK_PROVIDED="false"
-while getopts f:r:t:Xnb:u:s:p option
+SPARK_HOME_IN_DOCKER=
+while getopts f:r:t:Xnb:u:s:d: option
 do
  case "${option}"
  in
@@ -245,7 +247,7 @@ do
  X) CROSS_BUILD=1;;
  u) KYUUBI_UID=${OPTARG};;
  s) SPARK_HOME=${OPTARG};;
- p) SPARK_PROVIDED=1;;
+ d) SPARK_HOME_IN_DOCKER=${OPTARG};;
  esac
 done
 

--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -199,6 +199,8 @@ Options:
                         be used separately for each build arg.
   -s                    Put the specified Spark into the Kyuubi image to be used as the internal SPARK_HOME
                         of the container.
+  -S                    Declare SPARK_HOME in Docker Image. When you configured -S, you need to provide an image
+                        with Spark as BASE_IMAGE.
 
 Examples:
 
@@ -219,6 +221,9 @@ Examples:
   - Build with Spark placed "/path/spark"
     $0 -s /path/spark build
 
+  - Build with Spark Image myrepo/spark:3.1.0
+    $0 -S /opt/spark -b BASE_IMAGE=myrepo/spark:3.1.0 build
+
 EOF
 }
 
@@ -235,7 +240,7 @@ BUILD_PARAMS=
 KYUUBI_UID=
 CROSS_BUILD="false"
 SPARK_HOME_IN_DOCKER=
-while getopts f:r:t:Xnb:u:s:d: option
+while getopts f:r:t:Xnb:u:s:S: option
 do
  case "${option}"
  in
@@ -247,7 +252,7 @@ do
  X) CROSS_BUILD=1;;
  u) KYUUBI_UID=${OPTARG};;
  s) SPARK_HOME=${OPTARG};;
- d) SPARK_HOME_IN_DOCKER=${OPTARG};;
+ S) SPARK_HOME_IN_DOCKER=${OPTARG};;
  esac
 done
 

--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -124,7 +124,7 @@ function build {
   fi
   # if with spark image means, kyuubi won't copy spark from local.
   # In this case, we just pass SPARK_HOME without copy.
-  if [[ "${WITHSPARKIMAGE}" != "false" ]]; then
+  if [[ "${SPARK_PROVIDED}" != "false" ]]; then
     BUILD_ARGS+=(--build-arg spark_home=$SPARK_HOME)
   else
     if [[ ! -d "$SPARK_HOME" ]]; then
@@ -231,8 +231,8 @@ NOCACHEARG=
 BUILD_PARAMS=
 KYUUBI_UID=
 CROSS_BUILD="false"
-WITHSPARKIMAGE="false"
-while getopts f:r:t:Xnb:u:s:w option
+SPARK_PROVIDED="false"
+while getopts f:r:t:Xnb:u:s:p option
 do
  case "${option}"
  in
@@ -244,7 +244,7 @@ do
  X) CROSS_BUILD=1;;
  u) KYUUBI_UID=${OPTARG};;
  s) SPARK_HOME=${OPTARG};;
- w) WITHSPARKIMAGE=1;;
+ p) SPARK_PROVIDED=1;;
  esac
 done
 

--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -128,7 +128,7 @@ function build {
   # In this case, we just pass SPARK_HOME without copy.
   if [[ "${SPARK_PROVIDED}" != "false" ]]; then
     BUILD_ARGS+=(--build-arg spark_home=$SPARK_HOME)
-    BUILD_ARGS+=(--build-arg is_copy="copy")
+    BUILD_ARGS+=(--build-arg spark_provided="spark_provided")
   else
     if [[ ! -d "$SPARK_HOME" ]]; then
       error "Cannot found dir $SPARK_HOME, you must configure SPARK_HOME correct."

--- a/bin/docker-image-tool.sh
+++ b/bin/docker-image-tool.sh
@@ -115,6 +115,8 @@ function build {
     KYUUBI_ROOT="$CTX_DIR/base"
   fi
 
+  local BUILD_ARGS=(${BUILD_PARAMS})
+
   # mkdir spark-binary to cache spark
   # clean cache if spark-binary exists
   if [[ ! -d "$KYUUBI_ROOT/spark-binary" ]]; then
@@ -126,6 +128,7 @@ function build {
   # In this case, we just pass SPARK_HOME without copy.
   if [[ "${SPARK_PROVIDED}" != "false" ]]; then
     BUILD_ARGS+=(--build-arg spark_home=$SPARK_HOME)
+    BUILD_ARGS+=(--build-arg is_copy="copy")
   else
     if [[ ! -d "$SPARK_HOME" ]]; then
       error "Cannot found dir $SPARK_HOME, you must configure SPARK_HOME correct."
@@ -145,8 +148,6 @@ function build {
   if [ "${TOTAL_JARS}" -eq 0 ]; then
     error "Cannot find Kyuubi JARs. This script assumes that Apache Kyuubi has first been built locally or this is a runnable distribution."
   fi
-
-  local BUILD_ARGS=(${BUILD_PARAMS})
 
   # If a custom Kyuubi_UID was set add it to build arguments
   if [ -n "$KYUUBI_UID" ]; then

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,19 +26,18 @@
 
 ARG BASE_IMAGE=openjdk:8-jre-slim
 ARG spark_provided="spark_builtin"
+ARG spark_home="/opt/spark"
 
 FROM ${BASE_IMAGE} as builder_spark_provided
 
 FROM ${BASE_IMAGE} as builder_spark_builtin
 
-ONBUILD ENV SPARK_BINARY /opt/spark
-ONBUILD RUN mkdir -p  ${SPARK_BINARY}
-ONBUILD COPY spark-binary ${SPARK_BINARY}
+ONBUILD RUN mkdir -p  ${spark_home}
+ONBUILD COPY spark-binary ${spark_home}
 
 FROM builder_${spark_provided}
 
 ARG kyuubi_uid=10009
-ARG spark_home="/opt/spark"
 USER root
 
 ENV KYUUBI_HOME /opt/kyuubi

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,15 +24,17 @@
 #     -t the target repo and tag name
 #     more options can be found with -h
 
-ARG BASE_IMAGE=8-jre-slim
-FROM openjdk:${BASE_IMAGE}
+ARG BASE_IMAGE=openjdk:8-jre-slim
+FROM ${BASE_IMAGE}
 
 ARG kyuubi_uid=10009
+ARG spark_home="/opt/spark"
 
 USER root
 
 ENV KYUUBI_HOME /opt/kyuubi
-ENV SPARK_HOME /opt/spark
+ENV SPARK_BINARY /opt/spark
+ENV SPARK_HOME ${spark_home}
 ENV KYUUBI_LOG_DIR ${KYUUBI_HOME}/logs
 ENV KYUUBI_PID_DIR ${KYUUBI_HOME}/pid
 ENV KYUUBI_WORK_DIR_ROOT ${KYUUBI_HOME}/work
@@ -42,12 +44,12 @@ RUN set -ex && \
     apt-get update && \
     apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps && \
     useradd -u ${kyuubi_uid} -g root kyuubi && \
-    mkdir -p ${KYUUBI_HOME} ${KYUUBI_LOG_DIR} ${KYUUBI_PID_DIR} ${KYUUBI_WORK_DIR_ROOT} ${SPARK_HOME} && \
+    mkdir -p ${KYUUBI_HOME} ${KYUUBI_LOG_DIR} ${KYUUBI_PID_DIR} ${KYUUBI_WORK_DIR_ROOT} ${SPARK_BINARY} && \
     chmod ug+rw -R ${KYUUBI_HOME} && \
     chmod a+rwx -R ${KYUUBI_WORK_DIR_ROOT} && \
     rm -rf /var/cache/apt/*
 
-COPY spark-binary ${SPARK_HOME}
+COPY spark-binary ${SPARK_BINARY}
 COPY bin ${KYUUBI_HOME}/bin
 COPY jars ${KYUUBI_HOME}/jars
 COPY externals/engines/spark ${KYUUBI_HOME}/externals/engines/spark

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,15 +25,23 @@
 #     more options can be found with -h
 
 ARG BASE_IMAGE=openjdk:8-jre-slim
-FROM ${BASE_IMAGE}
+ARG is_copy="without_copy"
+
+FROM ${BASE_IMAGE} as builder_copy
+
+FROM ${BASE_IMAGE} as builder_without_copy
+
+ONBUILD ENV SPARK_BINARY /opt/spark
+ONBUILD RUN mkdir -p  ${SPARK_BINARY}
+ONBUILD COPY spark-binary ${SPARK_BINARY}
+
+FROM builder_${is_copy}
 
 ARG kyuubi_uid=10009
 ARG spark_home="/opt/spark"
-
 USER root
 
 ENV KYUUBI_HOME /opt/kyuubi
-ENV SPARK_BINARY /opt/spark
 ENV SPARK_HOME ${spark_home}
 ENV KYUUBI_LOG_DIR ${KYUUBI_HOME}/logs
 ENV KYUUBI_PID_DIR ${KYUUBI_HOME}/pid
@@ -44,12 +52,11 @@ RUN set -ex && \
     apt-get update && \
     apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps && \
     useradd -u ${kyuubi_uid} -g root kyuubi && \
-    mkdir -p ${KYUUBI_HOME} ${KYUUBI_LOG_DIR} ${KYUUBI_PID_DIR} ${KYUUBI_WORK_DIR_ROOT} ${SPARK_BINARY} && \
+    mkdir -p ${KYUUBI_HOME} ${KYUUBI_LOG_DIR} ${KYUUBI_PID_DIR} ${KYUUBI_WORK_DIR_ROOT} && \
     chmod ug+rw -R ${KYUUBI_HOME} && \
     chmod a+rwx -R ${KYUUBI_WORK_DIR_ROOT} && \
     rm -rf /var/cache/apt/*
 
-COPY spark-binary ${SPARK_BINARY}
 COPY bin ${KYUUBI_HOME}/bin
 COPY jars ${KYUUBI_HOME}/jars
 COPY externals/engines/spark ${KYUUBI_HOME}/externals/engines/spark

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,14 +26,16 @@
 
 ARG BASE_IMAGE=openjdk:8-jre-slim
 ARG spark_provided="spark_builtin"
-ARG spark_home="/opt/spark"
 
 FROM ${BASE_IMAGE} as builder_spark_provided
+ONBUILD ARG spark_home_in_docker
+ONBUILD ENV SPARK_HOME ${spark_home_in_docker}
 
 FROM ${BASE_IMAGE} as builder_spark_builtin
 
-ONBUILD RUN mkdir -p  ${spark_home}
-ONBUILD COPY spark-binary ${spark_home}
+ONBUILD ENV SPARK_HOME /opt/spark
+ONBUILD RUN mkdir -p  ${SPARK_HOME}
+ONBUILD COPY spark-binary ${SPARK_HOME}
 
 FROM builder_${spark_provided}
 
@@ -41,7 +43,6 @@ ARG kyuubi_uid=10009
 USER root
 
 ENV KYUUBI_HOME /opt/kyuubi
-ENV SPARK_HOME ${spark_home}
 ENV KYUUBI_LOG_DIR ${KYUUBI_HOME}/logs
 ENV KYUUBI_PID_DIR ${KYUUBI_HOME}/pid
 ENV KYUUBI_WORK_DIR_ROOT ${KYUUBI_HOME}/work

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -25,17 +25,17 @@
 #     more options can be found with -h
 
 ARG BASE_IMAGE=openjdk:8-jre-slim
-ARG is_copy="without_copy"
+ARG spark_provided="spark_builtin"
 
-FROM ${BASE_IMAGE} as builder_copy
+FROM ${BASE_IMAGE} as builder_spark_provided
 
-FROM ${BASE_IMAGE} as builder_without_copy
+FROM ${BASE_IMAGE} as builder_spark_builtin
 
 ONBUILD ENV SPARK_BINARY /opt/spark
 ONBUILD RUN mkdir -p  ${SPARK_BINARY}
 ONBUILD COPY spark-binary ${SPARK_BINARY}
 
-FROM builder_${is_copy}
+FROM builder_${spark_provided}
 
 ARG kyuubi_uid=10009
 ARG spark_home="/opt/spark"

--- a/docs/integrations/delta_lake_with_azure_blob.md
+++ b/docs/integrations/delta_lake_with_azure_blob.md
@@ -57,7 +57,7 @@ Create a new file named core-site.xml under ./spark/conf directory, and add foll
     <value>org.apache.hadoop.fs.azure.Wasb</value>
  </property>
  <property>
-  <name>fs.azure.account.key.Your_Azure_Account.blob.core.windows.net</name>
+  <name>fs.azure.account.key.YOUR_AZURE_ACCOUNT.blob.core.windows.net</name>
   <value>YOUR_AZURE_ACCOUNT_ACCESS_KEY</value>
  </property>
  <property>
@@ -77,6 +77,8 @@ Create a new file named core-site.xml under ./spark/conf directory, and add foll
 #### Copy Dependencies To Spark
 Copy jar packages required by delta lake and microsoft azure to ./spark/jars directory:
 ```shell
+wget https://repo1.maven.org/maven2/io/delta/delta-core_2.12/1.0.0/delta-core_2.12-1.0.0.jar -O ./spark/jars/delta-core_2.12-1.0.0.jar
+
 wget https://repo1.maven.org/maven2/com/microsoft/azure/azure-storage/8.6.6/azure-storage-8.6.6.jar -O ./spark/jars/azure-storage-8.6.6.jar
 
 wget https://repo1.maven.org/maven2/com/azure/azure-storage-blob/12.14.2/azure-storage-blob-12.14.2.jar -O ./spark/jars/azure-storage-blob-12.14.2.jar
@@ -97,8 +99,8 @@ Start spark shell:
 Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
 Setting default log level to "WARN".
 To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
-Spark context Web UI available at http://host:4040
-Spark context available as 'sc' (master = spark://host:7077, app id = app-20211126172803-0003).
+Spark context Web UI available at http://HOST:4040
+Spark context available as 'sc' (master = spark://HOST:7077, app id = app-20211126172803-0003).
 Spark session available as 'spark'.
 Welcome to
       ____              __
@@ -217,7 +219,7 @@ Check kyuubi log, in order to check kyuubi start status and find the jdbc connec
 2021-11-26 17:49:50.234 INFO session.KyuubiSessionManager: Service[KyuubiSessionManager] is started.
 2021-11-26 17:49:50.234 INFO server.KyuubiBackendService: Service[KyuubiBackendService] is started.
 2021-11-26 17:49:50.235 INFO service.ThriftFrontendService: Service[ThriftFrontendService] is started.
-2021-11-26 17:49:50.235 INFO service.ThriftFrontendService: Starting and exposing JDBC connection at: jdbc:hive2://host:10009/
+2021-11-26 17:49:50.235 INFO service.ThriftFrontendService: Starting and exposing JDBC connection at: jdbc:hive2://HOST:10009/
 2021-11-26 17:49:50.239 INFO zookeeper.ClientCnxn: Session establishment complete on server host/*.*.*.*:2181, sessionid = 0x100046ec0ca01b5, negotiated timeout = 40000
 2021-11-26 17:49:50.245 INFO state.ConnectionStateManager: State change: CONNECTED
 2021-11-26 17:49:50.247 INFO client.KyuubiServiceDiscovery: Zookeeper client connection state changed to: CONNECTED
@@ -231,7 +233,7 @@ You can get the jdbc connection url by the log:
 ```
 #### Test The Connectivity Of Kyuubi And Delta Lake
 ```shell
-/usr/apache/current/spark/bin> ./beeline -u 'jdbc:hive2://HOST:10009/'
+/usr/apache/current/spark/bin> ./beeline -u 'jdbc:hive2://<YOUR_HOST>:10009/'
 log4j:WARN No appenders could be found for logger (org.apache.hadoop.util.Shell).
 log4j:WARN Please initialize the log4j system properly.
 log4j:WARN See http://logging.apache.org/log4j/1.2/faq.html#noconfig for more info.
@@ -240,7 +242,7 @@ Connected to: Spark SQL (version 1.3.1-incubating)
 Driver: Hive JDBC (version 2.3.7)
 Transaction isolation: TRANSACTION_REPEATABLE_READ
 Beeline version 2.3.7 by Apache Hive
-0: jdbc:hive2://host>
+0: jdbc:hive2://YOUR_HOST>
 ```
 At the same time, you can also check whether the engine is running on the spark UI:
 ![](../imgs/deltalake/kyuubi_start_status_spark_UI.png)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. fix when using `-t` may cause build fail, because tag invalid reference format
2. add new option `-S`; Declare SPARK_HOME in Docker Image. When you configured -S, you need to provide an image
  with Spark as BASE_IMAGE.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
