### PR TITLE
[KYUUI #2036] Redirect Issues/PR Notifications to notifications@kyuubi.apache.org

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -42,5 +42,5 @@ github:
     projects: false
 notifications:
   commits: commits@kyuubi.apache.org
-  issues: dev@kyuubi.apache.org
-  pullrequests: commits@kyuubi.apache.org
+  issues: notifications@kyuubi.apache.org
+  pullrequests: notifications@kyuubi.apache.org


### PR DESCRIPTION


### _Why are the changes needed?_

Update `.asf.yaml` to redirect Issues/PR Notifications to notifications@kyuubi.apache.org


### _How was this patch tested?_

No test needed
