### PR TITLE
Fix operation log file handler leak

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/log/OperationLogSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/log/OperationLogSuite.scala
@@ -57,7 +57,8 @@ class OperationLogSuite extends KyuubiFunSuite {
     val operationLog = OperationLog.createOperationLog(session, oHandle)
     val logFile =
       Paths.get(operationLogRoot, sHandle.identifier.toString, oHandle.identifier.toString)
-    assert(Files.exists(logFile))
+    // lazy create
+    assert(!Files.exists(logFile))
 
     OperationLog.setCurrentOperationLog(operationLog)
     assert(OperationLog.getCurrentOperationLog === operationLog)
@@ -66,6 +67,8 @@ class OperationLogSuite extends KyuubiFunSuite {
     assert(OperationLog.getCurrentOperationLog === null)
 
     operationLog.write(msg1 + "\n")
+    assert(Files.exists(logFile))
+
     val tRowSet1 = operationLog.read(1)
     assert(tRowSet1.getColumns.get(0).getStringVal.getValues.get(0) === msg1)
     val tRowSet2 = operationLog.read(1)
@@ -148,8 +151,10 @@ class OperationLogSuite extends KyuubiFunSuite {
     val oHandle = OperationHandle(
       OperationType.EXECUTE_STATEMENT,
       TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10)
-    val log = OperationLog.createOperationLog(session, oHandle)
-    assert(log === null)
+    intercept[Exception] {
+      val log = OperationLog.createOperationLog(session, oHandle)
+      log.read(1)
+    }
     logRoot.delete()
 
     OperationLog.createOperationLogRootDirectory(session)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/ExecuteStatement.scala
@@ -161,8 +161,4 @@ class ExecuteStatement(
     super.setState(newState)
     EventBus.post(KyuubiOperationEvent(this))
   }
-
-  override def close(): Unit = {
-    super.close()
-  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If a session is empty which means that it does not contain any operation, then the OperationLog will never be closed.

This bug will happen if we enable `LaunchEngine`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
