### PR TITLE
[KYUUBI apache#2413  ] Fix InsertIntoHiveTableCommand case in PrivilegesBuilder#buildCommand()

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -303,8 +303,7 @@ object PrivilegesBuilder {
         outputObjs += tablePrivileges(table)
 
       case "CreateDataSourceTableAsSelectCommand" |
-          "OptimizedCreateHiveTableAsSelectCommand" |
-          "InsertIntoHiveTable" =>
+          "OptimizedCreateHiveTableAsSelectCommand" =>
         val table = getPlanField[CatalogTable]("table").identifier
         outputObjs += tablePrivileges(table)
         buildQuery(getQuery, inputObjs)
@@ -381,6 +380,13 @@ object PrivilegesBuilder {
           "InsertIntoHadoopFsRelationCommand" |
           "InsertIntoHiveDirCommand" =>
         // TODO: Should get the table via datasource options?
+        buildQuery(getQuery, inputObjs)
+
+      case "InsertIntoHiveTable" =>
+        val table = getPlanField[CatalogTable]("table").identifier
+        val overwrite = getPlanField[Boolean]("overwrite")
+        val actionType = if (overwrite) INSERT_OVERWRITE else INSERT
+        outputObjs += tablePrivileges(table, actionType = actionType)
         buildQuery(getQuery, inputObjs)
 
       case "LoadDataCommand" =>

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -1241,7 +1241,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
   test("InsertIntoHiveTableCommand") {
     assume(!isSparkV2)
     val tableName = "InsertIntoHiveTable"
-    withTable(tableName) {_ =>
+    withTable(tableName) { _ =>
       sql(s"CREATE TABLE $tableName (a int, b string) USING hive")
       val sqlStr =
         s"""
@@ -1256,15 +1256,15 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
 
       assert(outputs.size === 1)
       outputs.foreach { po =>
-      assert(po.actionType === PrivilegeObjectActionType. INSERT)
-      assert (po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
-      assert(po.dbname equalsIgnoreCase "default")
-      assert(po.objectName equalsIgnoreCase tableName)
-      assert(po.columns.isEmpty)
-      val accessType = ranger.AccessType(po, operationType, isInput = false)
-      assert(accessType === AccessType.UPDATE)
+        assert(po.actionType === PrivilegeObjectActionType.INSERT)
+        assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
+        assert(po.dbname equalsIgnoreCase "default")
+        assert(po.objectName equalsIgnoreCase tableName)
+        assert(po.columns.isEmpty)
+        val accessType = ranger.AccessType(po, operationType, isInput = false)
+        assert(accessType === AccessType.UPDATE)
+      }
     }
-  }
   }
 
   test("ShowCreateTableAsSerdeCommand") {


### PR DESCRIPTION
…gesBuilder#buildCommand()

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. To close #2413 
2. To move unit test case `AlterTableAddColumnsCommand` from the end of `HiveCatalogPrivilegeBuilderSuite` to the end of `PrivilegesBuilderSuite`. It is my mistake, this case should be tested both in InmemoryCatalog and HiveCatalog.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
