### PR TITLE
[KYUUBI #1905] log4j2-defaults.properties is not working since log4j 2 is always intialized by default

### DIFF
--- a/kyuubi-common/src/main/resources/log4j2-defaults.properties
+++ b/kyuubi-common/src/main/resources/log4j2-defaults.properties
@@ -19,20 +19,8 @@
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 
-# Console Appender
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n

--- a/kyuubi-common/src/main/resources/log4j2-defaults.properties
+++ b/kyuubi-common/src/main/resources/log4j2-defaults.properties
@@ -19,8 +19,20 @@
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 
+# Console Appender
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{yy/MM/dd HH:mm:ss} %p %c{1}: %m%n
+appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
+
+appender.console.filter.1.type = Filters
+
+appender.console.filter.1.a.type = ThresholdFilter
+appender.console.filter.1.a.level = INFO
+
+# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
+appender.console.filter.1.b.type = RegexFilter
+appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
+appender.console.filter.1.b.onMatch = deny
+appender.console.filter.1.b.onMismatch = neutral

--- a/kyuubi-common/src/main/resources/log4j2-defaults.properties
+++ b/kyuubi-common/src/main/resources/log4j2-defaults.properties
@@ -29,7 +29,7 @@ appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 appender.console.filter.1.type = Filters
 
 appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = INFO
+appender.console.filter.1.a.level = info
 
 # SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
 appender.console.filter.1.b.type = RegexFilter

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
@@ -187,9 +187,9 @@ object Logging {
   private[kyuubi] def islog4j2DefaultConfigured(): Boolean = {
     val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
     rootLogger.getAppenders.isEmpty ||
-      (rootLogger.getAppenders.size() == 1 &&
-        rootLogger.getLevel == Level.ERROR &&
-        LogManager.getContext.asInstanceOf[LoggerContext]
-          .getConfiguration.isInstanceOf[DefaultConfiguration])
+    (rootLogger.getAppenders.size() == 1 &&
+      rootLogger.getLevel == Level.ERROR &&
+      LogManager.getContext.asInstanceOf[LoggerContext]
+        .getConfiguration.isInstanceOf[DefaultConfiguration])
   }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
@@ -186,6 +186,9 @@ object Logging {
    */
   private[kyuubi] def islog4j2DefaultConfigured(): Boolean = {
     val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
+    // If Log4j 2 is used but is initialized by default configuration,
+    // load a default properties file
+    // (see org.apache.logging.log4j.core.config.DefaultConfiguration)
     rootLogger.getAppenders.isEmpty ||
     (rootLogger.getAppenders.size() == 1 &&
       rootLogger.getLevel == Level.ERROR &&

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
@@ -94,7 +94,7 @@ trait Logging {
   private def initializeLogging(isInterpreter: Boolean): Unit = {
     if (Logging.isLog4j2) {
       // scalastyle:off println
-      if (Logging.islog4j2DefaultConfigured()) {
+      if (Logging.isLog4j2DefaultConfigured()) {
         Logging.useDefault = true
         val defaultLogProps = "log4j2-defaults.properties"
         Option(Thread.currentThread().getContextClassLoader.getResource(defaultLogProps)) match {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
@@ -183,7 +183,7 @@ object Logging {
    * Return true if log4j2 is initialized by default configuration which has one
    * appender with error level. See `org.apache.logging.log4j.core.config.DefaultConfiguration`.
    */
-  private def islog4j2DefaultConfigured(): Boolean = {
+  private def isLog4j2DefaultConfigured(): Boolean = {
     val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
     // If Log4j 2 is used but is initialized by default configuration,
     // load a default properties file

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Logging.scala
@@ -101,7 +101,6 @@ trait Logging {
           case Some(url) =>
             val context = LogManager.getContext(false).asInstanceOf[LoggerContext]
             context.setConfigLocation(url.toURI)
-            System.err.println(s"Using Kyuubi's default log4j profile: $url")
           case None =>
             System.err.println(s"Missing $defaultLogProps")
         }
@@ -184,7 +183,7 @@ object Logging {
    * Return true if log4j2 is initialized by default configuration which has one
    * appender with error level. See `org.apache.logging.log4j.core.config.DefaultConfiguration`.
    */
-  private[kyuubi] def islog4j2DefaultConfigured(): Boolean = {
+  private def islog4j2DefaultConfigured(): Boolean = {
     val rootLogger = LogManager.getRootLogger.asInstanceOf[Log4jLogger]
     // If Log4j 2 is used but is initialized by default configuration,
     // load a default properties file


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As per [SPARK-37746](https://github.com/apache/spark/pull/35026), Kyuubi also has the same problem with initializing Log4j2.

[log4j2](https://github.com/apache/logging-log4j2/blob/rel/2.17.1/log4j-core/src/main/java/org/apache/logging/log4j/core/config/AbstractConfiguration.java#L717) provides a default configuration so there is always an appender (ConsoleAppender) with ERROR level

This pr changes the behavior of checking the initialization of log4j2.

```
LogManager.getRootLogger
  .asInstanceOf[org.apache.logging.log4j.core.Logger]
  .getAppenders
  .asScala
  .foreach {
    case (name, appender) =>
      println(s"default appender: $name, class: ${appender.getClass.getName}")
  }
```

```
default appender: DefaultConsole-2, class: org.apache.logging.log4j.core.appender.ConsoleAppender
```

After this pr, the root level is `INFO`.

![截屏2022-02-14 下午5 32 26](https://user-images.githubusercontent.com/8537877/153837958-ab0bab27-11c4-4b10-bf6f-40ea6954f6c7.png)

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
