### PR TITLE
Improve CI with cancel & concurrency & paths filter

### DIFF
--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -30,9 +30,6 @@ concurrency:
   group: dep-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn
-
 jobs:
   dep:
     name: Dependency check
@@ -47,6 +44,8 @@ jobs:
           cache: 'maven'
           check-latest: false
       - name: build
+        env:
+          MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=error
         run: >-
           build/mvn clean install
           -Pflink-provided,spark-provided

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -25,10 +25,10 @@ on:
       - master
       - branch-*
     paths:
-      - '**pom.xml'
+      - '**/pom.xml'
 
 concurrency:
-  group: linter-${{ github.ref }}
+  group: dep-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -17,14 +17,13 @@
 
 name: Dependency
 
-# This GitHub workflow checks style & dependency issues.
-
 on:
   pull_request:
     branches:
       - master
       - branch-*
     paths:
+      # dependency check happens only pom changes
       - '**/pom.xml'
 
 concurrency:
@@ -32,25 +31,30 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=warn
 
 jobs:
-  linter:
+  dep:
     name: Dependency check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Setup JDK 8
+      - name: setup java
         uses: actions/setup-java@v2
         with:
           distribution: zulu
           java-version: 8
           cache: 'maven'
           check-latest: false
-      - name: Maven install
+      - name: build
         run: >-
-          build/mvn clean install -Pflink-provided,spark-provided
-          -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests
+          build/mvn clean install
+          -Pflink-provided,spark-provided
+          -Dmaven.javadoc.skip=true
+          -Drat.skip=true
+          -Dscalastyle.skip=true
+          -Dspotless.check.skip
+          -DskipTests
           -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
       - name: Check dependency list
         run: build/dependency.sh

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: Style check
+name: Dependency
 
 # This GitHub workflow checks style & dependency issues.
 
@@ -36,7 +36,7 @@ env:
 
 jobs:
   linter:
-    name: Style and Dependency check
+    name: Dependency check
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -49,7 +49,7 @@ jobs:
           check-latest: false
       - name: Maven install
         run: >-
-          build/mvn -T 4 clean install -Pflink-provided,spark-provided
+          build/mvn clean install -Pflink-provided,spark-provided
           -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests
           -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
       - name: Check dependency list

--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -24,6 +24,8 @@ on:
     branches:
       - master
       - branch-*
+    paths:
+      - '**pom.xml'
 
 concurrency:
   group: linter-${{ github.ref }}
@@ -32,19 +34,10 @@ concurrency:
 env:
   MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=error
 
-# no install runs before style check because it is expensive, we can skip build if style fails
-# Well, sometimes when we introduce a new module, it may 'fail' the style check for missing
-# dependency we just create for other module to inherit.
-# We can ignore this failure and merge the PR, if we see the style check pass on the new module
-  # or via a local quick verification.
 jobs:
   linter:
-    name: Style check
+    name: Style and Dependency check
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        profiles:
-          - '-Ptpcds -Pspark-block-cleaner -Pkubernetes-deployment-it -Pspark-3.1 -Pspark-3.2'
     steps:
       - uses: actions/checkout@v2
       - name: Setup JDK 8
@@ -54,10 +47,10 @@ jobs:
           java-version: 8
           cache: 'maven'
           check-latest: false
-      - name: Scalastyle with maven
-        run: build/mvn -T 4 scalastyle:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
-      - name: Upload scalastyle report
-        if: failure()
-        run: for log in `find * -name "scalastyle-output.xml"`;  do echo "=========$log========="; grep "error" $log; done
-      - name: JavaStyle with maven
-        run: build/mvn -T 4 spotless:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
+      - name: Maven install
+        run: >-
+          build/mvn -T 4 clean install -Pflink-provided,spark-provided
+          -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests
+          -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
+      - name: Check dependency list
+        run: build/dependency.sh

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -25,6 +25,10 @@ on:
       - master
       - branch-*
 
+concurrency:
+  group: lincense-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   rat:
     name: License
@@ -36,6 +40,8 @@ jobs:
         with:
           distribution: zulu
           java-version: 8
+          cache: 'maven'
+          check-latest: false
       - run:  build/mvn org.apache.rat:apache-rat-plugin:check -Ptpcds -Pspark-block-cleaner -Pkubernetes-deployment-it -Pspark-3.1 -Pspark-3.2
       - name: Upload rat report
         if: failure()

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -118,7 +118,7 @@ jobs:
           check-latest: false
       - name: Run TPC-DS Tests
         run: >-
