### PR TITLE
Fix compile SQL measurement

### DIFF
--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Query.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Query.scala
@@ -22,6 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import scala.language.implicitConversions
 
 import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.execution.SparkPlan
 
@@ -66,19 +67,12 @@ class Query(
     try {
       val dataFrame = buildDataFrame
       val queryExecution = dataFrame.queryExecution
-      // We are not counting the time of ScalaReflection.convertRowToScala.
-      val parsingTime = measureTimeMs {
-        queryExecution.logical
-      }
-      val analysisTime = measureTimeMs {
-        queryExecution.analyzed
-      }
-      val optimizationTime = measureTimeMs {
-        queryExecution.optimizedPlan
-      }
-      val planningTime = measureTimeMs {
-        queryExecution.executedPlan
-      }
+      queryExecution.executedPlan
+      val phases = queryExecution.tracker.phases
+      val parsingTime = phases(QueryPlanningTracker.PARSING).durationMs.toDouble
+      val analysisTime = phases(QueryPlanningTracker.ANALYSIS).durationMs.toDouble
+      val optimizationTime = phases(QueryPlanningTracker.OPTIMIZATION).durationMs.toDouble
+      val planningTime = phases(QueryPlanningTracker.PLANNING).durationMs.toDouble
 
       val breakdownResults =
         if (includeBreakdown) {


### PR DESCRIPTION
### _Why are the changes needed?_

The previous measurement of parsing and analysis does not make sense because `Dataset` calls `queryExecution.assertAnalyzed()` in the constructor.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
