### PR TITLE
[KYUUBI #2186] Manage test failures with kyuubi spark nightly build - execute statement - select interval

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/IntervalQualifier.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/IntervalQualifier.scala
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark.schema
+
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+
+import org.apache.spark.sql.types.DataType
+
+object IntervalQualifier extends Enumeration {
+
+  type IntervalQualifier = Value
+
+  val DAY = new Val(0, "DAY")
+  val HOUR = new Val(1, "HOUR")
+  val MINUTE = new Val(3, "MINUTE")
+  val SECOND = new Val(4, "SECOND")
+  private final val SECOND_PER_MINUTE: Long = 60L
+  private final val SECOND_PER_HOUR: Long = SECOND_PER_MINUTE * 60L
+  private final val SECOND_PER_DAY: Long = SECOND_PER_HOUR * 24L
+
+  def toDayTimeIntervalString(d: Duration, typ: DataType): String = {
+    val endField = typ.getClass.getDeclaredField("endField")
+    endField.setAccessible(true)
+    val end = endField.get(typ).asInstanceOf[Byte]
+    val to = IntervalQualifier(end)
+    var sign = ""
+    var rest = d.getSeconds
+    if (d.getSeconds < 0) {
+      sign = "-"
+      rest = -rest
+    }
+    to match {
+      case DAY =>
+        val days = TimeUnit.SECONDS.toDays(rest)
+        s"$sign$days 00:00:00.000000000"
+      case HOUR =>
+        val days = TimeUnit.SECONDS.toDays(rest)
+        val hours = TimeUnit.SECONDS.toHours(rest % SECOND_PER_DAY)
+        f"$sign$days $hours%02d:00:00.000000000"
+      case MINUTE =>
+        val days = TimeUnit.SECONDS.toDays(rest)
+        rest %= SECOND_PER_DAY
+        val hours = TimeUnit.SECONDS.toHours(rest)
+        val minutes = TimeUnit.SECONDS.toMinutes(rest % SECOND_PER_HOUR)
+        f"$sign$days $hours%02d:$minutes%02d:00.000000000"
+      case SECOND =>
+        val days = TimeUnit.SECONDS.toDays(rest)
+        rest %= SECOND_PER_DAY
+        val hours = TimeUnit.SECONDS.toHours(rest)
+        rest %= SECOND_PER_HOUR
+        val minutes = TimeUnit.SECONDS.toMinutes(rest)
+        val seconds = rest % SECOND_PER_MINUTE
+        f"$sign$days $hours%02d:$minutes%02d:$seconds%02d.${d.getNano}%09d"
+    }
+  }
+}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/IntervalQualifier.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/IntervalQualifier.scala
@@ -20,32 +20,26 @@ package org.apache.kyuubi.engine.spark.schema
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 
-import org.apache.spark.sql.types.DataType
-
 object IntervalQualifier extends Enumeration {
 
   type IntervalQualifier = Value
 
-  val DAY = new Val(0, "DAY")
-  val HOUR = new Val(1, "HOUR")
-  val MINUTE = new Val(3, "MINUTE")
-  val SECOND = new Val(4, "SECOND")
-  private final val SECOND_PER_MINUTE: Long = 60L
-  private final val SECOND_PER_HOUR: Long = SECOND_PER_MINUTE * 60L
-  private final val SECOND_PER_DAY: Long = SECOND_PER_HOUR * 24L
+  val DAY = new Val(0, "interval day")
+  val HOUR = new Val(1, "interval day to hour")
+  val MINUTE = new Val(3, "interval day to minute")
+  val SECOND = new Val(4, "interval day to second")
+  final private val SECOND_PER_MINUTE: Long = 60L
+  final private val SECOND_PER_HOUR: Long = SECOND_PER_MINUTE * 60L
+  final private val SECOND_PER_DAY: Long = SECOND_PER_HOUR * 24L
 
-  def toDayTimeIntervalString(d: Duration, typ: DataType): String = {
-    val endField = typ.getClass.getDeclaredField("endField")
-    endField.setAccessible(true)
-    val end = endField.get(typ).asInstanceOf[Byte]
-    val to = IntervalQualifier(end)
+  def toDayTimeIntervalString(d: Duration, iq: IntervalQualifier): String = {
     var sign = ""
     var rest = d.getSeconds
     if (d.getSeconds < 0) {
       sign = "-"
       rest = -rest
     }
-    to match {
+    iq match {
       case DAY =>
         val days = TimeUnit.SECONDS.toDays(rest)
         s"$sign$days 00:00:00.000000000"

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/IntervalQualifier.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/IntervalQualifier.scala
@@ -26,8 +26,8 @@ object IntervalQualifier extends Enumeration {
 
   val DAY = new Val(0, "interval day")
   val HOUR = new Val(1, "interval day to hour")
-  val MINUTE = new Val(3, "interval day to minute")
-  val SECOND = new Val(4, "interval day to second")
+  val MINUTE = new Val(2, "interval day to minute")
+  val SECOND = new Val(3, "interval day to second")
   final private val SECOND_PER_MINUTE: Long = 60L
   final private val SECOND_PER_HOUR: Long = SECOND_PER_MINUTE * 60L
   final private val SECOND_PER_DAY: Long = SECOND_PER_HOUR * 24L

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.engine.spark.schema
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 import java.sql.Timestamp
-import java.time.{Instant, LocalDate, ZoneId}
+import java.time.{Duration, Instant, LocalDate, ZoneId}
 import java.util.Date
 
 import scala.collection.JavaConverters._
@@ -253,6 +253,8 @@ object RowSet {
       case (s: String, StringType) =>
         // Only match string in nested type values
         "\"" + s + "\""
+      case (d: Duration, dt) if dt.simpleString == "interval day" =>
+        IntervalQualifier.toDayTimeIntervalString(d, dt)
 
       case (seq: scala.collection.Seq[_], ArrayType(typ, _)) =>
         seq.map(v => (v, typ)).map(e => toHiveString(e, timeZone)).mkString("[", ",", "]")

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
@@ -29,6 +29,7 @@ import org.apache.hive.service.rpc.thrift._
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
 
+import org.apache.kyuubi.engine.spark.schema.IntervalQualifier.{DAY, HOUR, MINUTE, SECOND}
 import org.apache.kyuubi.util.RowSetUtils._
 
 object RowSet {
@@ -253,8 +254,17 @@ object RowSet {
       case (s: String, StringType) =>
         // Only match string in nested type values
         "\"" + s + "\""
-      case (d: Duration, dt) if dt.simpleString == "interval day" =>
-        IntervalQualifier.toDayTimeIntervalString(d, dt)
+
+      case (d: Duration, dt) =>
+        if (dt.simpleString == DAY.toString()) {
+          IntervalQualifier.toDayTimeIntervalString(d, DAY)
+        } else if (dt.simpleString == HOUR.toString()) {
+          IntervalQualifier.toDayTimeIntervalString(d, HOUR)
+        } else if (dt.simpleString == MINUTE.toString()) {
+          IntervalQualifier.toDayTimeIntervalString(d, MINUTE)
+        } else {
+          IntervalQualifier.toDayTimeIntervalString(d, SECOND)
+        }
 
       case (seq: scala.collection.Seq[_], ArrayType(typ, _)) =>
         seq.map(v => (v, typ)).map(e => toHiveString(e, timeZone)).mkString("[", ",", "]")

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
@@ -41,7 +41,7 @@ object SchemaHelper {
     case TimestampType => TTypeId.TIMESTAMP_TYPE
     case BinaryType => TTypeId.BINARY_TYPE
     case CalendarIntervalType => TTypeId.STRING_TYPE
-    case dt if dt.simpleString == "interval day" =>
+    case dt if dt.simpleString.startsWith("interval day") =>
       TTypeId.INTERVAL_DAY_TIME_TYPE
     case _: ArrayType => TTypeId.ARRAY_TYPE
     case _: MapType => TTypeId.MAP_TYPE

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
@@ -41,6 +41,8 @@ object SchemaHelper {
     case TimestampType => TTypeId.TIMESTAMP_TYPE
     case BinaryType => TTypeId.BINARY_TYPE
     case CalendarIntervalType => TTypeId.STRING_TYPE
+    case dt if dt.simpleString == "interval day" =>
+      TTypeId.INTERVAL_DAY_TIME_TYPE
     case _: ArrayType => TTypeId.ARRAY_TYPE
     case _: MapType => TTypeId.MAP_TYPE
     case _: StructType => TTypeId.STRUCT_TYPE

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -175,12 +175,10 @@ trait SparkQueryTests extends HiveJDBCTestHelper {
   }
 
   test("execute statement - select interval") {
-    // FIXME: [KYUUBI #1250]
-    assume(SPARK_ENGINE_MAJOR_MINOR_VERSION !== ((3, 2)))
     withJdbcStatement() { statement =>
-      val resultSet = statement.executeQuery("SELECT interval '1' day AS col")
+      val resultSet = statement.executeQuery("SELECT -interval '2' day AS col")
       assert(resultSet.next())
-      assert(resultSet.getString("col") === "1 days")
+      assert(resultSet.getObject("col") === "-2 00:00:00.000000000")
       assert(resultSet.getMetaData.getColumnType(1) === java.sql.Types.VARCHAR)
       val metaData = resultSet.getMetaData
       assert(metaData.getPrecision(1) === Int.MaxValue)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

In this PR, we handle newly added daytime interval type

TTypeId.INTERVAL_DAY_TIME_TYPE is used for compatible hive thrift type.
jdbc Type is java.sql.Types.OTHER

The data is converted from java duration to hive compatible string representation

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
