### PR TITLE
[KYUUBI #2440] [Improvement] spark engine event add endTime when it is stopped

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -285,7 +285,8 @@ object SparkSQLEngine extends Logging {
           case e: KyuubiException => currentEngine match {
               case Some(engine) =>
                 engine.stop()
-                val event = EngineEvent(engine).copy(diagnostic = e.getMessage)
+                val event = EngineEvent(engine)
+                  .copy(endTime = System.currentTimeMillis(), diagnostic = e.getMessage)
                 EventBus.post(event)
                 error(event, e)
               case _ => error("Current SparkSQLEngine is not created.")


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

spark engine event add endTime when it is stopped
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
