### PR TITLE
[KYUUBI #1504] Support to capture console out/error into interpreter output for ExecuteScala

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -57,7 +57,7 @@ class ExecuteScala(
     try {
       spark.sparkContext.setJobGroup(statementId, statement)
       Thread.currentThread().setContextClassLoader(spark.sharedState.jarClassLoader)
-      repl.interpret(statement) match {
+      repl.interpretWithRedirectOutError(statement) match {
         case Success =>
           iter =
             if (repl.results.nonEmpty) {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/repl/KyuubiSparkILoop.scala
@@ -93,6 +93,14 @@ private[spark] case class KyuubiSparkILoop private (
     }
   }
 
+  def interpretWithRedirectOutError(statement: String): scala.tools.nsc.interpreter.IR.Result = {
+    Console.withOut(output) {
+      Console.withErr(output) {
+        this.interpret(statement)
+      }
+    }
+  }
+
   def getOutput: String = {
     val res = output.toString.trim
     output.reset()

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -518,4 +518,21 @@ trait SparkQueryTests extends HiveJDBCTestHelper {
       assert(e.getMessage contains "not found: value y")
     }
   }
+
+  test("scala code with console output") {
+    withJdbcStatement() { statement =>
+      statement.execute("SET kyuubi.operation.language=scala")
+      val code =
+        """
+          |spark.sql("set").show(false)
+          |""".stripMargin
+      val rs = statement.executeQuery(code)
+
+      var foundOperationLangItem = false
+      while (rs.next() && !foundOperationLangItem) {
+        foundOperationLangItem = rs.getString(1).contains("kyuubi.operation.language")
+      }
+      assert(foundOperationLangItem)
+    }
+  }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -522,10 +522,7 @@ trait SparkQueryTests extends HiveJDBCTestHelper {
   test("scala code with console output") {
     withJdbcStatement() { statement =>
       statement.execute("SET kyuubi.operation.language=scala")
-      val code =
-        """
-          |spark.sql("SET kyuubi.operation.language=scala").show(false)
-          |""".stripMargin
+      val code = """spark.sql("SET kyuubi.operation.language").show(false)"""
       val rs = statement.executeQuery(code)
 
       var foundOperationLangItem = false

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -524,7 +524,7 @@ trait SparkQueryTests extends HiveJDBCTestHelper {
       statement.execute("SET kyuubi.operation.language=scala")
       val code =
         """
-          |spark.sql("set").show(false)
+          |spark.sql("SET kyuubi.operation.language=scala").show(false)
           |""".stripMargin
       val rs = statement.executeQuery(code)
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Redirect console output and error when interpreting scala code, see details in #1504

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
