### PR TITLE
Checking whether launchEngineOpHandle is null for KyuubiConnection:: getExecLog

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -235,7 +235,7 @@ public class KyuubiConnection implements java.sql.Connection, KyuubiLoggable {
   public List<String> getExecLog() throws SQLException, ClosedOrCancelledException {
     if (isClosed()) {
       throw new ClosedOrCancelledException(
-          "Method getEngineLog() failed. The " + "connection has been closed.");
+          "Method getExecLog() failed. The " + "connection has been closed.");
     }
 
     if (launchEngineOpHandle == null) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -237,6 +237,11 @@ public class KyuubiConnection implements java.sql.Connection, KyuubiLoggable {
       throw new ClosedOrCancelledException(
           "Method getEngineLog() failed. The " + "connection has been closed.");
     }
+
+    if (launchEngineOpHandle == null) {
+      return Collections.emptyList();
+    }
+
     TFetchResultsReq fetchResultsReq =
         new TFetchResultsReq(launchEngineOpHandle, TFetchOrientation.FETCH_NEXT, fetchSize);
     fetchResultsReq.setFetchType((short) 1);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I am developing internal submit application operation and there is no backend engine needed to launch.
But I meet below exception.
```
00:07:40.744 KyuubiThriftBinaryFrontendServiceHandler-Pool: Thread-37 ERROR server.KyuubiThriftBinaryFrontendService: Error fetching results:
java.lang.NullPointerException
	at org.apache.kyuubi.service.ThriftBinaryFrontendService.FetchResults(ThriftBinaryFrontendService.scala:494)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1837)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$FetchResults.getResult(TCLIService.java:1822)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
	at org.apache.kyuubi.service.authentication.TSetIpAddressProcessor.process(TSetIpAddressProcessor.scala:36)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:834)
```
it was invoked in KyuubiCommands::showRemainingLogsIfAny

```
  private void showRemainingLogsIfAny(Object sqlObject) {
    if (sqlObject instanceof KyuubiLoggable) {
      KyuubiLoggable kyuubiLoggable = (KyuubiLoggable) sqlObject;
      List<String> logs = null;
      do {
        try {
          logs = kyuubiLoggable.getExecLog();
```

And if using the kyuubi beeline to connect old kyuubi server, it will meet the same issue.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
