### PR TITLE
Using separate date time formatter for each toTRowSet opeartion

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
@@ -221,13 +221,13 @@ object RowSet {
         "null"
 
       case (d: Date, DateType) =>
-        timeFormatters.date.format(d.toInstant)
+        timeFormatters.simpleDate.format(d)
 
       case (ld: LocalDate, DateType) =>
         timeFormatters.date.format(ld)
 
       case (t: Timestamp, TimestampType) =>
-        timeFormatters.timestamp.format(t.toInstant)
+        timeFormatters.simpleTimestamp.format(t)
 
       case (i: Instant, TimestampType) =>
         timeFormatters.timestamp.withZone(timeZone).format(i)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/schema/RowSetSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/schema/RowSetSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
 
 import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.engine.spark.schema.RowSet.toHiveString
+import org.apache.kyuubi.util.RowSetUtils._
 
 class RowSetSuite extends KyuubiFunSuite {
 
@@ -167,14 +168,20 @@ class RowSetSuite extends KyuubiFunSuite {
     dateCol.getValues.asScala.zipWithIndex.foreach {
       case (b, 11) => assert(b.isEmpty)
       case (b, i) =>
-        assert(b === toHiveString((Date.valueOf(s"2018-11-${i + 1}"), DateType), zoneId))
+        assert(b === toHiveString(
+          (Date.valueOf(s"2018-11-${i + 1}"), DateType),
+          zoneId,
+          getTimeFormatters))
     }
 
     val tsCol = cols.next().getStringVal
     tsCol.getValues.asScala.zipWithIndex.foreach {
       case (b, 11) => assert(b.isEmpty)
       case (b, i) => assert(b ===
-          toHiveString((Timestamp.valueOf(s"2018-11-17 13:33:33.$i"), TimestampType), zoneId))
+          toHiveString(
+            (Timestamp.valueOf(s"2018-11-17 13:33:33.$i"), TimestampType),
+            zoneId,
+            getTimeFormatters))
     }
 
     val binCol = cols.next().getBinaryVal
@@ -188,7 +195,8 @@ class RowSetSuite extends KyuubiFunSuite {
       case (b, 11) => assert(b === "")
       case (b, i) => assert(b === toHiveString(
           (Array.fill(i)(java.lang.Double.valueOf(s"$i.$i")).toSeq, ArrayType(DoubleType)),
-          zoneId))
+          zoneId,
+          getTimeFormatters))
     }
 
     val mapCol = cols.next().getStringVal
@@ -196,7 +204,8 @@ class RowSetSuite extends KyuubiFunSuite {
       case (b, 11) => assert(b === "")
       case (b, i) => assert(b === toHiveString(
           (Map(i -> java.lang.Double.valueOf(s"$i.$i")), MapType(IntegerType, DoubleType)),
-          zoneId))
+          zoneId,
+          getTimeFormatters))
     }
 
     val intervalCol = cols.next().getStringVal
@@ -245,7 +254,7 @@ class RowSetSuite extends KyuubiFunSuite {
     val r8 = iter.next().getColVals
     assert(r8.get(12).getStringVal.getValue === Array.fill(7)(7.7d).mkString("[", ",", "]"))
     assert(r8.get(13).getStringVal.getValue ===
-      toHiveString((Map(7 -> 7.7d), MapType(IntegerType, DoubleType)), zoneId))
+      toHiveString((Map(7 -> 7.7d), MapType(IntegerType, DoubleType)), zoneId, getTimeFormatters))
 
     val r9 = iter.next().getColVals
     assert(r9.get(14).getStringVal.getValue === new CalendarInterval(8, 8, 8).toString)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/schema/RowSetSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/schema/RowSetSuite.scala
@@ -31,7 +31,7 @@ import org.apache.spark.unsafe.types.CalendarInterval
 
 import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.engine.spark.schema.RowSet.toHiveString
