### PR TITLE
Added support liveness and readiness for kyuubi pod

### DIFF
--- a/docker/helm/templates/kyuubi-deployment.yaml
+++ b/docker/helm/templates/kyuubi-deployment.yaml
@@ -43,6 +43,22 @@ spec:
             - name: frontend-port
               containerPort: {{ .Values.server.bind.port }}
               protocol: TCP
+          {{- if .Values.probe.liveness.enabled }}
+          livenessProbe:
+            tcpSocket:
+              port: {{ .Values.server.bind.port }
+            initialDelaySeconds: {{ .Values.probe.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.liveness.periodSeconds }}
+            failureThreshold: {{ .Values.probe.liveness.failureThreshold }}
+          {{- end }}
+          {{- if .Values.probe.readiness.enabled }}
+          readinessProbe:
+            tcpSocket:
+              port: {{ .Values.server.bind.port }
+            initialDelaySeconds: {{ .Values.probe.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probe.readiness.periodSeconds }}
+            failureThreshold: {{ .Values.probe.readiness.failureThreshold }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/docker/helm/values.yaml
+++ b/docker/helm/values.yaml
@@ -31,14 +31,14 @@ image:
 probe:
   liveness:
     enabled: true
-    failureThreshold: 10
     initialDelaySeconds: 30
     periodSeconds: 10
+    failureThreshold: 10
   readiness:
     enabled: true
-    failureThreshold: 10
     initialDelaySeconds: 30
     periodSeconds: 10
+    failureThreshold: 10
 
 server:
   bind:

--- a/docker/helm/values.yaml
+++ b/docker/helm/values.yaml
@@ -28,6 +28,18 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "master-snapshot"
 
+probe:
+  liveness:
+    enabled: true
+    failureThreshold: 10
+    initialDelaySeconds: 30
+    periodSeconds: 10
+  readiness:
+    enabled: true
+    failureThreshold: 10
+    initialDelaySeconds: 30
+    periodSeconds: 10
+
 server:
   bind:
     host: 0.0.0.0


### PR DESCRIPTION
### _Why are the changes needed?_
It is better to support `livenessProbe` and `readinessProbe` for indicating whether the container is running.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
