### PR TITLE
[KYUUBI #2201] Show ExecutionId when running status on query engine page

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -23,7 +23,6 @@ import scala.collection.JavaConverters._
 
 import org.apache.spark.kyuubi.SQLOperationListener
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.types._
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging}

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -95,9 +95,6 @@ class ExecuteStatement(
             new ArrayFetchIterator(result.take(resultMaxRows))
           }
         }
-      if (getStatus.state != OperationState.COMPILED) {
-        setCompiledState()
-      }
       setState(OperationState.FINISHED)
     } catch {
       onError(cancel = true)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -22,8 +22,8 @@ import java.util.concurrent.{RejectedExecutionException, ScheduledExecutorServic
 import scala.collection.JavaConverters._
 
 import org.apache.spark.kyuubi.SQLOperationListener
-import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.Row
+import org.apache.spark.sql.catalyst.QueryPlanningTracker
 import org.apache.spark.sql.types._
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging}
@@ -167,11 +167,12 @@ class ExecuteStatement(
 
   def setCompiledStateIfNeeded(): Unit = {
     if (getStatus.state != OperationState.COMPILED) {
-      val startTime = if (result != null) {
-        Some(result.queryExecution.tracker.phases(QueryPlanningTracker.PARSING).endTimeMs)
-      } else {
-        None
-      }
+      val startTime =
+        if (result != null) {
+          Some(result.queryExecution.tracker.phases(QueryPlanningTracker.PARSING).endTimeMs)
+        } else {
+          None
+        }
       setStateInt(OperationState.COMPILED, startTime)
     }
   }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -165,7 +165,7 @@ class ExecuteStatement(
       SparkOperationEvent(this, operationListener.getExecutionId))
   }
 
-  def setCompiledStateIfNeeded(): Unit = {
+  def setCompiledStateIfNeeded(): Unit = synchronized {
     if (getStatus.state == OperationState.RUNNING) {
       val startTime =
         if (result != null) {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -166,7 +166,7 @@ class ExecuteStatement(
   }
 
   def setCompiledStateIfNeeded(): Unit = {
-    if (getStatus.state != OperationState.COMPILED) {
+    if (getStatus.state == OperationState.RUNNING) {
       val startTime =
         if (result != null) {
           Some(result.queryExecution.tracker.phases(QueryPlanningTracker.PARSING).endTimeMs)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -22,12 +22,13 @@ import java.util.concurrent.ConcurrentHashMap
 
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.execution.ui.{SparkListenerSQLExecutionEnd, SparkListenerSQLExecutionStart}
+import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
 
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_SHOW_PROGRESS, ENGINE_SPARK_SHOW_PROGRESS_TIME_FORMAT, ENGINE_SPARK_SHOW_PROGRESS_UPDATE_INTERVAL}
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_STATEMENT_ID_KEY
+import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.SPARK_SQL_EXECUTION_ID_KEY
 import org.apache.kyuubi.engine.spark.operation.ExecuteStatement
 import org.apache.kyuubi.operation.Operation
 import org.apache.kyuubi.operation.log.OperationLog
@@ -83,6 +84,15 @@ class SQLOperationListener(
     if (sameGroupId(jobStart.properties)) {
       val jobId = jobStart.jobId
       val stageSize = jobStart.stageInfos.size
+      if (executionId.isEmpty) {
+        executionId = Option(jobStart.properties.getProperty(SPARK_SQL_EXECUTION_ID_KEY))
+          .map(_.toLong)
+        operation match {
+          case executeStatement: ExecuteStatement =>
+            executeStatement.setCompiledStateIfNeeded()
+          case _ =>
+        }
+      }
       withOperationLog {
         activeJobs.add(jobId)
         info(s"Query [$operationId]: Job $jobId started with $stageSize stages," +
@@ -151,15 +161,6 @@ class SQLOperationListener(
 
   override def onOtherEvent(event: SparkListenerEvent): Unit = {
     event match {
-      case sqlExecutionStart: SparkListenerSQLExecutionStart =>
-        if (executionId.isEmpty) {
-          executionId = Option(sqlExecutionStart.executionId)
-          operation match {
-            case executeStatement: ExecuteStatement =>
-              executeStatement.setCompiledState()
-            case _ =>
-          }
-        }
       case sqlExecutionEnd: SparkListenerSQLExecutionEnd
           if executionId.contains(sqlExecutionEnd.executionId) =>
         spark.sparkContext.removeSparkListener(this)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -29,9 +29,7 @@ import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_SHOW_PROGRESS, ENGINE_SPARK_SHOW_PROGRESS_TIME_FORMAT, ENGINE_SPARK_SHOW_PROGRESS_UPDATE_INTERVAL}
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_STATEMENT_ID_KEY
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.SPARK_SQL_EXECUTION_ID_KEY
-import org.apache.kyuubi.engine.spark.events.SparkOperationEvent
-import org.apache.kyuubi.engine.spark.operation.SparkOperation
-import org.apache.kyuubi.events.EventLogging
+import org.apache.kyuubi.engine.spark.operation.ExecuteStatement
 import org.apache.kyuubi.operation.Operation
 import org.apache.kyuubi.operation.log.OperationLog
 
@@ -90,8 +88,8 @@ class SQLOperationListener(
         executionId = Option(jobStart.properties.getProperty(SPARK_SQL_EXECUTION_ID_KEY))
           .map(_.toLong)
         operation match {
-          case sparkOperation: SparkOperation =>
-            EventLogging.onEvent(SparkOperationEvent(sparkOperation, getExecutionId))
+          case executeStatement: ExecuteStatement =>
+            executeStatement.setCompiledState()
           case _ =>
         }
       }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -29,6 +29,9 @@ import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_SHOW_PROGRESS, ENGINE_SPARK_SHOW_PROGRESS_TIME_FORMAT, ENGINE_SPARK_SHOW_PROGRESS_UPDATE_INTERVAL}
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_STATEMENT_ID_KEY
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.SPARK_SQL_EXECUTION_ID_KEY
+import org.apache.kyuubi.engine.spark.events.SparkOperationEvent
+import org.apache.kyuubi.engine.spark.operation.SparkOperation
+import org.apache.kyuubi.events.EventLogging
 import org.apache.kyuubi.operation.Operation
 import org.apache.kyuubi.operation.log.OperationLog
 
@@ -86,6 +89,11 @@ class SQLOperationListener(
       if (executionId.isEmpty) {
         executionId = Option(jobStart.properties.getProperty(SPARK_SQL_EXECUTION_ID_KEY))
           .map(_.toLong)
+        operation match {
+          case sparkOperation: SparkOperation =>
+            EventLogging.onEvent(SparkOperationEvent(sparkOperation, getExecutionId))
+          case _ =>
+        }
       }
       withOperationLog {
         activeJobs.add(jobId)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerJsonLoggingEventHandlerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerJsonLoggingEventHandlerSuite.scala
@@ -81,7 +81,7 @@ class ServerJsonLoggingEventHandlerSuite extends WithKyuubiServer with HiveJDBCT
       val engineTable = engineStatementEventPath.getParent
       val resultSet2 = statement.executeQuery(s"SELECT * FROM `json`.`${engineTable}`" +
         "where statement = \"" + sql + "\"")
-      val engineStates = Array(INITIALIZED, PENDING, RUNNING, COMPILED, COMPILED, FINISHED)
+      val engineStates = Array(INITIALIZED, PENDING, RUNNING, COMPILED, FINISHED)
       stateIndex = 0
       while (resultSet2.next()) {
         assert(resultSet2.getString("Event") ==

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerJsonLoggingEventHandlerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerJsonLoggingEventHandlerSuite.scala
@@ -81,7 +81,7 @@ class ServerJsonLoggingEventHandlerSuite extends WithKyuubiServer with HiveJDBCT
       val engineTable = engineStatementEventPath.getParent
       val resultSet2 = statement.executeQuery(s"SELECT * FROM `json`.`${engineTable}`" +
         "where statement = \"" + sql + "\"")
-      val engineStates = Array(INITIALIZED, PENDING, RUNNING, COMPILED, FINISHED)
+      val engineStates = Array(INITIALIZED, PENDING, RUNNING, COMPILED, COMPILED, FINISHED)
       stateIndex = 0
       while (resultSet2.next()) {
         assert(resultSet2.getString("Event") ==


### PR DESCRIPTION
### _Why are the changes needed?_

Now we can display the ExecutionId on the query engine page, but generally the sql has been finished.
We can update it when SQL is running and there is an ExecutionId.

close https://github.com/apache/incubator-kyuubi/issues/2201, https://github.com/apache/incubator-kyuubi/issues/921

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