-          ./build/mvn clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -V
+          ./build/mvn clean install -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -Dorg.slf4j.simpleLogger.defaultLogLevel=warn
           -pl kyuubi-server -am
           -Dmaven.plugin.scalatest.exclude.tags=''
           -Dtest=none -DwildcardSuites=org.apache.kyuubi.operation.tpcds

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,6 +27,10 @@ on:
       - master
       - branch-*
 
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   build:
@@ -95,7 +99,6 @@ jobs:
             **/kyuubi-flink-sql-engine.log*
             **/kyuubi-spark-sql-engine.log*
             **/kyuubi-trino-sql-engine.log*
-            **/target/scalastyle-output.xml
 
   tpcds:
     name: TPC-DS Tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: Kyuubi Nightly
+name: Kyuubi Spark Nightly
 
 on:
   schedule:
@@ -41,30 +41,8 @@ jobs:
         with:
           distribution: zulu
           java-version: 8
-      - uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/com
-          key: ${{ runner.os }}-maven-com-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-com-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/org
-          key: ${{ runner.os }}-maven-org-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-org-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/net
-          key: ${{ runner.os }}-maven-net-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-net-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository/io
-          key: ${{ runner.os }}-maven-io-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-io-
+          cache: 'maven'
+          check-latest: false
       - name: Build with Maven
         run: ./build/mvn clean install ${{ matrix.profiles }} -Dmaven.javadoc.skip=true -V
       - name: Upload test logs
@@ -74,6 +52,4 @@ jobs:
           name: unit-tests-log
           path: |
             **/target/unit-tests.log
-            **/kyuubi-flink-sql-engine.log*
             **/kyuubi-spark-sql-engine.log*
-            **/kyuubi-trino-sql-engine.log*

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -52,8 +52,6 @@ jobs:
         with:
           distribution: zulu
           java-version: 8
-          cache: 'maven'
-          check-latest: false
       - name: Scalastyle with maven
         run: build/mvn -T 4 scalastyle:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
       - name: Upload scalastyle report

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,7 +31,7 @@ concurrency:
 # Well, sometimes when we introduce a new module, it may 'fail' the style check for missing
 # dependency we just create for other module to inherit.
 # We can ignore this failure and merge the PR, if we see the style check pass on the new module
- # or via a local quick verification.
+# or via a local quick verification.
 jobs:
   linter:
     name: Style check

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -63,8 +63,8 @@ jobs:
         # We can ignore this failure and merge the PR, if we see the style check pass on the new module
         # or via a local quick verification.
         run: >-
-          build/mvn -T 4 clean install -V -B -Pflink-provided,spark-provided \
-          -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests \
+          build/mvn -T 4 clean install -Pflink-provided,spark-provided
+          -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests
           -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
       - name: Check dependency list
         run: build/dependency.sh

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: Style check
+name: Style
 
 # This GitHub workflow checks style & dependency issues.
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,8 +17,6 @@
 
 name: Style
 
-# This GitHub workflow checks style & dependency issues.
-
 on:
   pull_request:
     branches:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -57,6 +57,11 @@ jobs:
       - name: JavaStyle with maven
         run: build/mvn -T 4 spotless:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
       - name: Maven install
+        # run install after style check because it is expensive, we can skip build if style fails
+        # Well, sometimes when we introduce a new module, it may 'fail' the style check for missing
+        # dependency we just create for other module to inherit.
+        # We can ignore this failure and merge the PR, if we see the style check pass on the new module
+        # or via a local quick verification.
         run: >-
           build/mvn -T 4 clean install -V -B -Pflink-provided,spark-provided \
           -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests \

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -49,17 +49,17 @@ jobs:
           java-version: 8
           cache: 'maven'
           check-latest: false
-      - name: Maven install
-        run: >-
-          build/mvn -T 4 clean install -V -B -Pflink-provided,spark-provided \
-              -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests \
-              -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
       - name: Scalastyle with maven
         run: build/mvn -T 4 scalastyle:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
       - name: Upload scalastyle report
         if: failure()
         run: for log in `find * -name "scalastyle-output.xml"`;  do echo "=========$log========="; grep "error" $log; done
       - name: JavaStyle with maven
