### PR TITLE
[KYUUBI #2433] HiveSQLEngine load required jars from HIVE_HADOOP_CLASSPATH

### DIFF
--- a/conf/kyuubi-env.sh.template
+++ b/conf/kyuubi-env.sh.template
@@ -46,6 +46,10 @@
 # - FLINK_HOME              Flink distribution which you would like to use in Kyuubi.
 # - FLINK_CONF_DIR          Optional directory where the Flink configuration lives.
 #                           (Default: $FLINK_HOME/conf)
+# - HIVE_HOME               Hive distribution which you would like to use in Kyuubi.
+# - HIVE_CONF_DIR           Optional directory where the Hive configuration lives.
+#                           (Default: $HIVE_HOME/conf)
+# - HIVE_HADOOP_CLASSPATH   Required hadoop jars when you use Kyuubi Hive engine on Yarn.
 #
 
 
@@ -54,6 +58,8 @@
 # export JAVA_HOME=/usr/jdk64/jdk1.8.0_152
 # export SPARK_HOME=/opt/spark
 # export FLINK_HOME=/opt/flink
+# export HIVE_HOME=/opt/hive
+# export HIVE_HADOOP_CLASSPATH=${HADOOP_HOME}/share/hadoop/common/lib/commons-collections-3.2.2.jar:${HADOOP_HOME}/share/hadoop/client/hadoop-client-runtime-3.1.0.jar:${HADOOP_HOME}/share/hadoop/client/hadoop-client-api-3.1.0.jar:${HADOOP_HOME}/share/hadoop/common/lib/htrace-core4-4.1.0-incubating.jar
 # export HADOOP_CONF_DIR=/usr/ndp/current/mapreduce_client/conf
 # export YARN_CONF_DIR=/usr/ndp/current/yarn/conf
 # export KYUUBI_JAVA_OPTS="-Xmx10g -XX:+UnlockDiagnosticVMOptions -XX:ParGCCardsPerStrideChunk=4096 -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -XX:+CMSClassUnloadingEnabled -XX:+CMSParallelRemarkEnabled -XX:+UseCondCardMark -XX:MaxDirectMemorySize=1024m  -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./logs -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution -Xloggc:./logs/kyuubi-server-gc-%t.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=5M -XX:NewRatio=3 -XX:MetaspaceSize=512m"

--- a/conf/kyuubi-env.sh.template
+++ b/conf/kyuubi-env.sh.template
@@ -49,7 +49,7 @@
 # - HIVE_HOME               Hive distribution which you would like to use in Kyuubi.
 # - HIVE_CONF_DIR           Optional directory where the Hive configuration lives.
 #                           (Default: $HIVE_HOME/conf)
-# - HIVE_HADOOP_CLASSPATH   Required hadoop jars when you use Kyuubi Hive engine on Yarn.
+# - HIVE_HADOOP_CLASSPATH   Required Hadoop jars when you use the Kyuubi Hive engine.
 #
 
 

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -81,6 +81,10 @@ You can configure the environment variables in `$KYUUBI_HOME/conf/kyuubi-env.sh`
 # - FLINK_HOME              Flink distribution which you would like to use in Kyuubi.
 # - FLINK_CONF_DIR          Optional directory where the Flink configuration lives.
 #                           (Default: $FLINK_HOME/conf)
+# - HIVE_HOME               Hive distribution which you would like to use in Kyuubi.
+# - HIVE_CONF_DIR           Optional directory where the Hive configuration lives.
+#                           (Default: $HIVE_HOME/conf)
+# - HIVE_HADOOP_CLASSPATH   Required hadoop jars when you use Kyuubi Hive engine on Yarn.
 #
 
 
@@ -89,6 +93,8 @@ You can configure the environment variables in `$KYUUBI_HOME/conf/kyuubi-env.sh`
 # export JAVA_HOME=/usr/jdk64/jdk1.8.0_152
 # export SPARK_HOME=/opt/spark
 # export FLINK_HOME=/opt/flink
+# export HIVE_HOME=/opt/hive
+# export HIVE_HADOOP_CLASSPATH=${HADOOP_HOME}/share/hadoop/common/lib/commons-collections-3.2.2.jar:${HADOOP_HOME}/share/hadoop/client/hadoop-client-runtime-3.1.0.jar:${HADOOP_HOME}/share/hadoop/client/hadoop-client-api-3.1.0.jar:${HADOOP_HOME}/share/hadoop/common/lib/htrace-core4-4.1.0-incubating.jar
 # export HADOOP_CONF_DIR=/usr/ndp/current/mapreduce_client/conf
 # export YARN_CONF_DIR=/usr/ndp/current/yarn/conf
 # export KYUUBI_JAVA_OPTS="-Xmx10g -XX:+UnlockDiagnosticVMOptions -XX:ParGCCardsPerStrideChunk=4096 -XX:+UseParNewGC -XX:+UseConcMarkSweepGC -XX:+CMSConcurrentMTEnabled -XX:CMSInitiatingOccupancyFraction=70 -XX:+UseCMSInitiatingOccupancyOnly -XX:+CMSClassUnloadingEnabled -XX:+CMSParallelRemarkEnabled -XX:+UseCondCardMark -XX:MaxDirectMemorySize=1024m  -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=./logs -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution -Xloggc:./logs/kyuubi-server-gc-%t.log -XX:+UseGCLogFileRotation -XX:NumberOfGCLogFiles=10 -XX:GCLogFileSize=5M -XX:NewRatio=3 -XX:MetaspaceSize=512m"

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -84,7 +84,7 @@ You can configure the environment variables in `$KYUUBI_HOME/conf/kyuubi-env.sh`
 # - HIVE_HOME               Hive distribution which you would like to use in Kyuubi.
 # - HIVE_CONF_DIR           Optional directory where the Hive configuration lives.
 #                           (Default: $HIVE_HOME/conf)
-# - HIVE_HADOOP_CLASSPATH   Required hadoop jars when you use Kyuubi Hive engine on Yarn.
+# - HIVE_HADOOP_CLASSPATH   Required Hadoop jars when you use the Kyuubi Hive engine.
 #
 
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We submit a hive job to yarn, when we don't set `kyuubi.engine.hive.extra.classpath`, HiveSQLEngine will throw an error.

My improvement is supporting set `HIVE_HADOOP_CLASSPATH`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
