### PR TITLE
Remove useless logic about add conf when create a new engine

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -30,7 +30,7 @@ import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_MAIN_RESOURCE, FRONTEND_THRIFT_BINARY_BIND_HOST}
+import org.apache.kyuubi.config.KyuubiConf.ENGINE_SPARK_MAIN_RESOURCE
 import org.apache.kyuubi.engine.ProcBuilder
 import org.apache.kyuubi.ha.HighAvailabilityConf
 import org.apache.kyuubi.ha.client.ZooKeeperAuthTypes
@@ -132,20 +132,6 @@ class SparkProcessBuilder(
         }
       buffer += CONF
       buffer += s"$newKey=$v"
-    }
-
-    /**
-     * Kyuubi respect user setting config, if user set `spark.driver.host`, will pass it on.
-     * If user don't set this, will use thrift binary bind host to set.
-     * Kyuubi wants the Engine to bind hostName or IP with Kyuubi.
-     * Spark driver will pass this configuration as the driver-url to the executors
-     * to build RPC communication.
-     */
-    if (!allConf.contains("spark.driver.host")) {
-      conf.get(FRONTEND_THRIFT_BINARY_BIND_HOST).foreach(host => {
-        buffer += CONF
-        buffer += s"spark.driver.host=${host}"
-      })
     }
 
     // iff the keytab is specified, PROXY_USER is not supported

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -26,7 +26,7 @@ import org.scalatest.time.SpanSugar._
 
 import org.apache.kyuubi.{KerberizedTestHelper, KyuubiSQLException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.{ENGINE_LOG_TIMEOUT, ENGINE_SPARK_MAIN_RESOURCE, FRONTEND_THRIFT_BINARY_BIND_HOST}
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_LOG_TIMEOUT, ENGINE_SPARK_MAIN_RESOURCE}
 import org.apache.kyuubi.ha.HighAvailabilityConf
 import org.apache.kyuubi.ha.client.ZooKeeperAuthTypes
 import org.apache.kyuubi.service.ServiceUtils
@@ -270,26 +270,6 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper {
     val b1 = new SparkProcessBuilder("test", conf)
     assert(b1.toString.contains(s"--conf spark.files=$testKeytab"))
 
-  }
-
-  test("engine bind on host name or IP with Kyuubi") {
-    val conf = KyuubiConf()
-    conf.set(FRONTEND_THRIFT_BINARY_BIND_HOST.key, "kyuubi-example")
-
-    val builder = new SparkProcessBuilder("test", conf)
-    assert(builder.toString.contains("--conf spark.driver.host=kyuubi-example"))
-  }
-
-  test("respect to user set config") {
-    val conf = KyuubiConf()
-    conf.set(FRONTEND_THRIFT_BINARY_BIND_HOST.key, "kyuubi-example")
-    conf.set("spark.driver.host", "spark-example")
-
-    val builder = new SparkProcessBuilder("test", conf)
-    assertResult(false) {
-      builder.toString.contains("--conf spark.driver.host=kyuubi-example")
-    }
-    assert(builder.toString.contains("--conf spark.driver.host=spark-example"))
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Remove useless logic about add conf when create a new engine
This code worked before commit [575e9c95999d70ac88e8ee0bdd3b58bc016bc934] which unset `FRONTEND_THRIFT_BINARY_BIND_HOST` when copy conf.

The code which removed in this PR, only help kyuubi on k8s with spark client mode. Can be replace by set `spark.driver.host`.
Considering this approach is not recommended, so remove this code in this PR.

### _How was this patch tested?_
- [X] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
