### PR TITLE
Support to reconnect the kyuubi connection with known host, port and session handle

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -57,6 +57,8 @@ final class KyuubiTBinaryFrontendService(
       respConfiguration.put(
         "kyuubi.session.engine.launch.handle.secret",
         Base64.getMimeEncoder.encodeToString(opHandleIdentifier.getSecret))
+      respConfiguration.put("kyuubi.session.server.host", serverAddr.getHostName)
+      respConfiguration.put("kyuubi.session.server.port", serverSocket.getLocalPort.toString)
 
       resp.setSessionHandle(sessionHandle.toTSessionHandle)
       resp.setConfiguration(respConfiguration)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -224,6 +224,19 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
       }
     }
   }
+
+  test("support to reconnect to kyuubi server with known server host, port and session handle") {
+    withJdbcStatement() { statement =>
+      statement.executeQuery("set spark.sql.temp.key=value")
+      val reConnection = new KyuubiConnection(
+        jdbcUrlWithConf,
+        new Properties(),
+        statement.getConnection.asInstanceOf[KyuubiConnection].getKyuubiSessionRecovery)
+      val rs = reConnection.createStatement().executeQuery("set spark.sql.temp.key")
+      assert(rs.next())
+      assert(rs.getString(2).equals("value"))
+    }
+  }
 }
 
 class TestSessionConfAdvisor extends SessionConfAdvisor {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Support to reconnect the kyuubi connection with known host, port and session handle.

It might be related with #1754

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
