### PR TITLE
[KYUUBI #2012] rename EventLoggingService and creates an correct directory

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -33,7 +33,7 @@ import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_ENGINE_SUBMIT_TIME_KEY
 import org.apache.kyuubi.engine.spark.SparkSQLEngine.{countDownLatch, currentEngine}
-import org.apache.kyuubi.engine.spark.events.{EngineEvent, EngineEventsStore, EventLoggingService}
+import org.apache.kyuubi.engine.spark.events.{EngineEvent, EngineEventsStore, SparkEventLoggingService}
 import org.apache.kyuubi.events.EventLogging
 import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.ha.client.RetryPolicies
@@ -141,7 +141,7 @@ object SparkSQLEngine extends Logging {
     currentEngine = Some(new SparkSQLEngine(spark))
     currentEngine.foreach { engine =>
       // start event logging ahead so that we can capture all statuses
-      val eventLogging = new EventLoggingService(spark.sparkContext)
+      val eventLogging = new SparkEventLoggingService(spark.sparkContext)
       try {
         eventLogging.initialize(kyuubiConf)
         eventLogging.start()

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkEventLoggingService.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkEventLoggingService.scala
@@ -15,30 +15,29 @@
  * limitations under the License.
  */
 
-package org.apache.kyuubi.server
+package org.apache.kyuubi.engine.spark.events
 
-import java.net.InetAddress
+import org.apache.spark.SparkContext
+import org.apache.spark.kyuubi.SparkContextHelper
 
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.{SERVER_EVENT_JSON_LOG_PATH, SERVER_EVENT_LOGGERS}
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_JSON_LOG_PATH, ENGINE_EVENT_LOGGERS}
 import org.apache.kyuubi.events.{AbstractEventLoggingService, EventLoggerType, JsonEventLogger}
-import org.apache.kyuubi.util.KyuubiHadoopUtils
 
-class EventLoggingService extends AbstractEventLoggingService {
+class SparkEventLoggingService(spark: SparkContext)
+  extends AbstractEventLoggingService {
 
-  override def initialize(conf: KyuubiConf): Unit = {
-    val hadoopConf = KyuubiHadoopUtils.newHadoopConf(conf)
-    conf.get(SERVER_EVENT_LOGGERS)
+  override def initialize(conf: KyuubiConf): Unit = synchronized {
+    conf.get(ENGINE_EVENT_LOGGERS)
       .map(EventLoggerType.withName)
       .foreach {
+        case EventLoggerType.SPARK =>
+          addEventLogger(SparkContextHelper.createSparkHistoryLogger(spark))
         case EventLoggerType.JSON =>
-          val hostName = InetAddress.getLocalHost.getCanonicalHostName
           val jsonEventLogger = new JsonEventLogger(
-            s"server-$hostName",
-            SERVER_EVENT_JSON_LOG_PATH,
-            hadoopConf)
-          // TODO: #1180 kyuubiServerEvent need create logRoot automatically
-          jsonEventLogger.createEventLogRootDir(conf, hadoopConf)
+            spark.applicationAttemptId.getOrElse(spark.applicationId),
+            ENGINE_EVENT_JSON_LOG_PATH,
+            spark.hadoopConfiguration)
           addService(jsonEventLogger)
           addEventLogger(jsonEventLogger)
         case logger =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkEventLoggingService.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkEventLoggingService.scala
@@ -38,6 +38,7 @@ class SparkEventLoggingService(spark: SparkContext)
             spark.applicationAttemptId.getOrElse(spark.applicationId),
             ENGINE_EVENT_JSON_LOG_PATH,
             spark.hadoopConfiguration)
+          jsonEventLogger.createEventLogRootDir(conf, spark.hadoopConfiguration)
           addService(jsonEventLogger)
           addEventLogger(jsonEventLogger)
         case logger =>

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/events/SparkEventLoggingServiceSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/events/SparkEventLoggingServiceSuite.scala
@@ -32,7 +32,7 @@ import org.apache.kyuubi.events.EventLoggerType._
 import org.apache.kyuubi.events.JsonProtocol
 import org.apache.kyuubi.operation.{HiveJDBCTestHelper, OperationHandle}
 
-class EventLoggingServiceSuite extends WithSparkSQLEngine with HiveJDBCTestHelper {
+class SparkEventLoggingServiceSuite extends WithSparkSQLEngine with HiveJDBCTestHelper {
 
   private val logRoot = "file://" + Utils.createTempDir().toString
   private val currentDate = Utils.getDateFromTimestamp(System.currentTimeMillis())

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/events/JsonEventLogger.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/events/JsonEventLogger.scala
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.permission.FsPermission
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.{ConfigEntry, KyuubiConf}
-import org.apache.kyuubi.config.KyuubiConf.ENGINE_EVENT_JSON_LOG_PATH
+import org.apache.kyuubi.config.KyuubiConf.{SERVER_EVENT_JSON_LOG_PATH}
 import org.apache.kyuubi.events.JsonEventLogger._
 import org.apache.kyuubi.service.AbstractService
 
@@ -116,7 +116,7 @@ class JsonEventLogger(
 
   // This method is only called by kyuubiServer
   def createEventLogRootDir(conf: KyuubiConf, hadoopConf: Configuration): Unit = {
-    val logRoot: URI = URI.create(conf.get(ENGINE_EVENT_JSON_LOG_PATH))
+    val logRoot: URI = URI.create(conf.get(SERVER_EVENT_JSON_LOG_PATH))
     val fs: FileSystem = FileSystem.get(logRoot, hadoopConf)
     val success: Boolean = FileSystem.mkdirs(fs, new Path(logRoot), JSON_LOG_DIR_PERM)
     if (!success) {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/events/JsonEventLogger.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/events/JsonEventLogger.scala
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.permission.FsPermission
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.{ConfigEntry, KyuubiConf}
-import org.apache.kyuubi.config.KyuubiConf.{SERVER_EVENT_JSON_LOG_PATH}
+import org.apache.kyuubi.config.KyuubiConf.SERVER_EVENT_JSON_LOG_PATH
 import org.apache.kyuubi.events.JsonEventLogger._
 import org.apache.kyuubi.service.AbstractService
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/events/JsonEventLogger.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/events/JsonEventLogger.scala
@@ -29,7 +29,6 @@ import org.apache.hadoop.fs.permission.FsPermission
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.{ConfigEntry, KyuubiConf}
-import org.apache.kyuubi.config.KyuubiConf.SERVER_EVENT_JSON_LOG_PATH
 import org.apache.kyuubi.events.JsonEventLogger._
 import org.apache.kyuubi.service.AbstractService
 
@@ -114,9 +113,8 @@ class JsonEventLogger(
     stream.foreach(_.hflush())
   }
 
-  // This method is only called by kyuubiServer
   def createEventLogRootDir(conf: KyuubiConf, hadoopConf: Configuration): Unit = {
-    val logRoot: URI = URI.create(conf.get(SERVER_EVENT_JSON_LOG_PATH))
+    val logRoot: URI = URI.create(conf.get(logPath))
     val fs: FileSystem = FileSystem.get(logRoot, hadoopConf)
     val success: Boolean = FileSystem.mkdirs(fs, new Path(logRoot), JSON_LOG_DIR_PERM)
     if (!success) {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiEventLoggingService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiEventLoggingService.scala
@@ -37,7 +37,7 @@ class KyuubiEventLoggingService extends AbstractEventLoggingService {
             s"server-$hostName",
             SERVER_EVENT_JSON_LOG_PATH,
             hadoopConf)
-          // TODO: #1180 kyuubiServerEvent need create logRoot automatically
+
           jsonEventLogger.createEventLogRootDir(conf, hadoopConf)
           addService(jsonEventLogger)
           addEventLogger(jsonEventLogger)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiServer.scala
@@ -154,7 +154,7 @@ class KyuubiServer(name: String) extends Serverable(name) {
         throw new UnsupportedOperationException(s"Frontend protocol $other is not supported yet.")
     }
 
-  private val eventLoggingService = new EventLoggingService()
+  private val eventLoggingService = new KyuubiEventLoggingService()
 
   override def initialize(conf: KyuubiConf): Unit = synchronized {
     val kinit = new KinitAuxiliaryService()

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/events/KyuubiEventLoggingServiceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/events/KyuubiEventLoggingServiceSuite.scala
@@ -34,7 +34,7 @@ import org.apache.kyuubi.operation.OperationState._
 import org.apache.kyuubi.server.KyuubiServer
 import org.apache.kyuubi.service.ServiceState
 
-class EventLoggingServiceSuite extends WithKyuubiServer with HiveJDBCTestHelper {
+class KyuubiEventLoggingServiceSuite extends WithKyuubiServer with HiveJDBCTestHelper {
 
   private val engineLogRoot = "file://" + Utils.createTempDir().toString
   private val serverLogRoot = "file://" + Utils.createTempDir().toString


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix #2012 #1180 

In `EventLoggingService`, when `EventLoggerType` is set to `JSON`
Kyuubi creates an error directory, it should not be the `ENGINE_EVENT_JSON_LOG_PATH` but the `SERVER_EVENT_JSON_LOG_PATH`.
<img width="557" alt="微信图片_20220304165614" src="https://user-images.githubusercontent.com/14961757/156771039-e18fcdbe-8b99-4190-9b14-6953daa55e5f.png">
<img width="605" alt="微信图片_20220304165633" src="https://user-images.githubusercontent.com/14961757/156771053-defdee62-67f9-4f16-9d4a-8ef170304221.png">

rename `EventLoggingService` in `kyuubi-server` to `KyuubiEventLoggingService`
rename `EventLoggingService`  in `kyuubi-spark-sql-engine` to `SparkEventLoggingService`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
