### PR TITLE
[KYUUBI #1771] Change rate unit in `JsonReporterService`

### DIFF
--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/JsonReporterService.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/JsonReporterService.scala
@@ -38,7 +38,7 @@ import org.apache.kyuubi.service.AbstractService
 class JsonReporterService(registry: MetricRegistry)
   extends AbstractService("JsonReporterService") {
   private val jsonMapper = new ObjectMapper().registerModule(
-    new MetricsModule(TimeUnit.MILLISECONDS, TimeUnit.MILLISECONDS, false))
+    new MetricsModule(TimeUnit.SECONDS, TimeUnit.MILLISECONDS, false))
   private val timer = new Timer(true)
   private var reportDir: Path = _
   private var reportPath: Path = _


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Change rate unit in `JsonReporterService`.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
A part of the report JSON file  content  shows like this:
```
    "kyuubi.backend_service.close_operation" : {
      "count" : 2196,
      "max" : 211.072349,
      "mean" : 1.2610130266188537,
      "min" : 0.172128,
      "p50" : 0.492044,
      "p75" : 0.718252,
      "p95" : 1.6039109999999999,
      "p98" : 5.8341069999999995,
      "p99" : 9.43642,
      "p999" : 211.072349,
      "stddev" : 10.214272758857668,
      "m15_rate" : 2.405930386704415,
      "m1_rate" : 21.71755165233277,
      "m5_rate" : 6.395622468399835,
      "mean_rate" : 15.886573053353114,
      "duration_units" : "milliseconds",
      "rate_units" : "calls/second"
    },
    "kyuubi.backend_service.execute_statement" : {
      "count" : 2207,
      "max" : 12.308489999999999,
      "mean" : 1.0070540441064393,
      "min" : 0.255337,
      "p50" : 0.8148869999999999,
      "p75" : 1.133641,
      "p95" : 1.794405,
      "p98" : 2.698518,
      "p99" : 5.280635999999999,
      "p999" : 11.317784999999999,
      "stddev" : 0.8658011924327101,
      "m15_rate" : 2.4059209510427615,
      "m1_rate" : 21.719940889226297,
      "m5_rate" : 6.3955828312258785,
      "mean_rate" : 15.928117712442724,
      "duration_units" : "milliseconds",
      "rate_units" : "calls/second"
    },
```
- [ ] [Run test](https://kyuubi.readthedocs.io/en/latest/develop_tools/testing.html#running-tests) locally before make a pull request
