### PR TITLE
[BUILD] Remove spark-hadoop from matrix to simplify workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,18 +20,18 @@ jobs:
         include:
           - java: 8
             spark: '3.0'
-            profiles: "-Pspark-hadoop-2.7"
+            profiles: -Pspark-hadoop-2.7
           - java: 8
             spark: '3.1'
           - java: 8
             spark: '3.2'
-            profiles:
+            profiles: >-
               -Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.0.3
               -Dspark.archive.name=spark-3.0.3-bin-hadoop2.7.tgz
               -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest
           - java: 8
             spark: '3.2'
-            profiles:
+            profiles: >-
               -Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.1.2
               -Dspark.archive.name=spark-3.1.2-bin-hadoop3.2.tgz
               -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest
@@ -40,7 +40,7 @@ jobs:
             codecov: 'true'
           - java: 11
             spark: '3.2'
-            profiles: '-DskipTests -Pflink-provided,spark-provided'
+            profiles: -DskipTests -Pflink-provided,spark-provided
 
     env:
       SPARK_LOCAL_IP: localhost

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,15 +26,15 @@ jobs:
           - java: 8
             spark: '3.2'
             profiles:
-              - -Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.0.3
-              - -Dspark.archive.name=spark-3.0.3-bin-hadoop2.7.tgz
-              - -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest
+              -Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.0.3
+              -Dspark.archive.name=spark-3.0.3-bin-hadoop2.7.tgz
+              -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest
           - java: 8
             spark: '3.2'
             profiles:
-              - -Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.1.2
-              - -Dspark.archive.name=spark-3.1.2-bin-hadoop3.2.tgz
-              - -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest
+              -Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.1.2
+              -Dspark.archive.name=spark-3.1.2-bin-hadoop3.2.tgz
+              -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest
           - java: 8
             spark: '3.2'
             codecov: 'true'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,25 +20,21 @@ jobs:
         include:
           - java: 8
             spark: '3.0'
-            spark-hadoop: '2.7'
+            profiles: "-Pspark-hadoop-2.7"
           - java: 8
             spark: '3.1'
             spark-hadoop: '3.2'
           - java: 8
             spark: '3.2'
-            spark-hadoop: '2.7'
             profiles: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.0.3 -Dspark.archive.name=spark-3.0.3-bin-hadoop2.7.tgz -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
           - java: 8
             spark: '3.2'
-            spark-hadoop: '3.2'
             profiles: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.1.2 -Dspark.archive.name=spark-3.1.2-bin-hadoop3.2.tgz -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
           - java: 8
             spark: '3.2'
-            spark-hadoop: '3.2'
             codecov: 'true'
           - java: 11
             spark: '3.2'
-            spark-hadoop: '3.2'
             profiles: '-DskipTests -Pflink-provided,spark-provided'
 
     env:
@@ -79,7 +75,7 @@ jobs:
       - name: Build with Maven
         run: >-
           ./build/mvn clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -V
-          -Pspark-${{ matrix.spark }} -Pspark-hadoop-${{ matrix.spark-hadoop }} ${{ matrix.profiles }}
+          -Pspark-${{ matrix.spark }} ${{ matrix.profiles }}
       - name: Code coverage
         if: ${{ matrix.codecov == 'true' }}
         uses: codecov/codecov-action@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -23,7 +23,6 @@ jobs:
             profiles: "-Pspark-hadoop-2.7"
           - java: 8
             spark: '3.1'
-            spark-hadoop: '3.2'
           - java: 8
             spark: '3.2'
             profiles: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.0.3 -Dspark.archive.name=spark-3.0.3-bin-hadoop2.7.tgz -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,10 +25,16 @@ jobs:
             spark: '3.1'
           - java: 8
             spark: '3.2'
-            profiles: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.0.3 -Dspark.archive.name=spark-3.0.3-bin-hadoop2.7.tgz -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
+            profiles:
+              - -Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.0.3
+              - -Dspark.archive.name=spark-3.0.3-bin-hadoop2.7.tgz
+              - -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest
           - java: 8
             spark: '3.2'
-            profiles: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.1.2 -Dspark.archive.name=spark-3.1.2-bin-hadoop3.2.tgz -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
+            profiles:
+              - -Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.1.2
+              - -Dspark.archive.name=spark-3.1.2-bin-hadoop3.2.tgz
+              - -Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest
           - java: 8
             spark: '3.2'
             codecov: 'true'


### PR DESCRIPTION
### _Why are the changes needed?_

Remove `spark-hadoop` from matrix to simplify workflow

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
