### PR TITLE
[KYUUBI #2085][FOLLOWUP] Fix the wrong path of `module:hive`

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -74,7 +74,7 @@
   - "kyuubi-zookeeper/**/*"
 
 "module:hive":
-  - "kyuubi-hive-sql-engine/**/*"
+  - "externals/kyuubi-hive-sql-engine/**/*"
 
 "module:kubernetes":
   - ".dockerignore"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -74,7 +74,11 @@
   - "kyuubi-zookeeper/**/*"
 
 "module:hive":
+  - "bin/beeline"
   - "externals/kyuubi-hive-sql-engine/**/*"
+  - "kyuubi-hive-beeline/**/*"
+  - "kyuubi-hive-jdbc/**/*"
+  - "kyuubi-hive-jdbc-shaded/**/*"
 
 "module:kubernetes":
   - ".dockerignore"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix the wrong path of `module:hive`

### _How was this patch tested?_

- https://github.com/cfmcgrady/incubator-kyuubi/pull/12
