### PR TITLE
Make AuthZ plugin build pass scala 2.11

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -247,21 +247,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.kyuubi</groupId>
-            <artifactId>kyuubi-common_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.kyuubi</groupId>
-            <artifactId>kyuubi-common_${scala.binary.version}</artifactId>
-            <version>${project.version}</version>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
             <scope>test</scope>
@@ -291,4 +276,15 @@
         </testResources>
     </build>
 
+    <profiles>
+        <profile>
+            <id>spark-authz-scala_2.11</id>
+            <properties>
+                <scala.binary.version>2.11</scala.binary.version>
+                <scala.version>2.11.12</scala.version>
+                <skipTests>true</skipTests>
+                <spark.version>2.4.8</spark.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -240,10 +240,10 @@
         </dependency>
 
         <dependency>
+            <!-- for hive related test only -->
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-hive_${scala.binary.version}</artifactId>
             <scope>test</scope>
-            <!-- for hive related test only -->
         </dependency>
 
         <dependency>
@@ -283,6 +283,7 @@
                 <scala.binary.version>2.11</scala.binary.version>
                 <scala.version>2.11.12</scala.version>
                 <skipTests>true</skipTests>
+                <maven.plugin.scala.warn-unused>none</maven.plugin.scala.warn-unused>
                 <spark.version>2.4.8</spark.version>
             </properties>
         </profile>

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -19,12 +19,18 @@ package org.apache.kyuubi.plugin.spark.authz
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
-import org.apache.kyuubi.KyuubiFunSuite
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils
+// scalastyle:off
+import org.scalatest.funsuite.AnyFunSuite
+
 import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.ranger.AccessType
 
