### PR TITLE
[TASK-1] Add avg rpc time for each operation

### DIFF
--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/DataGenerator.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/DataGenerator.scala
@@ -570,31 +570,31 @@ object DataGenerator {
       $"web_tax_percentage"       .decimal(5, 2))
     // format: on
 
-   Seq(
-     store_sales,
-     store_returns,
-     catalog_sales,
-     catalog_returns,
-     web_sales,
-     web_returns,
-     inventory,
-     catalog_page,
-     call_center,
-     customer,
-     customer_address,
-     customer_demographics,
-     household_demographics,
-     store,
-     warehouse,
-     item,
-     income_band,
-     web_site,
-     web_page,
-     date_dim,
-     time_dim,
-     ship_mode,
-     reason,
-     promotion)
+    Seq(
+      store_sales,
+      store_returns,
+      catalog_sales,
+      catalog_returns,
+      web_sales,
+      web_returns,
+      inventory,
+      catalog_page,
+      call_center,
+      customer,
+      customer_address,
+      customer_demographics,
+      household_demographics,
+      store,
+      warehouse,
+      item,
+      income_band,
+      web_site,
+      web_page,
+      date_dim,
+      time_dim,
+      ship_mode,
+      reason,
+      promotion)
   }
 
   def run(config: RunConfig): Unit = {

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
@@ -40,4 +40,5 @@ object MetricsConstants {
   final val OPERATION_FAIL: String = OPERATION + "failed"
   final val OPERATION_TOTAL: String = OPERATION + "total"
 
+  final val OPERATION_RPC_TIME: String = OPERATION + "rpc_time"
 }

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
@@ -40,5 +40,5 @@ object MetricsConstants {
   final val OPERATION_FAIL: String = OPERATION + "failed"
   final val OPERATION_TOTAL: String = OPERATION + "total"
 
-  final val OPERATION_RPC_TIME: String = OPERATION + "rpc_time"
+  final val OPERATION_RPC_MS: String = OPERATION + "rpc_ms"
 }

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
@@ -50,6 +50,11 @@ class MetricsSystem extends CompositeService("MetricsSystem") {
       })
   }
 
