### PR TITLE
[KYUUBI #2268] Flaky test: submit spark app timeout with last log output

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -26,7 +26,7 @@ import scala.collection.JavaConverters._
 import org.apache.hive.service.rpc.thrift.{TExecuteStatementReq, TFetchResultsReq, TGetOperationStatusReq, TOperationState, TStatusCode}
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
-import org.apache.kyuubi.{Utils, WithKyuubiServer}
+import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.SESSION_CONF_ADVISOR
 import org.apache.kyuubi.jdbc.KyuubiHiveDriver
@@ -60,19 +60,6 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         assert(getOpStatusResp.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
         assert(getOpStatusResp.getOperationState === TOperationState.ERROR_STATE)
       }
-    }
-  }
-
-  test("submit spark app timeout with last log output") {
-    withSessionConf()(Map(
-      KyuubiConf.ENGINE_INIT_TIMEOUT.key -> "2000",
-      KyuubiConf.SESSION_ENGINE_LAUNCH_ASYNC.key -> "false"))(Map.empty) {
-      val exception = intercept[SQLException] {
-        withJdbcStatement() { _ => // no-op
-        }
-      }
-      val verboseMessage = Utils.stringifyException(exception)
-      assert(verboseMessage.contains("Failed to detect the root cause"))
     }
   }
 


### PR DESCRIPTION
### _Why are the changes needed?_
close https://github.com/apache/incubator-kyuubi/issues/2268

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
