### PR TITLE
[KYUUBI #2260] The running query will not update the duration of the page

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkOperationEvent.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/SparkOperationEvent.scala
@@ -65,7 +65,7 @@ case class SparkOperationEvent(
     ("day", Utils.getDateFromTimestamp(createTime)) :: Nil
 
   def duration: Long = {
-    if (completeTime == -1L) {
+    if (completeTime <= 0L) {
       System.currentTimeMillis - createTime
     } else {
       completeTime - createTime


### PR DESCRIPTION
### _Why are the changes needed?_
close https://github.com/apache/incubator-kyuubi/issues/2260

The default value of completedTime is 0, and the calculation of duration only considers the case where completedTime is -1.

org.apache.kyuubi.operation.AbstractOperation
```scala
protected var completedTime: Long = _
````

org.apache.kyuubi.engine.spark.events.SparkOperationEvent
```scala
  def duration: Long = {
    if (completeTime == -1L) {
      System.currentTimeMillis - createTime
    } else {
      completeTime - createTime
    }
  }
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
