### PR TITLE
[KYUUBI #1649] Determine the yarn command in stop-application.sh.

### DIFF
--- a/bin/stop-application.sh
+++ b/bin/stop-application.sh
@@ -21,9 +21,23 @@ if [[ $# < 1 ]] ; then
   exit 1
 fi
 
-if [[ -z ${HADOOP_HOME} ]]; then
-  echo "Error: HADOOP_HOME IS NOT SET! CANNOT PROCEED."
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+}
+
+YARN_CMD=""
+
+if check_cmd "yarn"; then
+  YARN_CMD="yarn"
+fi
+
+if [ -z "$YARN_CMD" ] && [ -n "${HADOOP_HOME}" ] && check_cmd "${HADOOP_HOME}/bin/yarn"; then
+  YARN_CMD="${HADOOP_HOME}/bin/yarn"
+fi
+
+if [[ -z "$YARN_CMD" ]]; then
+  echo "Error: Cannot find yarn command! CANNOT PROCEED."
   exit 1
 fi
 
-$HADOOP_HOME/bin/yarn application -kill $1
+$YARN_CMD application -kill $1

--- a/bin/stop-application.sh
+++ b/bin/stop-application.sh
@@ -36,7 +36,7 @@ if [ -z "$YARN_CMD" ] && [ -n "${HADOOP_HOME}" ] && check_cmd "${HADOOP_HOME}/bi
 fi
 
 if [[ -z "$YARN_CMD" ]]; then
-  echo "Error: Cannot find yarn command! CANNOT PROCEED."
+  echo "Error: Cannot find yarn command! Please ensure your 'yarn' command is available or define the 'HADOOP_HOME' which contains yarn script in 'kyuubi-env.sh'."
   exit 1
 fi
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When HADOOP_HOME is not set, the stop-application.sh script cannot kill the yarn task even if the yarn command exists. #1649

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Add screenshots for manual tests if appropriate
![image](https://user-images.githubusercontent.com/17894939/147664786-564b20b7-ce90-47ec-bffb-2ada93774345.png)

- [X] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
