### PR TITLE
[KYUUBI #1759] Remove duplicate close operation api

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
@@ -31,7 +31,6 @@ import org.apache.hive.service.rpc.thrift.{TGetInfoType, TProtocolVersion}
 import org.apache.kyuubi.Utils.error
 import org.apache.kyuubi.events.KyuubiEvent
 import org.apache.kyuubi.operation.OperationHandle
-import org.apache.kyuubi.operation.OperationHandle.parseOperationHandle
 import org.apache.kyuubi.server.api.ApiRequestContext
 import org.apache.kyuubi.session.SessionHandle
 import org.apache.kyuubi.session.SessionHandle.parseSessionHandle
@@ -304,28 +303,6 @@ private[v1] class SessionsResource extends ApiRequestContext {
     } catch {
       case NonFatal(_) =>
         throw new NotFoundException(s"Error getting functions")
-    }
-  }
-
-  @ApiResponse(
-    responseCode = "200",
-    content = Array(new Content(
-      mediaType = MediaType.APPLICATION_JSON)),
-    description = "Close an operation")
-  @DELETE
-  @Path("{sessionHandle}/operations/{operationHandle}")
-  def closeOperation(
-      @PathParam("sessionHandle") sessionHandleStr: String,
-      @PathParam("operationHandle") operationHandleStr: String): OperationHandle = {
-
-    try {
-      val operationHandle = parseOperationHandle(operationHandleStr)
-      fe.be.sessionManager.getSession(parseSessionHandle(sessionHandleStr))
-        .closeOperation(operationHandle)
-      operationHandle
-    } catch {
-      case NonFatal(_) =>
-        throw new NotFoundException(s"Error closing an operation")
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -247,43 +247,4 @@ class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     operationHandle = response.readEntity(classOf[OperationHandle])
     assert(operationHandle.typ == OperationType.GET_FUNCTIONS)
   }
-
-  test("close an operation") {
-    val requestObj = SessionOpenRequest(
-      1,
-      "admin",
-      "123456",
-      "localhost",
-      Map("testConfig" -> "testValue"))
-
-    var response: Response = webTarget.path("api/v1/sessions")
-      .request(MediaType.APPLICATION_JSON_TYPE)
-      .post(Entity.entity(requestObj, MediaType.APPLICATION_JSON_TYPE))
-
-    val sessionHandle = response.readEntity(classOf[SessionHandle])
-    val serializedSessionHandle = s"${sessionHandle.identifier.publicId}|" +
-      s"${sessionHandle.identifier.secretId}|${sessionHandle.protocol.getValue}"
-
-    val pathPrefix = s"api/v1/sessions/$serializedSessionHandle"
-
-    response = webTarget.path(s"$pathPrefix/operations/catalogs")
-      .request(MediaType.APPLICATION_JSON_TYPE)
-      .post(Entity.entity(null, MediaType.APPLICATION_JSON_TYPE))
-    assert(200 == response.getStatus)
-    val operationHandle = response.readEntity(classOf[OperationHandle])
-    assert(operationHandle.typ == OperationType.GET_CATALOGS)
-
-    val serializedOperationHandle = s"${operationHandle.identifier.publicId}|" +
-      s"${operationHandle.identifier.secretId}|${operationHandle.protocol.getValue}|" +
-      s"${operationHandle.typ.toString}"
-
-    response = webTarget.path(s"$pathPrefix/operations/$serializedOperationHandle")
-      .request(MediaType.APPLICATION_JSON_TYPE).delete()
-    assert(200 == response.getStatus)
-
-    // verify operation
-    response = webTarget.path(s"api/v1/operations/$serializedOperationHandle/event")
-      .request(MediaType.APPLICATION_JSON_TYPE).get()
-    assert(404 == response.getStatus)
-  }
 }


### PR DESCRIPTION
### _Why are the changes needed?_
Remove duplicate close operation api, closes #1759 
 
 #1445 is duplicate with #1517 where action='close'.

```
/${version}/operations/${operation_identifier}
desc: apply an action for an operation based on a given session identifier and operation identifier
method: PUT
params:
action: "CANCEL" or "ADD" or "CLOSE"
returns: status code

/${version}/sessions/${session_identifier}/operations/${operation_identifier}
desc: remove operation based on a given session identifier and operation identifier
method: DELETE
params: none
returns: an instance of OperationHandle
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
