### PR TITLE
[KYUUBI #1778] Support Flink Set/Reset Operations

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/java/org/apache/kyuubi/engine/flink/result/OperationUtil.java
+++ b/externals/kyuubi-flink-sql-engine/src/main/java/org/apache/kyuubi/engine/flink/result/OperationUtil.java
@@ -55,4 +55,19 @@ public class OperationUtil {
         .data(data.toArray(new Row[0]))
         .build();
   }
+
+  /**
+   * Build a simple result with OK message. Returned when SQL commands are executed successfully.
+   * Noted that a new ResultSet is returned each time, because ResultSet is stateful (with its
+   * cursor).
+   *
+   * @return A simple result with OK message.
+   */
+  public static ResultSet successResultSet() {
+    return ResultSet.builder()
+        .resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+        .columns(Column.physical("result", DataTypes.STRING()))
+        .data(new Row[] {Row.of("OK")})
+        .build();
+  }
 }

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/ExecuteStatement.scala
@@ -50,8 +50,6 @@ class ExecuteStatement(
 
   private var statementTimeoutCleaner: Option[ScheduledExecutorService] = None
 
-  private val PROPERTY_FORMAT = "%s = %s"
-
   override def getOperationLog: Option[OperationLog] = Option(operationLog)
 
   @VisibleForTesting
@@ -158,27 +156,33 @@ class ExecuteStatement(
       val value = executor.getSessionConfigMap(sessionId).getOrDefault(key, "")
       resultSet = ResultSet.builder
         .resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-        .columns(Column.physical("set", DataTypes.STRING()))
-        .data(Array(Row.of(PROPERTY_FORMAT.format(key, value))))
+        .columns(
+          Column.physical("key", DataTypes.STRING()),
+          Column.physical("value", DataTypes.STRING()))
+        .data(Array(Row.of(key, value)))
         .build
     } else {
       // show all properties if set without key
       val properties: util.Map[String, String] = executor.getSessionConfigMap(sessionId)
 
       val entries = ArrayBuffer.empty[Row]
-      properties.forEach((key, value) => entries.append(Row.of(PROPERTY_FORMAT.format(key, value))))
+      properties.forEach((key, value) => entries.append(Row.of(key, value)))
 
       if (entries.nonEmpty) {
         val prettyEntries = entries.sortBy(_.getField(0).asInstanceOf[String])
         resultSet = ResultSet.builder
           .resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-          .columns(Column.physical("set", DataTypes.STRING()))
+          .columns(
+            Column.physical("key", DataTypes.STRING()),
+            Column.physical("value", DataTypes.STRING()))
           .data(prettyEntries.toArray)
           .build
       } else {
         resultSet = ResultSet.builder
           .resultKind(ResultKind.SUCCESS_WITH_CONTENT)
-          .columns(Column.physical("set", DataTypes.STRING()))
+          .columns(
+            Column.physical("key", DataTypes.STRING()),
+            Column.physical("value", DataTypes.STRING()))
           .data(Array[Row]())
           .build
       }

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
@@ -704,4 +704,21 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
       assert(resultSet.next())
     })
   }
+
+  test("execute statement - rest property") {
+    withMultipleConnectionJdbcStatement()({ statement =>
+      statement.executeQuery("set pipeline.jars = my.jar")
+      statement.executeQuery("reset pipeline.jars")
+      val resultSet = statement.executeQuery("set")
+      // Flink does not support set key without value currently,
+      // thus read all rows to find the desired one
+      var found = false
+      while (resultSet.next()) {
+        if (resultSet.getString(1) == "pipeline.jars = ") {
+          found = true
+        }
+      }
+      assert(found)
+    })
+  }
 }

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
@@ -690,9 +690,11 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
     withMultipleConnectionJdbcStatement()({ statement =>
       val resultSet = statement.executeQuery("set table.dynamic-table-options.enabled = true")
       val metadata = resultSet.getMetaData
-      assert(metadata.getColumnName(1) == "set")
+      assert(metadata.getColumnName(1) == "key")
+      assert(metadata.getColumnName(2) == "value")
       assert(resultSet.next())
-      assert(resultSet.getString(1) == "table.dynamic-table-options.enabled = true")
+      assert(resultSet.getString(1) == "table.dynamic-table-options.enabled")
+      assert(resultSet.getString(2) == "true")
     })
   }
 
@@ -700,25 +702,26 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
     withMultipleConnectionJdbcStatement()({ statement =>
       val resultSet = statement.executeQuery("set")
       val metadata = resultSet.getMetaData
-      assert(metadata.getColumnName(1) == "set")
+      assert(metadata.getColumnName(1) == "key")
+      assert(metadata.getColumnName(2) == "value")
       assert(resultSet.next())
     })
   }
 
-  test("execute statement - rest property") {
+  test("execute statement - reset property") {
     withMultipleConnectionJdbcStatement()({ statement =>
       statement.executeQuery("set pipeline.jars = my.jar")
       statement.executeQuery("reset pipeline.jars")
       val resultSet = statement.executeQuery("set")
       // Flink does not support set key without value currently,
       // thus read all rows to find the desired one
-      var found = false
+      var success = false
       while (resultSet.next()) {
-        if (resultSet.getString(1) == "pipeline.jars = ") {
-          found = true
+        if (resultSet.getString(1) == "pipeline.jars" && resultSet.getString(2) == "") {
+          success = true
         }
       }
-      assert(found)
+      assert(success)
     })
   }
 }

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
@@ -685,4 +685,23 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
       assert(resultSet.getLong(1) == -1L)
     })
   }
+
+  test("execute statement - set properties") {
+    withMultipleConnectionJdbcStatement()({ statement =>
+      val resultSet = statement.executeQuery("set table.dynamic-table-options.enabled = true")
+      val metadata = resultSet.getMetaData
+      assert(metadata.getColumnName(1) == "set")
+      assert(resultSet.next())
+      assert(resultSet.getString(1) == "table.dynamic-table-options.enabled = true")
+    })
+  }
+
+  test("execute statement - show properties") {
+    withMultipleConnectionJdbcStatement()({ statement =>
+      val resultSet = statement.executeQuery("set")
+      val metadata = resultSet.getMetaData
+      assert(metadata.getColumnName(1) == "set")
+      assert(resultSet.next())
+    })
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_

Set/Reset operations are crucial for tunning Flink SQL jobs and enabling/disabling features, but they're not executed as SQL statements in Flink, thus can't be supported by the current ExecuteStatement implementation. We should extend ExecuteStatement to support these operations.

This is a sub-task of KPIP-2 #1322.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
