### PR TITLE
[KYUUBI #2187] Manage test failures with kyuubi spark nightly build - execute simple scala code *** FAILED ***

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -420,7 +420,7 @@ trait SparkQueryTests extends HiveJDBCTestHelper {
       rs.next()
       // scala repl will return resX = YYYYY, and here we only check YYYYY
       val sparkVer = rs.getString(1).split("=")(1).trim
-      assert("\\d\\.\\d\\.\\d".r.pattern.matcher(sparkVer).matches())
+      assert("\\d\\.\\d\\.\\d(-SNAPSHOT)?".r.pattern.matcher(sparkVer).matches())
       assert(rs.getMetaData.getColumnName(1) === "output")
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
execute simple scala code *** FAILED ***
scala.Predef.augmentString("\d\.\d\.\d").r.pattern.matcher(sparkVer).matches() was false (SparkQueryTests.scala:423)
#2187


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [X] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