+  def updateHistogram(key: String, value: Long): Unit = {
+    val histogram = registry.histogram(key)
+    histogram.update(value)
+  }
+
   override def initialize(conf: KyuubiConf): Unit = synchronized {
     registry.registerAll(new GarbageCollectorMetricSet)
     registry.registerAll(new MemoryUsageGaugeSet)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -35,7 +35,7 @@ import org.apache.kyuubi.session.SessionHandle
 import org.apache.kyuubi.util.ThriftUtils
 
 class KyuubiSyncThriftClient private (protocol: TProtocol)
-  extends TCLIService.Client(protocol) with Logging {
+  extends TCLIService.Client(protocol) with KyuubiThriftClient with Logging {
 
   @volatile private var _remoteSessionHandle: TSessionHandle = _
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiThriftClient.scala
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client
+
+import org.apache.hive.service.rpc.thrift._
+
+import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
+import org.apache.kyuubi.session.SessionHandle
+
+trait KyuubiThriftClient {
+
+  /**
+   * Return the engine SessionHandle for kyuubi session so that we can get the same session id
+   */
+  def openSession(
+      protocol: TProtocolVersion,
+      user: String,
+      password: String,
+      configs: Map[String, String]): SessionHandle
+
+  def closeSession(): Unit
+
+  def executeStatement(
+      statement: String,
+      shouldRunAsync: Boolean,
+      queryTimeout: Long): TOperationHandle
+
+  def getTypeInfo: TOperationHandle
+
+  def getCatalogs: TOperationHandle
+
+  def getSchemas(catalogName: String, schemaName: String): TOperationHandle
+
+  def getTables(
+      catalogName: String,
+      schemaName: String,
+      tableName: String,
+      tableTypes: java.util.List[String]): TOperationHandle
+
+  def getTableTypes: TOperationHandle
+
+  def getColumns(
+      catalogName: String,
+      schemaName: String,
+      tableName: String,
+      columnName: String): TOperationHandle
+
+  def getFunctions(
+      catalogName: String,
+      schemaName: String,
+      functionName: String): TOperationHandle
+
+  def getOperationStatus(operationHandle: TOperationHandle): TGetOperationStatusResp
+
+  def cancelOperation(operationHandle: TOperationHandle): Unit
+
+  def closeOperation(operationHandle: TOperationHandle): Unit
+
+  def getResultSetMetadata(operationHandle: TOperationHandle): TTableSchema
+
+  def fetchResults(
+      operationHandle: TOperationHandle,
+      orientation: FetchOrientation,
+      maxRows: Int,
+      fetchLog: Boolean): TRowSet
+
+  def sendCredentials(encodedCredentials: String): Unit
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiThriftClientCallTimeStatics.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiThriftClientCallTimeStatics.scala
@@ -50,11 +50,11 @@ class KyuubiThriftClientCallTimeStatics(client: KyuubiThriftClient) extends Kyuu
       user: String,
       password: String,
       configs: Map[String, String]): SessionHandle = {
-    time(client.openSession(protocol, user, password, configs))
+    client.openSession(protocol, user, password, configs)
   }
 
   override def closeSession(): Unit = {
-    time(client.closeSession())
+    client.closeSession()
   }
 
   override def executeStatement(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiThriftClientCallTimeStatics.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiThriftClientCallTimeStatics.scala
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client
+
+import java.util
+
+import org.apache.hive.service.rpc.thrift.{TGetOperationStatusResp, TOperationHandle, TProtocolVersion, TRowSet, TTableSchema}
+
+import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
+import org.apache.kyuubi.session.SessionHandle
+
+class KyuubiThriftClientCallTimeStatics(client: KyuubiThriftClient) extends KyuubiThriftClient {
+
+  private var timeCost: Long = 0L
+
+  /**
+   * Get the time cost millis on each call of the function in the [[KyuubiThriftClient]]
+   */
+  def getTimeCostMillis: Long = {
+    timeCost
+  }
+
+  @throws[Exception]
+  private def time[T](f: => T): T = {
+    val startTime = System.currentTimeMillis()
+    try {
+      f
+    } finally {
+      timeCost += System.currentTimeMillis() - startTime
+    }
+  }
+
+  override def openSession(
+      protocol: TProtocolVersion,
+      user: String,
+      password: String,
+      configs: Map[String, String]): SessionHandle = {
+    time(client.openSession(protocol, user, password, configs))
+  }
+
+  override def closeSession(): Unit = {
+    time(client.closeSession())
+  }
+
+  override def executeStatement(
+      statement: String,
+      shouldRunAsync: Boolean,
+      queryTimeout: Long): TOperationHandle = {
+    time(client.executeStatement(statement, shouldRunAsync, queryTimeout))
+  }
+
+  override def getTypeInfo: TOperationHandle = {
+    time(client.getTypeInfo)
+  }
+
+  override def getCatalogs: TOperationHandle = {
+    time(client.getCatalogs)
+  }
+
+  override def getSchemas(catalogName: String, schemaName: String): TOperationHandle = {
+    time(client.getSchemas(catalogName, schemaName))
+  }
+
+  override def getTables(
+      catalogName: String,
+      schemaName: String,
+      tableName: String,
+      tableTypes: util.List[String]): TOperationHandle = {
+    time(client.getTables(catalogName, schemaName, tableName, tableTypes))
+  }
+
+  override def getTableTypes: TOperationHandle = {
+    time(client.getTableTypes)
+  }
+
+  override def getColumns(
+      catalogName: String,
+      schemaName: String,
+      tableName: String,
+      columnName: String): TOperationHandle = {
+    time(client.getColumns(catalogName, schemaName, tableName, columnName))
+  }
+
+  override def getFunctions(
+      catalogName: String,
+      schemaName: String,
+      functionName: String): TOperationHandle = {
+    time(client.getFunctions(catalogName, schemaName, functionName))
+  }
+
+  override def getOperationStatus(operationHandle: TOperationHandle): TGetOperationStatusResp = {
+    time(client.getOperationStatus(operationHandle))
+  }
+
+  override def cancelOperation(operationHandle: TOperationHandle): Unit = {
+    time(client.cancelOperation(operationHandle))
+  }
+
+  override def closeOperation(operationHandle: TOperationHandle): Unit = {
+    time(client.cancelOperation(operationHandle))
+  }
+
+  override def getResultSetMetadata(operationHandle: TOperationHandle): TTableSchema = {
+    time(client.getResultSetMetadata(operationHandle))
+  }
+
+  override def fetchResults(
+      operationHandle: TOperationHandle,
+      orientation: FetchOrientation,
+      maxRows: Int,
+      fetchLog: Boolean): TRowSet = {
+    time(client.fetchResults(operationHandle, orientation, maxRows, fetchLog))
+  }
+
+  override def sendCredentials(encodedCredentials: String): Unit = {
+    time(client.sendCredentials(encodedCredentials))
+  }
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -27,7 +27,7 @@ import org.apache.thrift.transport.TTransportException
 
 import org.apache.kyuubi.{KyuubiSQLException, Utils}
 import org.apache.kyuubi.client.KyuubiThriftClientCallTimeStatics
-import org.apache.kyuubi.metrics.MetricsConstants.{OPERATION_FAIL, OPERATION_OPEN, OPERATION_RPC_TIME, OPERATION_TOTAL}
+import org.apache.kyuubi.metrics.MetricsConstants.{OPERATION_FAIL, OPERATION_OPEN, OPERATION_RPC_MS, OPERATION_TOTAL}
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.OperationType.OperationType
@@ -51,7 +51,7 @@ abstract class KyuubiOperation(opType: OperationType, session: Session)
   private def metricTraceCloseOrCancel(): Unit = MetricsSystem.tracing { ms =>
     ms.decCount(MetricRegistry.name(OPERATION_OPEN, opTypeName))
     ms.updateHistogram(
-      MetricRegistry.name(OPERATION_RPC_TIME, opTypeName),
+      MetricRegistry.name(OPERATION_RPC_MS, opTypeName),
       client.getTimeCostMillis)
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -52,7 +52,8 @@ abstract class KyuubiOperation(opType: OperationType, session: Session)
     ms.decCount(MetricRegistry.name(OPERATION_OPEN, opTypeName))
     ms.updateHistogram(
       MetricRegistry.name(OPERATION_RPC_TIME, opTypeName),
-      client.getTimeCostMillis)}
+      client.getTimeCostMillis)
+  }
 
   protected[operation] lazy val client = new KyuubiThriftClientCallTimeStatics(
     session.asInstanceOf[KyuubiSessionImpl].client)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationMetricSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationMetricSuite.scala
@@ -76,8 +76,8 @@ class KyuubiOperationMetricSuite extends WithKyuubiServer with HiveJDBCTestHelpe
           .get("count").asInt() == 1)
 
       val histograms = res2.get("histograms")
-      assert(histograms.has("kyuubi.operation.rpc_time.execute_statement"))
-      val rpcTimeHistograms = histograms.get("kyuubi.operation.rpc_time.execute_statement")
+      assert(histograms.has("kyuubi.operation.rpc_ms.execute_statement"))
+      val rpcTimeHistograms = histograms.get("kyuubi.operation.rpc_ms.execute_statement")
       assert(rpcTimeHistograms.get("count").asInt() == 3)
       assert(rpcTimeHistograms.get("max").asInt() >= rpcTimeHistograms.get("mean").asInt() &&
         rpcTimeHistograms.get("mean").asInt() >= rpcTimeHistograms.get("min").asInt())

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationMetricSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationMetricSuite.scala
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.operation
+
+import java.nio.file.{Path, Paths}
+import java.time.Duration
+
+import com.fasterxml.jackson.databind.ObjectMapper
+
+import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.metrics.MetricsConf
+
+class KyuubiOperationMetricSuite extends WithKyuubiServer with HiveJDBCTestHelper {
+
+  val reportPath: Path = Utils.createTempDir()
+
+  override protected val conf: KyuubiConf = {
+    KyuubiConf()
+      .set(MetricsConf.METRICS_REPORTERS, Seq("JSON"))
+      .set(MetricsConf.METRICS_JSON_LOCATION, reportPath.toString)
+      .set(MetricsConf.METRICS_JSON_INTERVAL, Duration.ofMillis(100).toMillis)
+  }
+
+  override protected def jdbcUrl: String = getJdbcUrl
+
+  test("test Kyuubi operation metric") {
+    val objMapper = new ObjectMapper()
+    withJdbcStatement() { statement =>
+      statement.executeQuery("show databases")
+      statement.executeQuery("show tables")
+
+      Thread.sleep(Duration.ofMillis(111).toMillis)
+      val res1 = objMapper.readTree(Paths.get(reportPath.toString, "report.json").toFile)
+      assert(res1.has("counters"))
+      val counter1 = res1.get("counters")
+      assert(counter1.has(s"kyuubi.connection.opened.$user"))
+      assert(counter1.get(s"kyuubi.connection.opened.$user").get("count").asInt() == 1)
+      assert(counter1.get("kyuubi.connection.total").get("count").asInt() == 1)
+      assert(counter1.get("kyuubi.operation.total.execute_statement").get("count").asInt() == 2)
+      assert(counter1.get("kyuubi.operation.opened.launch_engine").get("count").asInt() == 1)
+      assert(counter1.get("kyuubi.operation.total").get("count").asInt() == 3)
+
+      try {
+        statement.executeQuery("fail execute")
+      } catch {
+        case _: Exception => // do not thing
+      }
+      statement.close()
+
+      Thread.sleep(Duration.ofMillis(111).toMillis)
+      val res2 = objMapper.readTree(Paths.get(reportPath.toString, "report.json").toFile)
+      val counter2 = res2.get("counters")
+      assert(counter1.get("kyuubi.engine.total").get("count").asInt() == 1)
+      assert(counter2.get("kyuubi.operation.total.execute_statement").get("count").asInt() == 3)
+      assert(counter2.get("kyuubi.operation.opened.execute_statement").get("count").asInt() == 0)
+      assert(counter2.has("kyuubi.operation.failed.execute_statement.KyuubiSQLException"))
+      assert(
+        counter2
+          .get("kyuubi.operation.failed.execute_statement.KyuubiSQLException")
+          .get("count").asInt() == 1)
+
+      val histograms = res2.get("histograms")
+      assert(histograms.has("kyuubi.operation.rpc_time.execute_statement"))
+      val rpcTimeHistograms = histograms.get("kyuubi.operation.rpc_time.execute_statement")
+      assert(rpcTimeHistograms.get("count").asInt() == 3)
+      assert(rpcTimeHistograms.get("max").asInt() >= rpcTimeHistograms.get("mean").asInt() &&
+          rpcTimeHistograms.get("mean").asInt() >= rpcTimeHistograms.get("min").asInt())
+    }
+  }
+}

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationMetricSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationMetricSuite.scala
@@ -80,7 +80,7 @@ class KyuubiOperationMetricSuite extends WithKyuubiServer with HiveJDBCTestHelpe
       val rpcTimeHistograms = histograms.get("kyuubi.operation.rpc_time.execute_statement")
       assert(rpcTimeHistograms.get("count").asInt() == 3)
       assert(rpcTimeHistograms.get("max").asInt() >= rpcTimeHistograms.get("mean").asInt() &&
-          rpcTimeHistograms.get("mean").asInt() >= rpcTimeHistograms.get("min").asInt())
+        rpcTimeHistograms.get("mean").asInt() >= rpcTimeHistograms.get("min").asInt())
     }
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Subtask of #1393. Add avg rpc time for each operation on Kyuubi server.

Use MetricRegistry default histogram to record.

Screenshot of the json file generated by the json reporter:

![Screenshot from 2021-12-11 09-20-35](https://user-images.githubusercontent.com/29809822/145666232-1beebb64-43aa-4016-8740-eaa3722549fb.png)


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
