### PR TITLE
Simplify log4j2 configurations

### DIFF
--- a/conf/log4j2.properties.template
+++ b/conf/log4j2.properties.template
@@ -15,27 +15,19 @@
 # limitations under the License.
 #
 
-# Set everything to be logged to the file
+# Set everything to be logged to the console
 rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 
 # Console Appender
-appender.console.type = Console
 appender.console.name = STDOUT
+appender.console.type = Console
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = info
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = info
 
 # Set the default kyuubi-ctl log level to WARN. When running the kyuubi-ctl, the
 # log level for this class is used to overwrite the root logger's log level.

--- a/dev/kyuubi-extension-spark-3-1/src/test/resources/log4j2-test.properties
+++ b/dev/kyuubi-extension-spark-3-1/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/dev/kyuubi-extension-spark-3-2/src/test/resources/log4j2-test.properties
+++ b/dev/kyuubi-extension-spark-3-2/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/dev/kyuubi-extension-spark-common/src/test/resources/log4j2-test.properties
+++ b/dev/kyuubi-extension-spark-common/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -422,16 +422,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = info
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = info
 
 # Set the default kyuubi-ctl log level to WARN. When running the kyuubi-ctl, the
 # log level for this class is used to overwrite the root logger's log level.

--- a/externals/kyuubi-flink-sql-engine/src/test/resources/log4j2-test.properties
+++ b/externals/kyuubi-flink-sql-engine/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/externals/kyuubi-spark-sql-engine/src/test/resources/log4j2-test.properties
+++ b/externals/kyuubi-spark-sql-engine/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/externals/kyuubi-trino-engine/src/test/resources/log4j2-test.properties
+++ b/externals/kyuubi-trino-engine/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/integration-tests/kyuubi-flink-it/src/test/resources/log4j2-test.properties
+++ b/integration-tests/kyuubi-flink-it/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/integration-tests/kyuubi-kubernetes-deployment-it/src/test/resources/log4j2-test.properties
+++ b/integration-tests/kyuubi-kubernetes-deployment-it/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to INFO
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = info
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = info

--- a/kyuubi-common/src/main/resources/log4j-defaults.properties
+++ b/kyuubi-common/src/main/resources/log4j-defaults.properties
@@ -21,12 +21,3 @@ log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.err
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss.SSS} %p %c{2}: %m%n
-
-# SPARK-34128: Suppress undesirable TTransportException warnings involved in THRIFT-4805
-log4j.appender.CA.filter.1=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.CA.filter.1.StringToMatch=Thrift error occurred during processing of message
-log4j.appender.CA.filter.1.AcceptOnMatch=false
-
-log4j.appender.FA.filter.1=org.apache.log4j.varia.StringMatchFilter
-log4j.appender.FA.filter.1.StringToMatch=Thrift error occurred during processing of message
-log4j.appender.FA.filter.1.AcceptOnMatch=false

--- a/kyuubi-common/src/main/resources/log4j2-defaults.properties
+++ b/kyuubi-common/src/main/resources/log4j2-defaults.properties
@@ -20,8 +20,8 @@ rootLogger.level = info
 rootLogger.appenderRef.stdout.ref = STDOUT
 
 # Console Appender
-appender.console.type = Console
 appender.console.name = STDOUT
+appender.console.type = Console
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n

--- a/kyuubi-common/src/main/resources/log4j2-defaults.properties
+++ b/kyuubi-common/src/main/resources/log4j2-defaults.properties
@@ -26,13 +26,5 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = info
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = info

--- a/kyuubi-common/src/test/resources/log4j2-test.properties
+++ b/kyuubi-common/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/kyuubi-ctl/src/test/resources/log4j2-test.properties
+++ b/kyuubi-ctl/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/kyuubi-ha/src/test/resources/log4j2-test.properties
+++ b/kyuubi-ha/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/kyuubi-hive-jdbc/src/test/resources/log4j2-test.properties
+++ b/kyuubi-hive-jdbc/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/kyuubi-metrics/src/test/resources/log4j2-test.properties
+++ b/kyuubi-metrics/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug

--- a/kyuubi-server/src/test/resources/log4j2-test.properties
+++ b/kyuubi-server/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to INFO
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = info
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = info

--- a/kyuubi-zookeeper/src/test/resources/log4j2-test.properties
+++ b/kyuubi-zookeeper/src/test/resources/log4j2-test.properties
@@ -27,16 +27,8 @@ appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
 appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
 
-appender.console.filter.1.type = Filters
-
-appender.console.filter.1.a.type = ThresholdFilter
-appender.console.filter.1.a.level = fatal
-
-# SPARK-34128: Suppress undesirable TTransportException warnings, due to THRIFT-4805
-appender.console.filter.1.b.type = RegexFilter
-appender.console.filter.1.b.regex = .*Thrift error occurred during processing of message.*
-appender.console.filter.1.b.onMatch = deny
-appender.console.filter.1.b.onMismatch = neutral
+appender.console.filter.threshold.type = ThresholdFilter
+appender.console.filter.threshold.level = fatal
 
 # File Appender
 appender.file.type = File
@@ -45,13 +37,6 @@ appender.file.fileName = target/unit-tests.log
 appender.file.layout.type = PatternLayout
 appender.file.layout.pattern = %d{HH:mm:ss.SSS} %t %p %c{1}: %m%n
 
-appender.file.filter.1.type = Filters
-
-appender.file.filter.1.a.type = RegexFilter
-appender.file.filter.1.a.regex = .*Thrift error occurred during processing of message.*
-appender.file.filter.1.a.onMatch = deny
-appender.file.filter.1.a.onMismatch = neutral
-
 # Set the logger level of File Appender to DEBUG
-appender.file.filter.1.b.type = ThresholdFilter
-appender.file.filter.1.b.level = debug
+appender.file.filter.threshold.type = ThresholdFilter
+appender.file.filter.threshold.level = debug


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
As Kyuubi use thrift 0.9.3, which is not affected by THRIFT-4805, and spark will fallback to it's own log4j2-defaults.properties if user does not provide log4j2.properties.

The change suppress the noisy 
```
2022-03-11 14:36:13,463 ScalaTest-main ERROR Filters contains invalid attributes "onMatch", "onMismatch"
2022-03-11 14:36:13,475 ScalaTest-main ERROR Filters contains invalid attributes "onMatch", "onMismatch"
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
