### PR TITLE
Clean up log4j2 conf and enhance surefire plugin conf

### DIFF
--- a/conf/log4j2.properties.template
+++ b/conf/log4j2.properties.template
@@ -25,17 +25,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = info
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = info
 
 # Set the default kyuubi-ctl log level to WARN. When running the kyuubi-ctl, the
 # log level for this class is used to overwrite the root logger's log level.

--- a/dev/kyuubi-extension-spark-3-1/src/test/resources/log4j2-test.properties
+++ b/dev/kyuubi-extension-spark-3-1/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/dev/kyuubi-extension-spark-3-2/src/test/resources/log4j2-test.properties
+++ b/dev/kyuubi-extension-spark-3-2/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/dev/kyuubi-extension-spark-common/src/test/resources/log4j2-test.properties
+++ b/dev/kyuubi-extension-spark-common/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -407,17 +407,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = info
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = info
 
 # Set the default kyuubi-ctl log level to WARN. When running the kyuubi-ctl, the
 # log level for this class is used to overwrite the root logger's log level.

--- a/externals/kyuubi-flink-sql-engine/src/test/resources/log4j2-test.properties
+++ b/externals/kyuubi-flink-sql-engine/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/externals/kyuubi-spark-sql-engine/src/test/resources/log4j2-test.properties
+++ b/externals/kyuubi-spark-sql-engine/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/externals/kyuubi-trino-engine/src/test/resources/log4j2-test.properties
+++ b/externals/kyuubi-trino-engine/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/integration-tests/kyuubi-flink-it/src/test/resources/log4j2-test.properties
+++ b/integration-tests/kyuubi-flink-it/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/integration-tests/kyuubi-kubernetes-deployment-it/src/test/resources/log4j2-test.properties
+++ b/integration-tests/kyuubi-kubernetes-deployment-it/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to INFO
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = info
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = info

--- a/kyuubi-common/src/main/resources/log4j-defaults.properties
+++ b/kyuubi-common/src/main/resources/log4j-defaults.properties
@@ -21,12 +21,3 @@ log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{2}: %m%n
-
-# SPARK-34128: Suppress undesirable TTransportException warnings involved in THRIFT-4805
-log4j.appender.CA.filter.1=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.CA.filter.1.StringToMatch=Thrift error occurred during processing of message
-log4j.appender.CA.filter.1.AcceptOnMatch=false
-
-log4j.appender.FA.filter.1=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.FA.filter.1.StringToMatch=Thrift error occurred during processing of message
-log4j.appender.FA.filter.1.AcceptOnMatch=false

--- a/kyuubi-common/src/main/resources/log4j2-defaults.properties
+++ b/kyuubi-common/src/main/resources/log4j2-defaults.properties
@@ -25,14 +25,5 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = info
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = info

--- a/kyuubi-common/src/test/resources/log4j2-test.properties
+++ b/kyuubi-common/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/kyuubi-ctl/src/test/resources/log4j2-test.properties
+++ b/kyuubi-ctl/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/kyuubi-ha/src/test/resources/log4j2-test.properties
+++ b/kyuubi-ha/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/kyuubi-hive-jdbc/pom.xml
+++ b/kyuubi-hive-jdbc/pom.xml
@@ -241,6 +241,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/Test*.java</include>
+                        <include>**/*Test.java</include>
+                    </includes>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/kyuubi-hive-jdbc/pom.xml
+++ b/kyuubi-hive-jdbc/pom.xml
@@ -243,10 +243,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skipTests>false</skipTests>
-                    <includes>
-                        <include>**/Test*.java</include>
-                        <include>**/*Test.java</include>
-                    </includes>
                 </configuration>
             </plugin>
 

--- a/kyuubi-hive-jdbc/pom.xml
+++ b/kyuubi-hive-jdbc/pom.xml
@@ -242,6 +242,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
+                    <skipTests>false</skipTests>
                     <includes>
                         <include>**/Test*.java</include>
                         <include>**/*Test.java</include>

--- a/kyuubi-metrics/src/test/resources/log4j2-test.properties
+++ b/kyuubi-metrics/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/kyuubi-server/src/test/resources/log4j2-test.properties
+++ b/kyuubi-server/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to INFO
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = info
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = info

--- a/kyuubi-zookeeper/src/test/resources/log4j2-test.properties
+++ b/kyuubi-zookeeper/src/test/resources/log4j2-test.properties
@@ -26,17 +26,8 @@ appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
-
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.a.type = ThresholdFilter
+appender.console.filter.a.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -44,14 +35,6 @@ appender.file.name = File
 appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
-
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.a.type = ThresholdFilter
+appender.file.filter.a.level = debug

--- a/pom.xml
+++ b/pom.xml
@@ -1470,6 +1470,7 @@
                     <version>${maven.plugin.surefire.version}</version>
                     <configuration>
                         <skipTests>true</skipTests>
+                        <failIfNoTests>false</failIfNoTests>
                     </configuration>
                 </plugin>
                 <!-- enable scalatest -->

--- a/pom.xml
+++ b/pom.xml
@@ -1469,13 +1469,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.plugin.surefire.version}</version>
                     <configuration>
-                        <includes>
-                            <include>**/Test*.java</include>
-                            <include>**/*Test.java</include>
-                            <include>**/*TestCase.java</include>
-                            <include>**/*Suite.java</include>
-                        </includes>
-                        <failIfNoTests>false</failIfNoTests>
+                        <skipTests>true</skipTests>
                     </configuration>
                 </plugin>
                 <!-- enable scalatest -->


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

[THRIFT-4805](https://issues.apache.org/jira/browse/THRIFT-4805) has been fixed in thrift 0.13.0, we can remove the workaround of log4j2 configurations because we use thrift 0.16.0 now, the change also removes the following warnings.

```
2022-03-01 23:18:16,530 main ERROR Filters contains invalid attributes "onMatch", "onMismatch"
2022-03-01 23:18:16,543 main ERROR Filters contains invalid attributes "onMatch", "onMismatch"
```

`maven-surefire-plugin` is only used in `kyuubi-hive-jdbc`, we should disable it in other modules.

```
[INFO] --- maven-surefire-plugin:2.22.0:test (default-test) @ kyuubi-ctl_2.12 ---
[INFO]
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
2022-03-01 23:18:16,530 main ERROR Filters contains invalid attributes "onMatch", "onMismatch"
2022-03-01 23:18:16,543 main ERROR Filters contains invalid attributes "onMatch", "onMismatch"
[INFO] Running org.apache.kyuubi.ctl.ServiceControlCliSuite
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.031 s - in org.apache.kyuubi.ctl.ServiceControlCliSuite
[INFO] Running org.apache.kyuubi.ctl.ServiceControlCliArgumentsSuite
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0 s - in org.apache.kyuubi.ctl.ServiceControlCliArgumentsSuite
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