-import org.apache.kyuubi.util.RowSetUtils._
+import org.apache.kyuubi.util.DateTimeFormatter
 
 class RowSetSuite extends KyuubiFunSuite {
 
@@ -171,7 +171,7 @@ class RowSetSuite extends KyuubiFunSuite {
         assert(b === toHiveString(
           (Date.valueOf(s"2018-11-${i + 1}"), DateType),
           zoneId,
-          getTimeFormatters))
+          new DateTimeFormatter))
     }
 
     val tsCol = cols.next().getStringVal
@@ -181,7 +181,7 @@ class RowSetSuite extends KyuubiFunSuite {
           toHiveString(
             (Timestamp.valueOf(s"2018-11-17 13:33:33.$i"), TimestampType),
             zoneId,
-            getTimeFormatters))
+            new DateTimeFormatter))
     }
 
     val binCol = cols.next().getBinaryVal
@@ -196,7 +196,7 @@ class RowSetSuite extends KyuubiFunSuite {
       case (b, i) => assert(b === toHiveString(
           (Array.fill(i)(java.lang.Double.valueOf(s"$i.$i")).toSeq, ArrayType(DoubleType)),
           zoneId,
-          getTimeFormatters))
+          new DateTimeFormatter))
     }
 
     val mapCol = cols.next().getStringVal
@@ -205,7 +205,7 @@ class RowSetSuite extends KyuubiFunSuite {
       case (b, i) => assert(b === toHiveString(
           (Map(i -> java.lang.Double.valueOf(s"$i.$i")), MapType(IntegerType, DoubleType)),
           zoneId,
-          getTimeFormatters))
+          new DateTimeFormatter))
     }
 
     val intervalCol = cols.next().getStringVal
@@ -254,7 +254,10 @@ class RowSetSuite extends KyuubiFunSuite {
     val r8 = iter.next().getColVals
     assert(r8.get(12).getStringVal.getValue === Array.fill(7)(7.7d).mkString("[", ",", "]"))
     assert(r8.get(13).getStringVal.getValue ===
-      toHiveString((Map(7 -> 7.7d), MapType(IntegerType, DoubleType)), zoneId, getTimeFormatters))
+      toHiveString(
+        (Map(7 -> 7.7d), MapType(IntegerType, DoubleType)),
+        zoneId,
+        new DateTimeFormatter))
 
     val r9 = iter.next().getColVals
     assert(r9.get(14).getStringVal.getValue === new CalendarInterval(8, 8, 8).toString)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/DateTimeFormatter.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/DateTimeFormatter.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.util
