### PR TITLE
[KYUUBI #2125] closeSession should avoid sending RPC after openSession fails

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -79,10 +79,12 @@ class KyuubiSyncThriftClient private (protocol: TProtocol)
   }
 
   def closeSession(): Unit = {
-    val req = new TCloseSessionReq(_remoteSessionHandle)
     try {
-      val resp = withLockAcquired(CloseSession(req))
-      ThriftUtils.verifyTStatus(resp.getStatus)
+      if (_remoteSessionHandle != null) {
+        val req = new TCloseSessionReq(_remoteSessionHandle)
+        val resp = withLockAcquired(CloseSession(req))
+        ThriftUtils.verifyTStatus(resp.getStatus)
+      }
     } catch {
       case e: Exception =>
         throw KyuubiSQLException("Error while cleaning up the engine resources", e)


### PR DESCRIPTION
### _Why are the changes needed?_
https://github.com/apache/incubator-kyuubi/issues/2125


Now after the `openSession` call fails, `closeSession` is called. But because there is no `_remoteSessionHandle`, the `CloseSession` RPC request fails.
This does not need to send RPC and also increases the complexity of logging.


```
org.apache.kyuubi.KyuubiSQLException: Error while cleaning up the engine resources
        at org.apache.kyuubi.KyuubiSQLException$.apply(KyuubiSQLException.scala:69)
        at org.apache.kyuubi.session.KyuubiSessionImpl.close(KyuubiSessionImpl.scala:156)
        at org.apache.kyuubi.session.KyuubiSessionManager.openSession(KyuubiSessionManager.scala:75)
        at org.apache.kyuubi.service.AbstractBackendService.openSession(AbstractBackendService.scala:45)
        at org.apache.kyuubi.service.ThriftBinaryFrontendService.getSessionHandle(ThriftBinaryFrontendService.scala:199)
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
