### PR TITLE
[KYUUBI #1825] Generate appName for Flink applications

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
@@ -89,8 +89,6 @@ object FlinkSQLEngine extends Logging {
             val appName = s"kyuubi-${user}-flink-${Instant.now}"
             flinkConf.setString("kubernetes.cluster-id", appName)
           }
-        case null =>
-          error("No execution.target specified for Flink engine")
         case other =>
           debug(s"Skip generating app name for execution target $other")
       }

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
@@ -80,11 +80,15 @@ object FlinkSQLEngine extends Logging {
       // set cluster name for per-job and application mode
       executionTarget match {
         case "yarn-per-job" | "yarn-application" =>
-          val appName = s"kyuubi_${user}_flink_${Instant.now}"
-          flinkConf.setString("yarn.application.name", appName)
+          if (!flinkConf.containsKey("yarn.application.name")) {
+            val appName = s"kyuubi_${user}_flink_${Instant.now}"
+            flinkConf.setString("yarn.application.name", appName)
+          }
         case "kubernetes-application" =>
-          val appName = s"kyuubi-${user}-flink-${Instant.now}"
-          flinkConf.setString("kubernetes.cluster-id", appName)
+          if (!flinkConf.containsKey("kubernetes.cluster-id")) {
+            val appName = s"kyuubi-${user}-flink-${Instant.now}"
+            flinkConf.setString("kubernetes.cluster-id", appName)
+          }
         case null =>
           error("No execution.target specified for Flink engine")
         case other =>

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/FlinkSQLEngine.scala
@@ -87,6 +87,8 @@ object FlinkSQLEngine extends Logging {
           flinkConf.setString("kubernetes.cluster-id", appName)
         case null =>
           error("No execution.target specified for Flink engine")
+        case other =>
+          debug(s"Skip generating app name for execution target $other")
       }
 
       val engineContext = new DefaultContext(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Generate Flink application names for per-job clusters and application-mode clusters with respect to the pattern in Spark engine.

This is a sub-task of KPIP-2 #1322.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