-abstract class PrivilegesBuilderSuite extends KyuubiFunSuite with SparkSessionProvider {
+abstract class PrivilegesBuilderSuite extends AnyFunSuite
+  with SparkSessionProvider with BeforeAndAfterAll with BeforeAndAfterEach {
+// scalastyle:on
 
   protected def withTable(t: String)(f: String => Unit): Unit = {
     try {
@@ -581,7 +587,7 @@ abstract class PrivilegesBuilderSuite extends KyuubiFunSuite with SparkSessionPr
   }
 
   test("RefreshFunctionCommand") {
-    assume(isSparkV31OrGreater)
+    assume(AuthZUtils.isSparkVersionAtLeast("3.1"))
     sql(s"CREATE FUNCTION RefreshFunctionCommand AS '${getClass.getCanonicalName}'")
     val plan = sql("REFRESH FUNCTION RefreshFunctionCommand")
       .queryExecution.analyzed

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -20,7 +20,6 @@ package org.apache.kyuubi.plugin.spark.authz
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -21,12 +21,12 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.ranger.AccessType
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils
 
 abstract class PrivilegesBuilderSuite extends AnyFunSuite
   with SparkSessionProvider with BeforeAndAfterAll with BeforeAndAfterEach {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -31,10 +31,16 @@ trait SparkSessionProvider {
 
   protected val extension: SparkSessionExtensions => Unit = _ => Unit
   protected lazy val spark: SparkSession = {
+    val metastore = {
+      val path = Files.createTempDirectory("hms")
+      Files.delete(path)
+      path
+    }
     SparkSession.builder()
       .master("local")
       .config("spark.ui.enabled", "false")
       .config("spark.sql.catalogImplementation", catalogImpl)
+      .config("javax.jdo.option.ConnectionURL", s"jdbc:derby:;databaseName=$metastore;create=true")
       .config(
         "spark.sql.warehouse.dir",
         Files.createTempDirectory("spark-warehouse").toString)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/SparkSessionProvider.scala
@@ -19,7 +19,6 @@ package org.apache.kyuubi.plugin.spark.authz
 
 import java.nio.file.Files
 
-import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.{DataFrame, SparkSession, SparkSessionExtensions}
 
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
@@ -22,7 +22,6 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.ObjectType._
 
-// scalastyle:off
 class AccessResourceSuite extends AnyFunSuite {
 // scalastyle:on
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
@@ -17,10 +17,14 @@
 
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
-import org.apache.kyuubi.KyuubiFunSuite
+// scalastyle:off
+import org.scalatest.funsuite.AnyFunSuite
+
 import org.apache.kyuubi.plugin.spark.authz.ObjectType._
 
-class AccessResourceSuite extends KyuubiFunSuite {
+// scalastyle:off
+class AccessResourceSuite extends AnyFunSuite {
+// scalastyle:on
 
   test("generate spark ranger resources") {
     val resource = AccessResource(DATABASE, "my_db_name")

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -25,11 +25,14 @@ import scala.util.Try
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
-
-import org.apache.kyuubi.{KyuubiFunSuite, Utils}
+import org.scalatest.BeforeAndAfterAll
+// scalastyle:off
+import org.scalatest.funsuite.AnyFunSuite
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 
-abstract class RangerSparkExtensionSuite extends KyuubiFunSuite with SparkSessionProvider {
+abstract class RangerSparkExtensionSuite extends AnyFunSuite
+  with SparkSessionProvider with BeforeAndAfterAll {
+// scalastyle:on
 
   override protected val extension: SparkSessionExtensions => Unit = new RangerSparkExtension
 
@@ -48,7 +51,7 @@ abstract class RangerSparkExtensionSuite extends KyuubiFunSuite with SparkSessio
   private def errorMessage(
       privilege: String,
       resource: String = "default/src",
-      user: String = Utils.currentUser): String = {
+      user: String = UserGroupInformation.getCurrentUser.getShortUserName): String = {
     s"Permission denied: user [$user] does not have [$privilege] privilege on [$resource]"
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -28,6 +28,7 @@ import org.apache.spark.sql.{Row, SparkSessionExtensions}
 import org.scalatest.BeforeAndAfterAll
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
+
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 
 abstract class RangerSparkExtensionSuite extends AnyFunSuite

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPluginSuite.scala
@@ -18,12 +18,14 @@
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
 import org.apache.hadoop.security.UserGroupInformation
+// scalastyle:off
+import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.plugin.spark.authz.{ObjectType, OperationType}
 import org.apache.kyuubi.plugin.spark.authz.ranger.SparkRangerAdminPlugin._
 
-class SparkRangerAdminPluginSuite extends KyuubiFunSuite {
+class SparkRangerAdminPluginSuite extends AnyFunSuite {
+// scalastyle:on
 
   test("get filter expression") {
     val bob = UserGroupInformation.createRemoteUser("bob")

--- a/pom.xml
+++ b/pom.xml
@@ -1463,7 +1463,7 @@
                             <arg>-Yno-adapted-args</arg>
                             <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
                             <arg>-Xfatal-warnings</arg>
-                            <arg>-Ywarn-unused:imports</arg>
+                            <arg>-Ywarn-unused</arg>
                         </args>
                         <jvmArgs>
                             <jvmArg>-Xms1024m</jvmArg>

--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,7 @@
         <!-- DO NOT bump 4.4.0, see https://github.com/apache/incubator-kyuubi/pull/441 -->
         <!-- DO NOT bump 4.5.3, see https://github.com/apache/incubator-kyuubi/issues/708 -->
         <maven.plugin.scala.version>4.3.0</maven.plugin.scala.version>
+        <maven.plugin.scala.warn-unused>-Ywarn-unused:imports</maven.plugin.scala.warn-unused>
         <maven.plugin.surefire.version>2.22.0</maven.plugin.surefire.version>
         <maven.plugin.scalatest.version>2.0.2</maven.plugin.scalatest.version>
         <maven.plugin.scalatest.exclude.tags>org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.HudiTest</maven.plugin.scalatest.exclude.tags>
@@ -1463,7 +1464,7 @@
                             <arg>-Yno-adapted-args</arg>
                             <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
                             <arg>-Xfatal-warnings</arg>
-                            <arg>-Ywarn-unused:imports</arg>
+                            <arg>${maven.plugin.scala.warn-unused}</arg>
                         </args>
                         <jvmArgs>
                             <jvmArg>-Xms1024m</jvmArg>

--- a/pom.xml
+++ b/pom.xml
@@ -1463,7 +1463,7 @@
                             <arg>-Yno-adapted-args</arg>
                             <arg>-P:silencer:globalFilters=.*deprecated.*</arg>
                             <arg>-Xfatal-warnings</arg>
-                            <arg>-Ywarn-unused</arg>
+                            <arg>-Ywarn-unused:imports</arg>
                         </args>
                         <jvmArgs>
                             <jvmArg>-Xms1024m</jvmArg>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Spark 2.4 and earlier were build with scala 2.11 in this PR, we remove the dep of kyuubi common module with is used only in test now

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