-        run: build/mvn -T 4 spotless:check ${{ matrix.profiles }}
+        run: build/mvn -T 4 spotless:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
+      - name: Maven install
+        run: >-
+          build/mvn -T 4 clean install -V -B -Pflink-provided,spark-provided \
+          -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests \
+          -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
       - name: Check dependency list
         run: build/dependency.sh

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,9 +29,6 @@ concurrency:
   group: linter-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-
 # no install runs before style check because it is expensive, we can skip build if style fails
 # Well, sometimes when we introduce a new module, it may 'fail' the style check for missing
 # dependency we just create for other module to inherit.
@@ -55,9 +52,9 @@ jobs:
           cache: 'maven'
           check-latest: false
       - name: Scalastyle with maven
-        run: build/mvn -T 4 scalastyle:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
+        run: build/mvn scalastyle:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
       - name: Upload scalastyle report
         if: failure()
         run: for log in `find * -name "scalastyle-output.xml"`;  do echo "=========$log========="; grep "error" $log; done
       - name: JavaStyle with maven
-        run: build/mvn -T 4 spotless:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
+        run: build/mvn spotless:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -31,7 +31,7 @@ concurrency:
 # Well, sometimes when we introduce a new module, it may 'fail' the style check for missing
 # dependency we just create for other module to inherit.
 # We can ignore this failure and merge the PR, if we see the style check pass on the new module
-  # or via a local quick verification.
+ # or via a local quick verification.
 jobs:
   linter:
     name: Style check

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,6 +25,13 @@ on:
       - master
       - branch-*
 
+concurrency:
+  group: linter-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MAVEN_OPTS: -Dorg.slf4j.simpleLogger.defaultLogLevel=error
+
 jobs:
   linter:
     name: Style and Dependency check
@@ -40,18 +47,19 @@ jobs:
         with:
           distribution: zulu
           java-version: 8
-      - name: Install
+          cache: 'maven'
+          check-latest: false
+      - name: Maven install
         run: >-
-          build/mvn clean install -V -Pflink-provided,spark-provided -Dorg.slf4j.simpleLogger.defaultLogLevel=warn \
+          build/mvn -T 4 clean install -V -B -Pflink-provided,spark-provided \
               -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests \
-              -Pflink-provided,spark-provided \
               -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
-      - name: Scalastyle with Maven
-        run: build/mvn scalastyle:check ${{ matrix.profiles }}
+      - name: Scalastyle with maven
+        run: build/mvn -T 4 scalastyle:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
       - name: Upload scalastyle report
         if: failure()
         run: for log in `find * -name "scalastyle-output.xml"`;  do echo "=========$log========="; grep "error" $log; done
-      - name: JavaStyle with Maven
-        run: build/mvn spotless:check ${{ matrix.profiles }}
+      - name: JavaStyle with maven
+        run: build/mvn -T 4 spotless:check ${{ matrix.profiles }}
       - name: Check dependency list
         run: build/dependency.sh

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -52,6 +52,8 @@ jobs:
         with:
           distribution: zulu
           java-version: 8
+          cache: 'maven'
+          check-latest: false
       - name: Scalastyle with maven
         run: build/mvn -T 4 scalastyle:check ${{ matrix.profiles }} -pl '!:kyuubi-codecov_2.12,!:kyuubi-assembly_2.12'
       - name: Upload scalastyle report

--- a/dev/kyuubi-codecov/pom.xml
+++ b/dev/kyuubi-codecov/pom.xml
@@ -110,6 +110,12 @@
             <artifactId>kyuubi-hive-beeline</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.kyuubi</groupId>
+            <artifactId>kyuubi-hive-sql-engine_${scala.binary.version}</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Better ASF GHA resource usage, see more https://cwiki.apache.org/confluence/display/BUILDS/GitHub+Actions+status

- cancel-in-progress enabled. w/ this, a previous build can be canceled if new commit(s) have arrived
- style check w/o install. currently, the style check takes 8~10min to finish because an install step before it. now, it shall return within a minute. note that, this might 'fail' itself when we introduce a new module and others depend on it, but it's ok to verify by the log whether a PR ok to be merged.
- dependency check runs only when pom.xml updates. this flow now runs only pom changes as it is the only way that may cause dependency changes.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

**Canceled**: https://github.com/apache/incubator-kyuubi/runs/5604809742?check_suite_focus=true

<img width="548" alt="image" src="https://user-images.githubusercontent.com/8326978/159059722-480f4fd6-d87e-4b07-984e-eb5b08a84beb.png">

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
