### PR TITLE
[TEST] Fix EngineSecurityAccessorSuite

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/EngineSecurityAccessorSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/EngineSecurityAccessorSuite.scala
@@ -27,7 +27,7 @@ class EngineSecurityAccessorSuite extends KyuubiFunSuite {
     classOf[UserDefinedEngineSecuritySecretProvider].getCanonicalName)
 
   test("test encrypt/decrypt, issue token/auth token") {
-    Seq("AES/CBC/PKCS5PADDING", "AES/CTR/PKCS5PADDING").foreach { cipher =>
+    Seq("AES/CBC/PKCS5PADDING", "AES/CTR/NoPadding").foreach { cipher =>
       val newConf = conf.clone
       newConf.set(KyuubiConf.ENGINE_SECURITY_CRYPTO_CIPHER_TRANSFORMATION, cipher)
 


### PR DESCRIPTION
### _Why are the changes needed?_

Currently, the UT failed in AArch64 JDK-17 with

```
EngineSecurityAccessorSuite:
- test encrypt/decrypt, issue token/auth token *** FAILED ***
  java.security.NoSuchAlgorithmException: Cannot find any provider supporting AES/CTR/PKCS5PADDING
  at java.base/javax.crypto.Cipher.getInstance(Cipher.java:571)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessor.initializeForAuth(EngineSecurityAccessor.scala:43)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessor.<init>(EngineSecurityAccessor.scala:36)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessorSuite.$anonfun$new$2(EngineSecurityAccessorSuite.scala:34)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessorSuite.$anonfun$new$2$adapted(EngineSecurityAccessorSuite.scala:30)
  at scala.collection.immutable.List.foreach(List.scala:431)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessorSuite.$anonfun$new$1(EngineSecurityAccessorSuite.scala:30)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
  at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
  at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
  ...
  Cause: javax.crypto.NoSuchPaddingException: CTR mode must be used with NoPadding
  at java.base/com.sun.crypto.provider.CipherCore.setPadding(CipherCore.java:300)
  at java.base/com.sun.crypto.provider.AESCipher.engineSetPadding(AESCipher.java:225)
  at java.base/javax.crypto.Cipher$Transform.setModePadding(Cipher.java:388)
  at java.base/javax.crypto.Cipher.getInstance(Cipher.java:564)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessor.initializeForAuth(EngineSecurityAccessor.scala:43)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessor.<init>(EngineSecurityAccessor.scala:36)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessorSuite.$anonfun$new$2(EngineSecurityAccessorSuite.scala:34)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessorSuite.$anonfun$new$2$adapted(EngineSecurityAccessorSuite.scala:30)
  at scala.collection.immutable.List.foreach(List.scala:431)
  at org.apache.kyuubi.service.authentication.EngineSecurityAccessorSuite.$anonfun$new$1(EngineSecurityAccessorSuite.scala:30)
  ...
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
