### PR TITLE
[KYUUBI #1936][FOLLOWUP] Stop updating credentials when credentials are expired

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/CredentialsRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/CredentialsRef.scala
@@ -49,6 +49,10 @@ class CredentialsRef(appUser: String) {
 
   def getLastAccessTime: Long = lastAccessTime
 
+  def getNoOperationTime: Long = {
+    System.currentTimeMillis() - lastAccessTime
+  }
+
   def getEpoch: Long = epoch
 
   def getAppUser: String = appUser

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HadoopCredentialsManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HadoopCredentialsManagerSuite.scala
@@ -158,6 +158,18 @@ class HadoopCredentialsManagerSuite extends KyuubiFunSuite {
       eventually(timeout(9000.milliseconds), interval(100.milliseconds)) {
         assert(manager.userCredentialsRefMap.size == 0)
       }
+
+      // New userRef is created
+      val newUserRef = manager.getOrCreateUserCredentialsRef(appUser)
+      assert(manager.userCredentialsRefMap.size == 1)
+
+      // Old renewal schedule is stopped
+      val epoch = userRef.getEpoch
+      Thread.sleep(2000L)
+      assert(userRef.getEpoch == epoch)
+
+      // New renewal schedule is running
+      assert(newUserRef.getEpoch >= 1)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This is the follow-up for the comments in https://github.com/apache/incubator-kyuubi/pull/2210 

------
But considering the following scenario, I think we should also check whether userRef in `userCredentialsRefMap` has been replaced by a new one .

`userRef` was waiting for next renewal.
`userRef` expired and was removed from `userCredentialsRefMap`
A new `userRef` was created because of user visiting.
Renewal of old userRef started again.
If we do not check, both old and new userRef will renew periodically.

modified the code and added test case for the scenario.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
