### PR TITLE
Build and test all modules on Linux ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
       - ./build/mvn test $MVN_ARGS -pl externals/kyuubi-spark-sql-engine,kyuubi-server
   - name: Build Kyuubi Trino on Linux ARM64
     script:
-      - ./build/mvn test $MVN_ARGS -pl externals/kyuubi-trino-sql-engine,kyuubi-server
+      - ./build/mvn test $MVN_ARGS -pl externals/kyuubi-trino-engine,kyuubi-server
   - name: Build Kyuubi Hive on Linux ARM64
     script:
       - ./build/mvn test $MVN_ARGS -pl externals/kyuubi-hive-sql-engine,kyuubi-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ branches:
     - master
 
 # https://releases.ubuntu.com/ use the latest LTS release of ubuntu
-dist: bionic
 language: scala
 scala:
   - 2.12.15
@@ -36,6 +35,7 @@ matrix:
     arch: arm64-graviton2
     group: edge
     virt: vm
+    env: SPARK_LOCAL_IP=localhost
 
 cache:
   directories:
@@ -47,7 +47,7 @@ install:
 script:
   - export MVN_ARGS="-Dmaven.javadoc.skip=true -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
   - ./build/mvn clean install -DskipTests $MVN_ARGS
-  - ./build/mvn test $MVN_ARGS -pl kyuubi-common -am
+  - ./build/mvn test $MVN_ARGS -pl kyuubi-common,kyuubi-zookeeper,kyuubi-ha,kyuubi-ctl,kyuubi-metrics,kyuubi-hive-beeline,kyuubi-hive-jdbc,kyuubi-server-plugin -am
 
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,11 @@
 #
 
 sudo: required
+dist: focal
+arch: arm64-graviton2
+group: edge
+virt: vm
+env: SPARK_LOCAL_IP=localhost
 
 branches:
   only:
@@ -30,12 +35,21 @@ jdk:
 
 matrix:
   include:
-  - name: Build Kyuubi on Linux ARM64
-    dist: focal
-    arch: arm64-graviton2
-    group: edge
-    virt: vm
-    env: SPARK_LOCAL_IP=localhost
+  - name: Build Kyuubi common on Linux ARM64
+    script:
+      - ./build/mvn test $MVN_ARGS -pl kyuubi-common,kyuubi-zookeeper,kyuubi-ha,kyuubi-ctl,kyuubi-metrics,kyuubi-hive-beeline,kyuubi-hive-jdbc,kyuubi-server-plugin -am
+  - name: Build Kyuubi Flink on Linux ARM64
+    script:
+      - ./build/mvn test $MVN_ARGS -pl externals/kyuubi-flink-sql-engine,kyuubi-server
+  - name: Build Kyuubi Spark on Linux ARM64
+    script:
+      - ./build/mvn test $MVN_ARGS -pl externals/kyuubi-spark-sql-engine,kyuubi-server
+  - name: Build Kyuubi Trino on Linux ARM64
+    script:
+      - ./build/mvn test $MVN_ARGS -pl externals/kyuubi-trino-sql-engine,kyuubi-server
+  - name: Build Kyuubi Hive on Linux ARM64
+    script:
+      - ./build/mvn test $MVN_ARGS -pl externals/kyuubi-hive-sql-engine,kyuubi-server
 
 cache:
   directories:
@@ -44,10 +58,10 @@ cache:
 install:
   - ./build/mvn --version
 
-script:
+before_script:
   - export MVN_ARGS="-Dmaven.javadoc.skip=true -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
   - ./build/mvn clean install -DskipTests $MVN_ARGS
-  - ./build/mvn test $MVN_ARGS -pl kyuubi-common,kyuubi-zookeeper,kyuubi-ha,kyuubi-ctl,kyuubi-metrics,kyuubi-hive-beeline,kyuubi-hive-jdbc,kyuubi-server-plugin -am
+
 
 after_success:
   - echo "Travis exited with ${TRAVIS_TEST_RESULT}"


### PR DESCRIPTION

### _Why are the changes needed?_

This is a follow-up of #1918
There were some problems with Zookeeper and because of that only the tests of `kyuubi-common` module were enabled.
I've just tested latest `master` on my Linux ARM64 machine and now the Zookeeper related tests pass! 

### _How was this patch tested?_

I've executed `mvn clean install` locally and many more Maven modules were successfully built and tested! 
There was a test failure in the Flink related tests. I want to see whether the same will fail at TravisCI too. If it does then I will disable the Flink module in .travisci.yaml until it is resolved too.
