### PR TITLE
[KYUUBI #2078] `logCaptureThread` does not catch sparksubmit exception

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -148,14 +148,14 @@ trait ProcBuilder {
         val maxErrorSize = conf.get(KyuubiConf.ENGINE_ERROR_MAX_SIZE)
         while (true) {
           if (reader.ready()) {
-            var line: String = reader.readLine
-            if (containsIgnoreCase(line, "Exception:") &&
+            var line: String = reader.readLine.trim
+            if (containsException(line) &&
               !line.contains("at ") && !line.startsWith("Caused by:")) {
               val sb = new StringBuilder(line)
               error = KyuubiSQLException(sb.toString() + s"\n See more: $engineLog")
-              line = reader.readLine()
+              line = reader.readLine().trim
               while (sb.length < maxErrorSize && line != null &&
-                (containsIgnoreCase(line, "Exception:") ||
+                (containsException(line) ||
                   line.startsWith("\tat ") ||
                   line.startsWith("Caused by: "))) {
                 sb.append("\n" + line)
@@ -211,6 +211,9 @@ trait ProcBuilder {
       case other => other
     }
   }
+
+  private def containsException(log: String): Boolean =
+    containsIgnoreCase(log, "Exception:") || containsIgnoreCase(log, "Exception in thread")
 }
 
 object ProcBuilder extends Logging {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -94,6 +94,16 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper {
       assert(error1.getMessage.contains("See more: "))
       assert(!error1.getMessage.contains(msg), "stack trace shall be truncated")
     }
+
+    val pb3 =
+      new SparkProcessBuilder("kentyao", conf.set("spark.kerberos.principal", testPrincipal))
+    pb3.start
+    eventually(timeout(90.seconds), interval(500.milliseconds)) {
+      val error1 = pb3.getError
+      assert(!error1.getMessage.contains("Failed to detect the root cause"))
+      assert(error1.getMessage.contains("See more: "))
+      assert(error1.getMessage.contains("Exception in thread"))
+    }
   }
 
   test("proxy user or keytab") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`logCaptureThread` does not catch sparksubmit exception.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request