### PR TITLE
[KYUUBI #2436] Add AlterTableRecoverPartitionsCommand for Spark Sql Authz PrivilegesBuilder

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -206,6 +206,10 @@ object PrivilegesBuilder {
         outputObjs += tablePrivileges(oldTable, actionType = PrivilegeObjectActionType.DELETE)
         outputObjs += tablePrivileges(newTable)
 
+      case "AlterTableRecoverPartitionsCommand" =>
+        val table = getTableName
+        outputObjs += tablePrivileges(table)
+
       case "AlterTableRenamePartitionCommand" =>
         val table = getTableName
         val cols = getPlanField[TablePartitionSpec]("oldPartition").keySet.toSeq

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -205,8 +205,8 @@ object PrivilegesBuilder {
         val newTable = getPlanField[TableIdentifier]("newName")
         outputObjs += tablePrivileges(oldTable, actionType = PrivilegeObjectActionType.DELETE)
         outputObjs += tablePrivileges(newTable)
-      
-      // this is for spark 3.1 or below 
+
+      // this is for spark 3.1 or below
       case "AlterTableRecoverPartitionsCommand" =>
         val table = getTableName
         outputObjs += tablePrivileges(table)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -205,7 +205,8 @@ object PrivilegesBuilder {
         val newTable = getPlanField[TableIdentifier]("newName")
         outputObjs += tablePrivileges(oldTable, actionType = PrivilegeObjectActionType.DELETE)
         outputObjs += tablePrivileges(newTable)
-
+      
+      // this is for spark 3.1 or below 
       case "AlterTableRecoverPartitionsCommand" =>
         val table = getTableName
         outputObjs += tablePrivileges(table)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -202,37 +202,36 @@ abstract class PrivilegesBuilderSuite extends KyuubiFunSuite with SparkSessionPr
   }
 
   test("AlterTableRecoverPartitionsCommand") {
-    // AlterTableRecoverPartitionsCommand occurs in spark 3.1 or below.
-    if (!isSparkV32OrGreater) {
-      val tableName = reusedDb + "." + "TableToMsck"
-      withTable(tableName) { _ =>
-        sql(
-          s"""
-             |CREATE TABLE $tableName
-             |(key int, value string, pid string)
-             |USING parquet
-             |PARTITIONED BY (pid)""".stripMargin)
-        val sqlStr =
-          s"""
-             |MSCK REPAIR TABLE $tableName
-             |""".stripMargin
-        val plan = sql(sqlStr).queryExecution.analyzed
-        val operationType = OperationType(plan.nodeName)
-        assert(operationType === MSCK)
-        val (inputs, outputs) = PrivilegesBuilder.build(plan)
+    // AlterTableRecoverPartitionsCommand exists in the version below 3.2
+    assume(!isSparkV32OrGreater)
+    val tableName = reusedDb + "." + "TableToMsck"
+    withTable(tableName) { _ =>
+      sql(
+        s"""
+           |CREATE TABLE $tableName
+           |(key int, value string, pid string)
+           |USING parquet
+           |PARTITIONED BY (pid)""".stripMargin)
+      val sqlStr =
+        s"""
+           |MSCK REPAIR TABLE $tableName
+           |""".stripMargin
+      val plan = sql(sqlStr).queryExecution.analyzed
+      val operationType = OperationType(plan.nodeName)
+      assert(operationType === MSCK)
+      val (inputs, outputs) = PrivilegesBuilder.build(plan)
 
-        assert(inputs.isEmpty)
+      assert(inputs.isEmpty)
 
-        assert(outputs.size === 1)
-        outputs.foreach { po =>
-          assert(po.actionType === PrivilegeObjectActionType.INSERT)
-          assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
-          assert(po.dbname equalsIgnoreCase reusedDb)
-          assert(po.objectName equalsIgnoreCase tableName.split("\\.").last)
-          assert(po.columns.isEmpty)
-          val accessType = ranger.AccessType(po, operationType, isInput = false)
-          assert(accessType === AccessType.UPDATE)
-        }
+      assert(outputs.size === 1)
+      outputs.foreach { po =>
+        assert(po.actionType === PrivilegeObjectActionType.INSERT)
+        assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
+        assert(po.dbname equalsIgnoreCase reusedDb)
+        assert(po.objectName equalsIgnoreCase tableName.split("\\.").last)
+        assert(po.columns.isEmpty)
+        val accessType = ranger.AccessType(po, operationType, isInput = false)
+        assert(accessType === AccessType.UPDATE)
       }
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -225,13 +225,13 @@ abstract class PrivilegesBuilderSuite extends KyuubiFunSuite with SparkSessionPr
 
       assert(outputs.size === 1)
       outputs.foreach { po =>
-        assert(po.actionType === PrivilegeObjectActionType.INSERT)
+        assert(po.actionType === PrivilegeObjectActionType.OTHER)
         assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
         assert(po.dbname equalsIgnoreCase reusedDb)
         assert(po.objectName equalsIgnoreCase tableName.split("\\.").last)
         assert(po.columns.isEmpty)
         val accessType = ranger.AccessType(po, operationType, isInput = false)
-        assert(accessType === AccessType.UPDATE)
+        assert(accessType === AccessType.ALTER)
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To close #2436 

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
