### PR TITLE
Migrate bind-api and activation-api from javax to jakarta

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -53,7 +53,6 @@ jakarta.validation-api/2.0.2//jakarta.validation-api-2.0.2.jar
 jakarta.ws.rs-api/2.1.6//jakarta.ws.rs-api-2.1.6.jar
 jakarta.xml.bind-api/2.3.2//jakarta.xml.bind-api-2.3.2.jar
 javassist/3.25.0-GA//javassist-3.25.0-GA.jar
-jaxb-api/2.2.11//jaxb-api-2.2.11.jar
 jcl-over-slf4j/1.7.30//jcl-over-slf4j-1.7.30.jar
 jersey-client/2.34//jersey-client-2.34.jar
 jersey-common/2.34//jersey-common-2.34.jar

--- a/dev/kyuubi-extension-spark-3-1/pom.xml
+++ b/dev/kyuubi-extension-spark-3-1/pom.xml
@@ -122,8 +122,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dev/kyuubi-extension-spark-3-2/pom.xml
+++ b/dev/kyuubi-extension-spark-3-2/pom.xml
@@ -122,8 +122,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/dev/kyuubi-extension-spark-common/pom.xml
+++ b/dev/kyuubi-extension-spark-common/pom.xml
@@ -108,8 +108,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -99,8 +99,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
         </dependency>
 
         <dependency>

--- a/kyuubi-server/pom.xml
+++ b/kyuubi-server/pom.xml
@@ -356,8 +356,8 @@
         </dependency>
 
         <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
+            <groupId>jakarta.activation</groupId>
+            <artifactId>jakarta.activation-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -116,8 +116,8 @@
         <iceberg.version>0.12.1</iceberg.version>
         <jackson.version>2.12.5</jackson.version>
         <jakarta.servlet-api.version>4.0.4</jakarta.servlet-api.version>
-        <jaxb.version>2.2.11</jaxb.version>
-        <javax-activation.version>1.1.1</javax-activation.version>
+        <jakarta.xml-bind.version>2.3.2</jakarta.xml-bind.version>
+        <jakarta.activation.version>1.2.1</jakarta.activation.version>
         <jersey.version>2.34</jersey.version>
         <jetty.version>9.4.41.v20210516</jetty.version>
         <jline.version>0.9.94</jline.version>
@@ -705,16 +705,6 @@
                 <groupId>com.fasterxml.jackson.module</groupId>
                 <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>${jackson.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>jakarta.xml.bind-api</artifactId>
-                        <groupId>jakarta.xml.bind</groupId>
-                    </exclusion>
-                    <exclusion>
-                        <artifactId>jakarta.activation-api</artifactId>
-                        <groupId>jakarta.activation</groupId>
-                    </exclusion>
-                </exclusions>
             </dependency>
 
             <dependency>
@@ -1019,9 +1009,9 @@
               we need explicitly add this dependency.
               -->
             <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml-bind.version}</version>
             </dependency>
 
             <!--
@@ -1029,9 +1019,9 @@
               of spark-core, thus only should explicitly add on Kyuubi Server Main test scope.
               -->
             <dependency>
-                <groupId>javax.activation</groupId>
-                <artifactId>activation</artifactId>
-                <version>${javax-activation.version}</version>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${jakarta.activation.version}</version>
             </dependency>
 
             <!-- Zookeeper Cli required -->


### PR DESCRIPTION
### _Why are the changes needed?_

The Java world is migrating JavaEE components from `javax` to `jakarta`, we should follow it.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
