### PR TITLE
[KYUUBI #1992] Remove SPARK_HOME predication.

### DIFF
--- a/bin/kyuubi
+++ b/bin/kyuubi
@@ -74,19 +74,6 @@ if [[ -z ${JAVA_HOME} ]]; then
   exit 1
 fi
 
-if [[ -z ${SPARK_HOME} ]]; then
-  echo "Error: SPARK_HOME IS NOT SET! CANNOT PROCEED." >&2
-  exit 1
-elif [[ ! -d ${SPARK_HOME} ]]; then
-  echo "Error: SPARK_HOME[${SPARK_HOME}] DOES NOT EXIST! CANNOT PROCEED." >&2
-  exit 1
-else
-  if [[ ! -x "${SPARK_HOME}/bin/spark-submit" ]]; then
-    echo "Error: INVALID SPARK DISTRIBUTION! CANNOT PROCEED." >&2
-    exit 1
-  fi
-fi
-
 RUNNER="${JAVA_HOME}/bin/java"
 
 ## Find the Kyuubi Jar


### PR DESCRIPTION
### _Why are the changes needed?_

Users who use Flink or Trino need not set SPARK_HOME, so I remove SPARK_HOME predication in bin/kyuubi script.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
