### PR TITLE
[KYUUBI #1896] Make `Query Details` and `Failure Reason` sortable on the Kyuubi Query Engine page

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -467,6 +467,8 @@ private class StatementStatsTableDataSource(
       case "Duration" => Ordering.by(_.duration)
       case "Statement" => Ordering.by(_.statement)
       case "State" => Ordering.by(_.state)
+      case "Query Details" => Ordering.by(_.executionId)
+      case "Failure Reason" => Ordering.by(_.exception.toString)
       case unknownColumn => throw new IllegalArgumentException(s"Unknown column: $unknownColumn")
     }
     if (desc) {


### PR DESCRIPTION
…y Engine page.

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Before this PR, when we sorted the `SQL statistics` using the `Query Details` column, an exception would be thrown.

![截屏2022-02-11 下午2 51 40](https://user-images.githubusercontent.com/8537877/153548694-ee6875fa-5ea1-447c-a27d-86c3a2cdf9fd.png)



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
