### PR TITLE
[KYUUBI #1931] `AbstractSession._lastIdleTime` should be reset in acquire method

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -58,6 +58,7 @@ abstract class AbstractSession(
     if (userAccess) {
       _lastAccessTime = System.currentTimeMillis
     }
+    _lastIdleTime = 0
   }
 
   private def release(userAccess: Boolean): Unit = {
@@ -66,8 +67,6 @@ abstract class AbstractSession(
     }
     if (opHandleSet.isEmpty) {
       _lastIdleTime = System.currentTimeMillis
-    } else {
-      _lastIdleTime = 0
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`AbstractSession._lastIdleTime` should be reset in acquire method.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request