### PR TITLE
[KYUUBI #1972][FOLLOWUP] Fix flaky test: SchedulerPoolSuite: Scheduler pool

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SchedulerPoolSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SchedulerPoolSuite.scala
@@ -96,13 +96,15 @@ class SchedulerPoolSuite extends WithSparkSQLEngine with HiveJDBCTestHelper {
         })
       }
       threads.shutdown()
+      // wait for all jobs to finish
       eventually(Timeout(20.seconds)) {
-        // We can not ensure that job1 is started before job2 so here using abs.
-        assert(Math.abs(job1StartTime - job2StartTime) < 1000)
-        // Job1 minShare is 2(total resource) so that job2 should be allocated tasks after
-        // job1 finished.
-        assert(job2FinishTime - job1FinishTime >= 1000)
+        assert(job2FinishTime > 0 && job1FinishTime > 0 && job1StartTime > 0 && job2StartTime > 0)
       }
+      // We can not ensure that job1 is started before job2 so here using abs.
+      assert(Math.abs(job1StartTime - job2StartTime) < 1000)
+      // Job1 minShare is 2(total resource) so that job2 should be allocated tasks after
+      // job1 finished.
+      assert(Math.abs(job2FinishTime - job1FinishTime) >= 1000)
     } finally {
       spark.sparkContext.removeSparkListener(listener)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Follow-up to #1972

Make the following changes:
1. change `job2FinishTime - job1FinishTime >= 1000` to `Math.abs(job2FinishTime - job1FinishTime) >= 1000`
2. eventually is only used to wait for all jobs to complete so we can identify the reason for the failure

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
