### PR TITLE
[KYUUBI #2189] Manage test failures with kyuubi spark nightly build - deregister when meeting specified exception *** FAILED *** 

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
@@ -60,7 +60,7 @@ class SparkSQLEngineDeregisterExceptionSuite extends SparkSQLEngineDeregisterSui
     super.withKyuubiConf ++ Map(ENGINE_DEREGISTER_EXCEPTION_CLASSES.key -> {
       sparkMajorMinorVersion match {
         // see https://issues.apache.org/jira/browse/SPARK-35958
-        case (3, minor) if minor >= 2 => "org.apache.spark.SparkArithmeticException"
+        case (3, minor) if minor > 2 => "org.apache.spark.SparkArithmeticException"
         case _ => classOf[ArithmeticException].getCanonicalName
       }
     })
@@ -85,7 +85,7 @@ class SparkSQLEngineDeregisterExceptionTTLSuite extends WithDiscoverySparkSQLEng
       ENGINE_DEREGISTER_EXCEPTION_CLASSES.key -> {
         sparkMajorMinorVersion match {
           // see https://issues.apache.org/jira/browse/SPARK-35958
-          case (3, minor) if minor >= 2 => "org.apache.spark.SparkArithmeticException"
+          case (3, minor) if minor > 2 => "org.apache.spark.SparkArithmeticException"
           case _ => classOf[ArithmeticException].getCanonicalName
         }
       },

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
@@ -60,10 +60,7 @@ class SparkSQLEngineDeregisterExceptionSuite extends SparkSQLEngineDeregisterSui
     super.withKyuubiConf ++ Map(ENGINE_DEREGISTER_EXCEPTION_CLASSES.key -> {
       sparkMajorMinorVersion match {
         // see https://issues.apache.org/jira/browse/SPARK-35958
-        case (3, minor) if minor >= 2 => {
-          import org.apache.spark.SparkArithmeticException
-          classOf[SparkArithmeticException].getCanonicalName
-        }
+        case (3, minor) if minor >= 2 => "org.apache.spark.SparkArithmeticException"
         case _ => classOf[ArithmeticException].getCanonicalName
       }
     })
@@ -88,10 +85,7 @@ class SparkSQLEngineDeregisterExceptionTTLSuite extends WithDiscoverySparkSQLEng
       ENGINE_DEREGISTER_EXCEPTION_CLASSES.key -> {
         sparkMajorMinorVersion match {
           // see https://issues.apache.org/jira/browse/SPARK-35958
-          case (3, minor) if minor >= 2 => {
-            import org.apache.spark.SparkArithmeticException
-            classOf[SparkArithmeticException].getCanonicalName
-          }
+          case (3, minor) if minor >= 2 => "org.apache.spark.SparkArithmeticException"
           case _ => classOf[ArithmeticException].getCanonicalName
         }
       },

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
@@ -19,7 +19,6 @@ package org.apache.spark.kyuubi
 
 import java.util.UUID
 
-import org.apache.spark.SparkArithmeticException
 import org.apache.spark.SparkException
 import org.apache.spark.sql.internal.SQLConf.ANSI_ENABLED
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
@@ -61,7 +60,10 @@ class SparkSQLEngineDeregisterExceptionSuite extends SparkSQLEngineDeregisterSui
     super.withKyuubiConf ++ Map(ENGINE_DEREGISTER_EXCEPTION_CLASSES.key -> {
       sparkMajorMinorVersion match {
         // see https://issues.apache.org/jira/browse/SPARK-35958
-        case (3, minor) if minor >= 2 => classOf[SparkArithmeticException].getCanonicalName
+        case (3, minor) if minor >= 2 => {
+          import org.apache.spark.SparkArithmeticException
+          classOf[SparkArithmeticException].getCanonicalName
+        }
         case _ => classOf[ArithmeticException].getCanonicalName
       }
     })
@@ -86,7 +88,10 @@ class SparkSQLEngineDeregisterExceptionTTLSuite extends WithDiscoverySparkSQLEng
       ENGINE_DEREGISTER_EXCEPTION_CLASSES.key -> {
         sparkMajorMinorVersion match {
           // see https://issues.apache.org/jira/browse/SPARK-35958
-          case (3, minor) if minor >= 2 => classOf[SparkArithmeticException].getCanonicalName
+          case (3, minor) if minor >= 2 => {
+            import org.apache.spark.SparkArithmeticException
+            classOf[SparkArithmeticException].getCanonicalName
+          }
           case _ => classOf[ArithmeticException].getCanonicalName
         }
       },


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
deregister when meeting specified exception *** FAILED ***
The code passed to eventually never returned normally. Attempted 15 times over 5.008027662 seconds. Last failure message: STARTED did not equal STOPPED. (SparkSQLEngineDeregisterSuite.scala:50)
#2189
deregister exception ttl test *** FAILED ***
The code passed to eventually never returned normally. Attempted 15 times over 5.007941715 seconds. Last failure message: STARTED did not equal STOPPED. (SparkSQLEngineDeregisterSuite.scala:98)
#2188 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
