### PR TITLE
[KYUUBI #1679] Remove invalid column and field number check

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/java/org/apache/kyuubi/engine/flink/result/ResultSet.java
+++ b/externals/kyuubi-flink-sql-engine/src/main/java/org/apache/kyuubi/engine/flink/result/ResultSet.java
@@ -53,11 +53,6 @@ public class ResultSet {
     this.resultKind = Preconditions.checkNotNull(resultKind, "resultKind must not be null");
     this.columns = Preconditions.checkNotNull(columns, "columns must not be null");
     this.data = Preconditions.checkNotNull(data, "data must not be null");
-    if (data.hasNext()) {
-      Preconditions.checkArgument(
-          columns.size() == data.next().getArity(),
-          "the size of columns and the number of fields in the row should be equal");
-    }
     this.changeFlags = changeFlags;
     if (changeFlags != null) {
       Preconditions.checkArgument(

--- a/externals/kyuubi-flink-sql-engine/src/main/java/org/apache/kyuubi/engine/flink/result/ResultSet.java
+++ b/externals/kyuubi-flink-sql-engine/src/main/java/org/apache/kyuubi/engine/flink/result/ResultSet.java
@@ -53,7 +53,7 @@ public class ResultSet {
     this.resultKind = Preconditions.checkNotNull(resultKind, "resultKind must not be null");
     this.columns = Preconditions.checkNotNull(columns, "columns must not be null");
     this.data = Preconditions.checkNotNull(data, "data must not be null");
-    if (!data.hasNext()) {
+    if (data.hasNext()) {
       Preconditions.checkArgument(
           columns.size() == data.next().getArity(),
           "the size of columns and the number of fields in the row should be equal");


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

ResultSet checks if the column number of data matches the one in metadata by calling iterator.next() to get a sample row, which would make the first row missing in the final result.

The bug didn't appear in the tests, because the condition is wrong. Fixed by c0e9072a4c3383562b0fe1938e3bfa1947376754.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
