### PR TITLE
Fix flaky test using connection share level by default

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServer.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServer.scala
@@ -56,6 +56,7 @@ trait WithKyuubiServer extends KyuubiFunSuite {
     conf.setIfMissing(ENGINE_IDLE_TIMEOUT, 10000L)
     // TODO KYUUBI #745
     conf.setIfMissing(ENGINE_INIT_TIMEOUT, 300000L)
+    conf.setIfMissing(ENGINE_SHARE_LEVEL, "CONNECTION")
     server = KyuubiServer.startServer(conf)
     super.beforeAll()
     Thread.sleep(1500)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The CI become flaky after we adding more engines (flink/trino) and more tests(can see in package `org.apache.kyuubi.operation`) 

We should release engine as far as possible.

### _How was this patch tested?_
Pass CI