+
+import java.sql.Timestamp
+import java.text.SimpleDateFormat
+import java.time.{Instant, LocalDate, LocalDateTime, ZoneId}
+import java.time.chrono.IsoChronology
+import java.time.format.DateTimeFormatterBuilder
+import java.time.temporal.ChronoField
+import java.util.{Date, Locale}
+
+class DateTimeFormatter {
+  private lazy val dateFormatter = {
+    createDateTimeFormatterBuilder().appendPattern("yyyy-MM-dd")
+      .toFormatter(Locale.US)
+      .withChronology(IsoChronology.INSTANCE)
+  }
+
+  private lazy val simpleDateFormatter = new SimpleDateFormat("yyyy-MM-dd", Locale.US)
+
+  private lazy val timestampFormatter = {
+    createDateTimeFormatterBuilder().appendPattern("yyyy-MM-dd HH:mm:ss")
+      .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
+      .toFormatter(Locale.US)
+      .withChronology(IsoChronology.INSTANCE)
+  }
+
+  private lazy val simpleTimestampFormatter = {
+    new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+  }
+
+  private def createDateTimeFormatterBuilder(): DateTimeFormatterBuilder = {
+    new DateTimeFormatterBuilder().parseCaseInsensitive()
+  }
+
+  def formatDate(d: Date): String = {
+    simpleDateFormatter.format(d)
+  }
+
+  def formatLocalDate(ld: LocalDate): String = {
+    dateFormatter.format(ld)
+  }
+
+  def formatLocalDateTime(ldt: LocalDateTime): String = {
+    timestampFormatter.format(ldt)
+  }
+
+  def formatInstant(i: Instant, timeZone: Option[ZoneId] = None): String = {
+    timeZone.map(timestampFormatter.withZone(_).format(i))
+      .getOrElse(timestampFormatter.format(i))
+  }
+
+  def formatTimestamp(t: Timestamp): String = {
+    simpleTimestampFormatter.format(t)
+  }
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/RowSetUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/RowSetUtils.scala
@@ -18,7 +18,6 @@
 package org.apache.kyuubi.util
 
 import java.nio.ByteBuffer
-import java.text.SimpleDateFormat
 import java.time.chrono.IsoChronology
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
@@ -28,24 +27,18 @@ import java.util.Locale
 import scala.language.implicitConversions
 
 private[kyuubi] object RowSetUtils {
+  case class TimeFormatters(date: DateTimeFormatter, timestamp: DateTimeFormatter)
 
-  lazy val dateFormatter = {
-    createDateTimeFormatterBuilder().appendPattern("yyyy-MM-dd")
+  def getTimeFormatters: TimeFormatters = {
+    val dateFormatter = createDateTimeFormatterBuilder().appendPattern("yyyy-MM-dd")
       .toFormatter(Locale.US)
       .withChronology(IsoChronology.INSTANCE)
-  }
 
-  lazy val simpleDateFormatter = new SimpleDateFormat("yyyy-MM-dd", Locale.US)
-
-  lazy val timestampFormatter: DateTimeFormatter = {
-    createDateTimeFormatterBuilder().appendPattern("yyyy-MM-dd HH:mm:ss")
+    val timestampFormatter = createDateTimeFormatterBuilder().appendPattern("yyyy-MM-dd HH:mm:ss")
       .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
       .toFormatter(Locale.US)
       .withChronology(IsoChronology.INSTANCE)
-  }
-
-  lazy val simpleTimestampFormatter = {
-    new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+    TimeFormatters(dateFormatter, timestampFormatter)
   }
 
   private def createDateTimeFormatterBuilder(): DateTimeFormatterBuilder = {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/RowSetUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/RowSetUtils.scala
@@ -18,6 +18,7 @@
 package org.apache.kyuubi.util
 
 import java.nio.ByteBuffer
+import java.text.SimpleDateFormat
 import java.time.chrono.IsoChronology
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
@@ -27,7 +28,11 @@ import java.util.Locale
 import scala.language.implicitConversions
 
 private[kyuubi] object RowSetUtils {
-  case class TimeFormatters(date: DateTimeFormatter, timestamp: DateTimeFormatter)
+  case class TimeFormatters(
+      date: DateTimeFormatter,
+      timestamp: DateTimeFormatter,
+      simpleDate: SimpleDateFormat,
+      simpleTimestamp: SimpleDateFormat)
 
   def getTimeFormatters: TimeFormatters = {
     val dateFormatter = createDateTimeFormatterBuilder().appendPattern("yyyy-MM-dd")
@@ -38,7 +43,11 @@ private[kyuubi] object RowSetUtils {
       .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
       .toFormatter(Locale.US)
       .withChronology(IsoChronology.INSTANCE)
-    TimeFormatters(dateFormatter, timestampFormatter)
+
+    val simpleDateFormatter = new SimpleDateFormat("yyyy-MM-dd", Locale.US)
+    val simpleTimestampFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
+
+    TimeFormatters(dateFormatter, timestampFormatter, simpleDateFormatter, simpleTimestampFormatter)
   }
 
   private def createDateTimeFormatterBuilder(): DateTimeFormatterBuilder = {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/RowSetUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/RowSetUtils.scala
@@ -18,41 +18,10 @@
 package org.apache.kyuubi.util
 
 import java.nio.ByteBuffer
-import java.text.SimpleDateFormat
-import java.time.chrono.IsoChronology
-import java.time.format.DateTimeFormatter
-import java.time.format.DateTimeFormatterBuilder
-import java.time.temporal.ChronoField
-import java.util.Locale
 
 import scala.language.implicitConversions
 
 private[kyuubi] object RowSetUtils {
-  case class TimeFormatters(
-      date: DateTimeFormatter,
-      timestamp: DateTimeFormatter,
-      simpleDate: SimpleDateFormat,
-      simpleTimestamp: SimpleDateFormat)
-
-  def getTimeFormatters: TimeFormatters = {
-    val dateFormatter = createDateTimeFormatterBuilder().appendPattern("yyyy-MM-dd")
-      .toFormatter(Locale.US)
-      .withChronology(IsoChronology.INSTANCE)
-
-    val timestampFormatter = createDateTimeFormatterBuilder().appendPattern("yyyy-MM-dd HH:mm:ss")
-      .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
-      .toFormatter(Locale.US)
-      .withChronology(IsoChronology.INSTANCE)
-
-    val simpleDateFormatter = new SimpleDateFormat("yyyy-MM-dd", Locale.US)
-    val simpleTimestampFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS", Locale.US)
-
-    TimeFormatters(dateFormatter, timestampFormatter, simpleDateFormatter, simpleTimestampFormatter)
-  }
-
-  private def createDateTimeFormatterBuilder(): DateTimeFormatterBuilder = {
-    new DateTimeFormatterBuilder().parseCaseInsensitive()
-  }
 
   implicit def bitSetToBuffer(bitSet: java.util.BitSet): ByteBuffer = {
     ByteBuffer.wrap(bitSet.toByteArray)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We meet below issue when fetching result.

```
Caused by: java.lang.RuntimeException: java.lang.ArrayIndexOutOfBoundsException:46
7022	at sun.util.calendar.BaseCalendar.getCalendarDateFromFixedDate(BaseCalendar.java:453)
7023	at java.util.GregorianCalendar.computeFields(GregorianCalendar.java:2397)
7024	at java.util.GregorianCalendar.computeFields(GregorianCalendar.java:2312)
7025	at java.util.Calendar.setTimeInMillis(Calendar.java:1804)
7026	at java.util.Calendar.setTime(Calendar.java:1770)
7027	at java.text.SimpleDateFormat.format(SimpleDateFormat.java:943)
7028	at java.text.SimpleDateFormat.format(SimpleDateFormat.java:936)
7029	at java.text.DateFormat.format(DateFormat.java:345)
7030	at org.apache.kyuubi.schema.RowSet$.toHiveString(RowSet.scala:245)
7031	at org.apache.kyuubi.schema.RowSet$.$anonfun$toTColumn$3(RowSet.scala:120)
7032	at scala.collection.immutable.List.map(List.scala:290)
7033	at org.apache.kyuubi.schema.RowSet$.toTColumn(RowSet.scala:115)
7034	at org.apache.kyuubi.schema.RowSet$.$anonfun$toColumnBasedSet$1(RowSet.scala:65)
7035	at org.apache.kyuubi.schema.RowSet$.$anonfun$toColumnBasedSet$1$adapted(RowSet.scala:64)
7036	at scala.collection.immutable.List.foreach(List.scala:392)
7037	at org.apache.kyuubi.schema.RowSet$.toColumnBasedSet(RowSet.scala:64)
7038	at org.apache.kyuubi.schema.RowSet$.toTRowSet(RowSet.scala:47)
7039	at org.apache.kyuubi.engine.spark.operation.SparkOperation.getNextRowSet(SparkOperation.scala:183)
7040	at org.apache.kyuubi.operation.OperationManager.getOperationNextRowSet(OperationManager.scala:116)
7041	at org.apache.kyuubi.session.AbstractSession.fetchResults(AbstractSession.scala:197)
7042	at org.apache.kyuubi.service.AbstractBackendService.fetchResults(AbstractBackendService.scala:169)
7043	at org.apache.kyuubi.service.ThriftBinaryFrontendService.FetchResults(ThriftBinaryFrontendService.scala:505)
```

The root cause is that the date time formatter used to convert the result to rowSet is not thread-safe.
In this pr, we use separate date time formatters for each toRowSet operation.

### _How was this patch tested?_
Existing UT.
