### PR TITLE
[KYUUBI #2450] Update lastAccessTime in getStatus and add opHandle to opHandleSet before run

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -174,6 +174,7 @@ abstract class AbstractOperation(opType: OperationType, session: Session)
   override def getHandle: OperationHandle = handle
 
   override def getStatus: OperationStatus = {
+    lastAccessTime = System.currentTimeMillis()
     OperationStatus(
       state,
       createTime,

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -90,8 +90,8 @@ abstract class AbstractSession(
   protected def runOperation(operation: Operation): OperationHandle = {
     try {
       val opHandle = operation.getHandle
-      operation.run()
       opHandleSet.add(opHandle)
+      operation.run()
       opHandle
     } catch {
       case e: KyuubiSQLException =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -155,7 +155,12 @@ class KyuubiSessionImpl(
 
   override def close(): Unit = {
     if (!OperationState.isTerminal(launchEngineOp.getStatus.state)) {
-      closeOperation(launchEngineOp.getHandle)
+      try {
+        closeOperation(launchEngineOp.getHandle)
+      } catch {
+        case e: Exception =>
+          warn(s"Error closing operation $launchEngineOp.getHandle during closing $handle for", e)
+      }
     }
     super.close()
     sessionManager.credentialsManager.removeSessionCredentialsEpoch(handle.identifier.toString)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -155,12 +155,7 @@ class KyuubiSessionImpl(
 
   override def close(): Unit = {
     if (!OperationState.isTerminal(launchEngineOp.getStatus.state)) {
-      try {
-        closeOperation(launchEngineOp.getHandle)
-      } catch {
-        case e: Exception =>
-          warn(s"Error closing operation $launchEngineOp.getHandle during closing $handle for", e)
-      }
+      closeOperation(launchEngineOp.getHandle)
     }
     super.close()
     sessionManager.credentialsManager.removeSessionCredentialsEpoch(handle.identifier.toString)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

close #2450

1. The client obtains the status of the Operation by calling getOperationStatus cyclically. We need to update the lastAccessTime in the getStatus method to prevent timeouts caused by long-running.
2. We need to add opHandle to opHandleSet before running to avoid losing Operation by calling close during Operation running.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
