### PR TITLE
Fix UT property of log4j2 conf

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1390,7 +1390,7 @@
                             <KYUUBI_WORK_DIR_ROOT>${project.build.directory}/work</KYUUBI_WORK_DIR_ROOT>
                         </environmentVariables>
                         <systemProperties>
-                            <log4j.configuration>file:src/test/resources/log4j2.properties</log4j.configuration>
+                            <log4j2.configurationFile>file:src/test/resources/log4j2.properties</log4j2.configurationFile>
                             <java.io.tmpdir>${project.build.directory}/tmp</java.io.tmpdir>
                             <spark.driver.memory>1g</spark.driver.memory>
                             <kyuubi.metrics.json.location>${project.build.directory}/metrics</kyuubi.metrics.json.location>


### PR DESCRIPTION
### _Why are the changes needed?_

We need use `log4j2.configurationFile` for log4j2 instead of `log4j.configuration`.
https://logging.apache.org/log4j/2.x/manual/configuration.html

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
