### PR TITLE
[KYUUBI #2008][FOLLOWUP] Support engine type and subdomain in kyuubi-ctl

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCli.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCli.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable.ListBuffer
 import org.apache.curator.framework.CuratorFramework
 import org.apache.curator.utils.ZKPaths
 
-import org.apache.kyuubi.Logging
+import org.apache.kyuubi.{KYUUBI_VERSION, Logging}
 import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARE_LEVEL_SUBDOMAIN
 import org.apache.kyuubi.config.KyuubiConf.ENGINE_TYPE
 import org.apache.kyuubi.engine.ShareLevel
@@ -235,8 +235,10 @@ object ServiceControlCli extends CommandLineUtils with Logging {
         val engineSubdomain = Some(args.cliArgs.engineSubdomain)
           .filter(_ != null).filter(_.nonEmpty)
           .getOrElse(args.conf.get(ENGINE_SHARE_LEVEL_SUBDOMAIN).getOrElse("default"))
+        // The path of the engine defined in zookeeper comes from
+        // org.apache.kyuubi.engine.EngineRef#engineSpace
         ZKPaths.makePath(
-          s"${args.cliArgs.namespace}_${ShareLevel.USER}_${engineType}",
+          s"${args.cliArgs.namespace}_${KYUUBI_VERSION}_${ShareLevel.USER}_${engineType}",
           args.cliArgs.user,
           engineSubdomain)
     }

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
@@ -278,7 +278,7 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       "--user",
       user)
     assert(getZkNamespace(new ServiceControlCliArguments(arg2)) ==
-      s"/${namespace}_USER_SPARK_SQL/$user/default")
+      s"/${namespace}_${KYUUBI_VERSION}_USER_SPARK_SQL/$user/default")
   }
 
   test("test list zk service nodes info") {
@@ -417,7 +417,7 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       "--user",
       user)
     assert(getZkNamespace(new ServiceControlCliArguments(arg1)) ==
-      s"/${namespace}_USER_SPARK_SQL/$user/default")
+      s"/${namespace}_${KYUUBI_VERSION}_USER_SPARK_SQL/$user/default")
 
     val arg2 = Array(
       "list",
@@ -431,7 +431,7 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       "--engine-type",
       "FLINK_SQL")
     assert(getZkNamespace(new ServiceControlCliArguments(arg2)) ==
-      s"/${namespace}_USER_FLINK_SQL/$user/default")
+      s"/${namespace}_${KYUUBI_VERSION}_USER_FLINK_SQL/$user/default")
 
     val arg3 = Array(
       "list",
@@ -445,7 +445,7 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       "--engine-type",
       "TRINO")
     assert(getZkNamespace(new ServiceControlCliArguments(arg3)) ==
-      s"/${namespace}_USER_TRINO/$user/default")
+      s"/${namespace}_${KYUUBI_VERSION}_USER_TRINO/$user/default")
 
     val arg4 = Array(
       "list",
@@ -461,6 +461,6 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       "--engine-subdomain",
       "sub_1")
     assert(getZkNamespace(new ServiceControlCliArguments(arg4)) ==
-      s"/${namespace}_USER_SPARK_SQL/$user/sub_1")
+      s"/${namespace}_${KYUUBI_VERSION}_USER_SPARK_SQL/$user/sub_1")
   }
 }


### PR DESCRIPTION
### _Why are the changes needed?_
https://github.com/apache/incubator-kyuubi/issues/2008

In version 1.5, the kyuubi version is added to the engine path registered to the znode, which makes the original list engine operation invalid.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
