### PR TITLE
Build and test on Linux ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ install:
 script:
   - export MVN_ARGS="-Dmaven.javadoc.skip=true -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
   - ./build/mvn clean install -DskipTests $MVN_ARGS
-# - ./build/mvn test $MVN_ARGS
+ - ./build/mvn test $MVN_ARGS -pl kyuubi-common -am
 
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,16 @@ scala:
 jdk:
   - openjdk8
 
+matrix:
+  include:
+  - name: Linux x86_64
+    arch: amd64
+  - name: Linux aarch64
+    dist: focal
+    arch: arm64-graviton2
+    group: edge
+    virt: vm
+
 cache:
   directories:
     - $HOME/.m2

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,7 @@ jdk:
 
 matrix:
   include:
-  - name: Linux x86_64
-    arch: amd64
-  - name: Linux aarch64
+  - name: Build Kyuubi on Linux ARM64
     dist: focal
     arch: arm64-graviton2
     group: edge
@@ -49,7 +47,7 @@ install:
 script:
   - export MVN_ARGS="-Dmaven.javadoc.skip=true -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
   - ./build/mvn clean install -DskipTests $MVN_ARGS
- - ./build/mvn test $MVN_ARGS -pl kyuubi-common -am
+  - ./build/mvn test $MVN_ARGS -pl kyuubi-common -am
 
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - ./build/mvn --version
 
 script:
-  - ./build/mvn clean install -Dmaven.javadoc.skip=true -V
+  - ./build/mvn clean install -Dmaven.javadoc.skip=true -V -B -ntp
 
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,9 @@ install:
   - ./build/mvn --version
 
 script:
-  - ./build/mvn clean install -Dmaven.javadoc.skip=true -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn
+  - export MVN_ARGS="-Dmaven.javadoc.skip=true -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
+  - ./build/mvn clean install -DskipTests $MVN_ARGS
+# - ./build/mvn test $MVN_ARGS
 
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
   - ./build/mvn --version
 
 script:
-  - ./build/mvn clean install -Dmaven.javadoc.skip=true -V -B -ntp
+  - ./build/mvn clean install -Dmaven.javadoc.skip=true -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn
 
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"


### PR DESCRIPTION

### _Why are the changes needed?_

More and more software development is being done on ARM64 CPU architecture.
It would be good if Kyuubi is being regularly tested on Linux ARM64 (aarch64).

### _How was this patch tested?_
- [X] An additional job is added to the TravisCI config. Now the build will be executed on both AMD64 and ARM64
