### PR TITLE
[KYUUBI #2432][DOCS] button "Download" is invalid

### DIFF
--- a/docs/quick_start/quick_start.md
+++ b/docs/quick_start/quick_start.md
@@ -31,7 +31,7 @@
 Currently, Apache Kyuubi maintains all its releases on our official [website](https://kyuubi.apache.org/releases.html).
 You can get the most recent stable release of Apache Kyuubi here:
 
-<a class="github-button" href="https://kyuubi.apache.org/releases.html" data-color-scheme="no-preference: light; light: dark; dark: light;" data-icon="octicon-download" data-size="large" aria-label="Download Kyuubi">Download</a>
+<p><a class="btn btn-neutral" href="https://kyuubi.apache.org/releases.html" data-color-scheme="no-preference: light; light: dark; dark: light;" data-icon="octicon-download" data-size="large" aria-label="Download Kyuubi"><span class="fa fa-arrow-circle-down" aria-hidden="true"></span>Download</a></p>
 
 ## Requirements
 

--- a/docs/quick_start/quick_start.md
+++ b/docs/quick_start/quick_start.md
@@ -15,8 +15,6 @@
  - limitations under the License.
  -->
 
-<script async defer src="https://buttons.github.io/buttons.js"></script>
-
 <div align=center>
 
 ![](../imgs/kyuubi_logo.png)


### PR DESCRIPTION
#2432

### _How was this patch tested?_
rerun “build_document.md” to generate html and test download button click jumping website.
here is ui
<img width="1075" alt="image" src="https://user-images.githubusercontent.com/14138772/164618499-6c05abb8-a834-4e5a-9337-ac183b4c70c9.png">

