### PR TITLE
[KYUUBI #2123] Output engine information after openEngineSession call fails

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -106,8 +106,10 @@ class KyuubiSessionImpl(
         _engineSessionHandle = _client.openSession(protocol, user, passwd, optimizedConf)
       } catch {
         case e: Throwable =>
-          error(s"Opening engine [${engine.defaultEngineName} $host:$port]" +
-            s" for $user session failed", e)
+          error(
+            s"Opening engine [${engine.defaultEngineName} $host:$port]" +
+              s" for $user session failed",
+            e)
           throw e
       }
       logSessionInfo(s"Connected to engine [$host:$port] with ${_engineSessionHandle}")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -101,8 +101,15 @@ class KyuubiSessionImpl(
         } else {
           Option(password).filter(_.nonEmpty).getOrElse("anonymous")
         }
-      _client = KyuubiSyncThriftClient.createClient(user, passwd, host, port, sessionConf)
-      _engineSessionHandle = _client.openSession(protocol, user, passwd, optimizedConf)
+      try {
+        _client = KyuubiSyncThriftClient.createClient(user, passwd, host, port, sessionConf)
+        _engineSessionHandle = _client.openSession(protocol, user, passwd, optimizedConf)
+      } catch {
+        case e: Throwable =>
+          error(s"Opening engine [${engine.defaultEngineName} $host:$port]" +
+            s" for $user session failed", e)
+          throw e
+      }
       logSessionInfo(s"Connected to engine [$host:$port] with ${_engineSessionHandle}")
       sessionEvent.openedTime = System.currentTimeMillis()
       sessionEvent.remoteSessionId = _engineSessionHandle.identifier.toString


### PR DESCRIPTION
### _Why are the changes needed?_
https://github.com/apache/incubator-kyuubi/issues/2123

Now after the openEngineSession call fails, there is no engine information output, and it is more difficult to know which engine has the problem in pool mode.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
