### PR TITLE
Upgrade minikube action from 2.4.2 to 2.4.3

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -162,7 +162,7 @@ jobs:
           tags: apache/kyuubi:latest
       # from https://github.com/marketplace/actions/setup-minikube-kubernetes-cluster
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.4.2
+        uses: manusa/actions-setup-minikube@v2.4.3
         with:
           minikube version: 'v1.16.0'
           kubernetes version: 'v1.19.2'


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
support test k8s 1.23.

more details see [change list](https://github.com/manusa/actions-setup-minikube/compare/v2.4.2...v2.4.3).

note that, we should upgrade k8s-client first, since k8s-client 5.5.0 does not support k8s 1.22.1 and later. see [Compatibility Matrix](https://github.com/fabric8io/kubernetes-client#kubernetes-compatibility-matrix)

### _How was this patch tested?_
Pass CI
