### PR TITLE
[KYUUBI #2112]  Improve the compatibility of queryTimeout in more version clients

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -809,6 +809,20 @@ object KyuubiConf {
       .checkValue(_ >= 1000, "must >= 1s if set")
       .createOptional
 
+  val OPERATION_QUERY_TIMEOUT_COMPATIBLE_STATE: ConfigEntry[Boolean] =
+    buildConf("operation.query.timeout.compatible.state")
+      .doc("Clients less than version 2.1 have no HIVE-4924 Patch, " +
+        "no queryTimeout parameter and no TIMEOUT status. " +
+        s"When the server enables ${OPERATION_QUERY_TIMEOUT.key}, " +
+        s"this will cause the client of the lower version to get stuck." +
+        s"when true, regardless of the version of the client, " +
+        s"the queryTimeout parameter is not set, " +
+        s"and the TIMEOUT state is converted to CANCELED. " +
+        s"If queryTimeout is set, the TIMEOUT state is still maintained.")
+      .version("1.6.0")
+      .booleanConf
+      .createWithDefault(false)
+
   val OPERATION_INCREMENTAL_COLLECT: ConfigEntry[Boolean] =
     buildConf("operation.incremental.collect")
       .internal


### PR DESCRIPTION
### _Why are the changes needed?_
https://github.com/apache/incubator-kyuubi/issues/2112

Clients less than version 2.1 have no [HIVE-4924](https://issues.apache.org/jira/browse/HIVE-4924) Patch, no queryTimeout parameter and no TIMEOUT status. When the server enables kyuubi.operation.query.timeout, this will cause the client of the lower version to get stuck.

Introduce a parameter, when it is turned on, no matter what the version of the client is, the queryTimeout parameter is not set, and the TIMEOUT state is converted to CANCELED. If queryTimeout is set, the TIMEOUT state is still maintained.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
