### PR TITLE
[KYUUBI #2207]  Fix DayTimeIntervalType/YearMonthIntervalType Column Size

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/SchemaHelper.scala
@@ -31,6 +31,16 @@ object SchemaHelper {
    */
   final val TIMESTAMP_NTZ = "TimestampNTZType$"
 
+  /**
+   * Spark 3.2.0 DataType DayTimeIntervalType's class name.
+   */
+  final val DAY_TIME_INTERVAL = "DayTimeIntervalType"
+
+  /**
+   * Spark 3.2.0 DataType YearMonthIntervalType's class name.
+   */
+  final val YEAR_MONTH_INTERVAL = "YearMonthIntervalType"
+
   def toTTypeId(typ: DataType): TTypeId = typ match {
     case NullType => TTypeId.NULL_TYPE
     case BooleanType => TTypeId.BOOLEAN_TYPE
@@ -47,9 +57,9 @@ object SchemaHelper {
     case ntz if ntz.getClass.getSimpleName.equals(TIMESTAMP_NTZ) => TTypeId.TIMESTAMP_TYPE
     case BinaryType => TTypeId.BINARY_TYPE
     case CalendarIntervalType => TTypeId.STRING_TYPE
-    case dt if dt.getClass.getSimpleName.equals("DayTimeIntervalType") =>
+    case dt if dt.getClass.getSimpleName.equals(DAY_TIME_INTERVAL) =>
       TTypeId.INTERVAL_DAY_TIME_TYPE
-    case ym if ym.getClass.getSimpleName.equals("YearMonthIntervalType") =>
+    case ym if ym.getClass.getSimpleName.equals(YEAR_MONTH_INTERVAL) =>
       TTypeId.INTERVAL_YEAR_MONTH_TYPE
     case _: ArrayType => TTypeId.ARRAY_TYPE
     case _: MapType => TTypeId.MAP_TYPE
@@ -125,7 +135,9 @@ object SchemaHelper {
    * For array, map, string, and binaries, the column size is variable, return null as unknown.
    */
   def getColumnSize(sparkType: DataType): Option[Int] = sparkType match {
-    case ntz if ntz.getClass.getSimpleName.equals(TIMESTAMP_NTZ) => Some(ntz.defaultSize)
+    case dt
+        if Array(TIMESTAMP_NTZ, DAY_TIME_INTERVAL, YEAR_MONTH_INTERVAL)
+          .contains(dt.getClass.getSimpleName) => Some(dt.defaultSize)
     case dt @ (BooleanType | _: NumericType | DateType | TimestampType |
         CalendarIntervalType | NullType) =>
       Some(dt.defaultSize)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
@@ -57,7 +57,7 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
 
   test("get columns operation") {
     val tableName = "spark_get_col_operation"
-    val schema = new StructType()
+    var schema = new StructType()
       .add("c0", "boolean", nullable = false, "0")
       .add("c1", "tinyint", nullable = true, "1")
       .add("c2", "smallint", nullable = false, "2")
@@ -80,7 +80,9 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
     // since spark3.3.0
     if (SPARK_ENGINE_MAJOR_MINOR_VERSION._1 > 3 ||
       (SPARK_ENGINE_MAJOR_MINOR_VERSION._1 == 3 && SPARK_ENGINE_MAJOR_MINOR_VERSION._2 >= 3)) {
-      schema.add("c18", "timestamp_ntz", nullable = true, "18")
+      schema = schema.add("c18", "timestamp_ntz", nullable = true, "18")
+        .add("c19", "interval day", nullable = true, "19")
+        .add("c20", "interval year", nullable = true, "20")
     }
 
     val ddl =
@@ -118,7 +120,9 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
           STRUCT,
           BINARY,
           STRUCT,
-          TIMESTAMP)
+          TIMESTAMP,
+          OTHER,
+          OTHER)
 
         var pos = 0
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Data type DayTimeIntervalType and YearMonthIntervalType have default column size ,but now is null.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
