### PR TITLE
[KYUUBI #2006] Improve the readability of ServiceControl list/get operations

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/CommandLineUtils.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/CommandLineUtils.scala
@@ -89,6 +89,9 @@ private[kyuubi] object Tabulator {
     for (row <- data) {
       for ((cell, i) <- row.zipWithIndex) {
         colWidths(i) = math.max(colWidths(i), stringHalfWidth(cell))
+        if (!verbose) {
+          colWidths(i) += 1
+        }
       }
     }
 


### PR DESCRIPTION

### _Why are the changes needed?_
When the get server and list server commands are displayed, when the namespace exceeds the minimum width, it will be glued to the hostname.

Add a space beyond the minimum cell width in non-verbose mode.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
