### PR TITLE
Export JAVA_HOME. It seems TravisCI stopped doing it recently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - ./build/mvn --version
 
 before_script:
-  - export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-arm64"
+  - export JAVA_HOME="/usr/lib/jvm/adoptopenjdk-8-hotspot-arm64"
   - export MVN_ARGS="-Dmaven.javadoc.skip=true -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
   - ./build/mvn clean install -DskipTests $MVN_ARGS
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ install:
   - ./build/mvn --version
 
 before_script:
+  - export JAVA_HOME="/usr/lib/jvm/java-8-openjdk-arm64"
   - export MVN_ARGS="-Dmaven.javadoc.skip=true -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
   - ./build/mvn clean install -DskipTests $MVN_ARGS
 


### PR DESCRIPTION

### _Why are the changes needed?_

Many builds at TravisCI recently failed due to error like
```
- hive process builder *** FAILED ***

  org.apache.kyuubi.KyuubiSQLException: JAVA_HOME is not set! For more information on installing and configuring JAVA_HOME, please visit https://kyuubi.apache.org/docs/latest/deployment
```

It seems TravisCI stopped exporting JAVA_HOME ...

### _How was this patch tested?_

TravisCI build should pass