### PR TITLE
Return the last rows of log for prompts even exception detected

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -203,12 +203,15 @@ trait ProcBuilder {
     if (error == UNCAUGHT_ERROR) {
       Thread.sleep(1000)
     }
+    val lastLogRows = lastRowsOfLog.toArray.mkString("\n")
     error match {
       case UNCAUGHT_ERROR =>
         KyuubiSQLException(s"Failed to detect the root cause, please check $engineLog at server " +
           s"side if necessary. The last $engineLogMaxLines line(s) of log are:\n" +
           s"${lastRowsOfLog.toArray.mkString("\n")}")
-      case other => other
+      case other =>
+        KyuubiSQLException(s"${Utils.stringifyException(other)}.\n" +
+          s"FYI: The last $engineLogMaxLines line(s) of log are:\n$lastLogRows")
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The detected error might not be accurate,  return the last rows of log anyway.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
