### PR TITLE
[KYUUBI #2397] Supports managing engines of different versions in kyuubi-ctl

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCli.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCli.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.ctl
 
 import scala.collection.mutable.ListBuffer
 
-import org.apache.kyuubi.{KYUUBI_VERSION, Logging}
+import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARE_LEVEL_SUBDOMAIN
 import org.apache.kyuubi.config.KyuubiConf.ENGINE_TYPE
 import org.apache.kyuubi.engine.ShareLevel
@@ -235,7 +235,7 @@ object ServiceControlCli extends CommandLineUtils with Logging {
         // The path of the engine defined in zookeeper comes from
         // org.apache.kyuubi.engine.EngineRef#engineSpace
         DiscoveryPaths.makePath(
-          s"${args.cliArgs.namespace}_${KYUUBI_VERSION}_${ShareLevel.USER}_${engineType}",
+          s"${args.cliArgs.namespace}_${args.cliArgs.version}_${ShareLevel.USER}_${engineType}",
           args.cliArgs.user,
           Array(engineSubdomain))
     }

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
@@ -460,5 +460,23 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       "sub_1")
     assert(getZkNamespace(new ServiceControlCliArguments(arg4)) ==
       s"/${namespace}_${KYUUBI_VERSION}_USER_SPARK_SQL/$user/sub_1")
+
+    val arg5 = Array(
+      "list",
+      "engine",
+      "--zk-quorum",
+      zkServer.getConnectString,
+      "--namespace",
+      namespace,
+      "--version",
+      "1.5.0",
+      "--user",
+      user,
+      "--engine-type",
+      "SPARK_SQL",
+      "--engine-subdomain",
+      "sub_1")
+    assert(getZkNamespace(new ServiceControlCliArguments(arg5)) ==
+      s"/${namespace}_1.5.0_USER_SPARK_SQL/$user/sub_1")
   }
 }


### PR DESCRIPTION
### _Why are the changes needed?_
Now only supports the management of the current build version of the engine.   
If `--version` is specified, use this version, otherwise use the version of the build version.  
close https://github.com/apache/incubator-kyuubi/issues/2397


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
