### PR TITLE
Refine usage about option '--namespace' in kyuubi-ctl

### DIFF
--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
@@ -133,7 +133,7 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
     }
   }
 
-  test("test expose to same namespace or not specified namespace") {
+  test("test expose to same namespace") {
     conf
       .unset(KyuubiConf.SERVER_KEYTAB)
       .unset(KyuubiConf.SERVER_PRINCIPAL)
@@ -153,6 +153,14 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       "--port",
       port)
     testPrematureExit(args, "Only support expose Kyuubi server instance to another domain")
+  }
+
+  test("test not specified namespace") {
+    conf
+      .unset(KyuubiConf.SERVER_KEYTAB)
+      .unset(KyuubiConf.SERVER_PRINCIPAL)
+      .set(HA_ZK_QUORUM, zkServer.getConnectString)
+      .set(KyuubiConf.FRONTEND_THRIFT_BINARY_BIND_PORT, 0)
 
     val args2 = Array(
       "create",
@@ -163,7 +171,29 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       host,
       "--port",
       port)
-    testPrematureExit(args2, "Zookeeper namespace is not specified")
+    testPrematureExit(args2, "Only support expose Kyuubi server instance to another domain")
+  }
+
+  test("test expose to another namespace") {
+    conf
+      .unset(KyuubiConf.SERVER_KEYTAB)
+      .unset(KyuubiConf.SERVER_PRINCIPAL)
+      .set(HA_ZK_QUORUM, zkServer.getConnectString)
+      .set(HA_ZK_NAMESPACE, namespace)
+      .set(KyuubiConf.FRONTEND_THRIFT_BINARY_BIND_PORT, 0)
+
+    val args = Array(
+      "create",
+      "server",
+      "--zk-quorum",
+      zkServer.getConnectString,
+      "--namespace",
+      "other-kyuubi-server",
+      "--host",
+      host,
+      "--port",
+      port)
+    testPrematureExit(args, "")
   }
 
   test("test render zookeeper service node info") {


### PR DESCRIPTION
### _Why are the changes needed?_
The current option `-n` of command `kyuubi-ctl create` is confusing for new users. For example, when using the below command without setting `kyuubi.ha.zookeeper.namespace` it throws following exception which seems confused:
```
$ bin/kyuubi-ctl create -s localhost -p 10009 -n test
Only support expose Kyuubi server instance to another domain, but the default
namespace is [None] and specified namespace is [test]

        at org.apache.kyuubi.ctl.ServiceControlCliArguments.fail(ServiceControlCliArguments.scala:294)
        at org.apache.kyuubi.ctl.ServiceControlCliArguments.validateCreateActionArguments(ServiceControlCliArguments.scala:195)
        at org.apache.kyuubi.ctl.ServiceControlCliArguments.validateArguments(ServiceControlCliArguments.scala:176)
        at org.apache.kyuubi.ctl.ServiceControlCliArguments.parse(ServiceControlCliArguments.scala:136)
        at org.apache.kyuubi.ctl.ServiceControlCliArguments.<init>(ServiceControlCliArguments.scala:36)
        ...
```
In addtion, the description of option `-n` in `kyuubi-ctl --help` is `using kyuubi-defaults/conf if absent`, however when using below without option `-n` throws like:
```
$ bin/kyuubi-ctl create -s localhost -p 10009
Zookeeper namespace is not specified
...
```
this because the default value is not copied to `cli.args` for `create` action. Users may confuse about this.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
