### PR TITLE
[KYUUBI #2456] Supports managing engines of different share level in kyuubi-ctl

### DIFF
--- a/docs/tools/kyuubi-ctl.md
+++ b/docs/tools/kyuubi-ctl.md
@@ -56,6 +56,8 @@ Command: get engine
                            The engine type this engine belong to.
   -es, --engine-subdomain <value>
                            The engine subdomain this engine belong to.
+  -esl, --engine-share-level <value>
+                           The engine share level this engine belong to.
 
 Command: delete [server|engine] [options]
 	Delete the specified service/engine node, host and port needed.
@@ -68,6 +70,8 @@ Command: delete engine
                            The engine type this engine belong to.
   -es, --engine-subdomain <value>
                            The engine subdomain this engine belong to.
+  -esl, --engine-share-level <value>
+                           The engine share level this engine belong to.
 
 Command: list [server|engine] [options]
 	List all the service/engine nodes for a particular domain.
@@ -80,6 +84,8 @@ Command: list engine
                            The engine type this engine belong to.
   -es, --engine-subdomain <value>
                            The engine subdomain this engine belong to.
+  -esl, --engine-share-level <value>
+                           The engine share level this engine belong to.
 
   -h, --help               Show help message and exit.
 ```
@@ -116,22 +122,40 @@ bin/kyuubi-ctl delete server --host XXX --port YYY
 ```
 
 ## Manage kyuubi engines
-You can also specify the engine type(`--engine-type`), and the engine share level subdomain(`--engine-subdomain`).
+You can also specify the engine type(`--engine-type`), engine share level subdomain(`--engine-subdomain`) and engine share level(`--engine-share-level`).
 
-If not specified, the configuration item `kyuubi.engine.type` of `kyuubi-defaults.conf` read, the default value is `SPARK_SQL`, `kyuubi.engine.share.level.subdomain`, the default value is `default`.
+If not specified, the configuration item `kyuubi.engine.type` of `kyuubi-defaults.conf` read, the default value is `SPARK_SQL`, `kyuubi.engine.share.level.subdomain`, the default value is `default`, `kyuubi.engine.share.level`, the default value is `USER`.
 
 If the engine pool mode is enabled through `kyuubi.engine.pool.size`, the subdomain consists of `kyuubi.engine.pool.name` and a number below size, e.g. `engine-pool-0` .
+
+`--engine-share-level` supports the following enum values.
+* CONNECTION
+
+  The engine Ref Id (UUID) must be specified via `--engine-subdomain`.
+* USER:
+  
+  Default Value.
+* GROUP:
+
+  The `--user` parameter is the group name corresponding to the user.
+* SERVER:
+
+  The `--user` parameter is the user who started the kyuubi server.
 
 ### List engine
 List all the engine nodes for a user.
 ```shell
-bin/kyuubi-ctl list egnine --user AAA
+bin/kyuubi-ctl list engine --user AAA
+```
+The management share level is SERVER, the user who starts the kyuubi server is A, the engine is TRINO, and the subdomain is adhoc.
+```shell
+bin/kyuubi-ctl list engine --user A --engine-type TRINO --engine-subdomain adhoc --engine-share-level SERVER
 ```
 
 ### Get engine
 Get Kyuubi engine info belong to a user.
 ```shell
-bin/kyuubi-ctl get egnine --user AAA --host XXX --port YYY
+bin/kyuubi-ctl get engine --user AAA --host XXX --port YYY
 ```
 
 ### Delete engine
@@ -139,5 +163,5 @@ Delete the specified engine node for user.
 
 After the engine node is deleted, the kyuubi engine stops opening new sessions and waits for all currently open sessions to be closed before the process exits.
 ```shell
-bin/kyuubi-ctl delete egnine --user AAA --host XXX --port YYY
+bin/kyuubi-ctl delete engine --user AAA --host XXX --port YYY
 ```

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCli.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCli.scala
@@ -20,9 +20,7 @@ package org.apache.kyuubi.ctl
 import scala.collection.mutable.ListBuffer
 
 import org.apache.kyuubi.Logging
-import org.apache.kyuubi.config.KyuubiConf.ENGINE_SHARE_LEVEL_SUBDOMAIN
-import org.apache.kyuubi.config.KyuubiConf.ENGINE_TYPE
-import org.apache.kyuubi.engine.ShareLevel
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SHARE_LEVEL, ENGINE_SHARE_LEVEL_SUBDOMAIN, ENGINE_TYPE}
 import org.apache.kyuubi.ha.HighAvailabilityConf._
 import org.apache.kyuubi.ha.client.{DiscoveryClientProvider, ServiceNodeInfo}
 import org.apache.kyuubi.ha.client.DiscoveryClient
@@ -232,10 +230,13 @@ object ServiceControlCli extends CommandLineUtils with Logging {
         val engineSubdomain = Some(args.cliArgs.engineSubdomain)
           .filter(_ != null).filter(_.nonEmpty)
           .getOrElse(args.conf.get(ENGINE_SHARE_LEVEL_SUBDOMAIN).getOrElse("default"))
+        val engineShareLevel = Some(args.cliArgs.engineShareLevel)
+          .filter(_ != null).filter(_.nonEmpty)
+          .getOrElse(args.conf.get(ENGINE_SHARE_LEVEL))
         // The path of the engine defined in zookeeper comes from
         // org.apache.kyuubi.engine.EngineRef#engineSpace
         DiscoveryPaths.makePath(
-          s"${args.cliArgs.namespace}_${args.cliArgs.version}_${ShareLevel.USER}_${engineType}",
+          s"${args.cliArgs.namespace}_${args.cliArgs.version}_${engineShareLevel}_${engineType}",
           args.cliArgs.user,
           Array(engineSubdomain))
     }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArguments.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArguments.scala
@@ -77,6 +77,10 @@ class ServiceControlCliArguments(args: Seq[String], env: Map[String, String] = s
       .action((v, c) => c.copy(engineSubdomain = v))
       .text("The engine subdomain this engine belong to.")
 
+    val engineShareLevelOps = opt[String]("engine-share-level").abbr("esl")
+      .action((v, c) => c.copy(engineShareLevel = v))
+      .text("The engine share level this engine belong to.")
+
     val serverCmd =
       cmd("server").action((_, c) => c.copy(service = ServiceControlObject.SERVER))
     val engineCmd =
@@ -102,6 +106,7 @@ class ServiceControlCliArguments(args: Seq[String], env: Map[String, String] = s
               .children(userOps)
               .children(engineTypeOps)
               .children(engineSubdomainOps)
+              .children(engineShareLevelOps)
               .text("\tGet Kyuubi engine info belong to a user.")),
         note(""),
         cmd("delete")
@@ -113,6 +118,7 @@ class ServiceControlCliArguments(args: Seq[String], env: Map[String, String] = s
               .children(userOps)
               .children(engineTypeOps)
               .children(engineSubdomainOps)
+              .children(engineShareLevelOps)
               .text("\tDelete the specified engine node for user.")),
         note(""),
         cmd("list")
@@ -124,6 +130,7 @@ class ServiceControlCliArguments(args: Seq[String], env: Map[String, String] = s
               .children(userOps)
               .children(engineTypeOps)
               .children(engineSubdomainOps)
+              .children(engineShareLevelOps)
               .text("\tList all the engine nodes for a user")),
         checkConfig(f => {
           if (f.action == null) failure("Must specify action command: [create|get|delete|list].")

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArgumentsParser.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ServiceControlCliArgumentsParser.scala
@@ -38,7 +38,8 @@ abstract private[kyuubi] class ServiceControlCliArgumentsParser {
       version: String = null,
       verbose: Boolean = false,
       engineType: String = null,
-      engineSubdomain: String = null)
+      engineSubdomain: String = null,
+      engineShareLevel: String = null)
 
   /**
    * Cli arguments parse rules.

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliArgumentsSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliArgumentsSuite.scala
@@ -379,6 +379,8 @@ class ServiceControlCliArgumentsSuite extends KyuubiFunSuite {
          |                           The engine type this engine belong to.
          |  -es, --engine-subdomain <value>
          |                           The engine subdomain this engine belong to.
+         |  -esl, --engine-share-level <value>
+         |                           The engine share level this engine belong to.
          |
          |Command: delete [server|engine] [options]
          |${"\t"}Delete the specified service/engine node, host and port needed.
@@ -391,6 +393,8 @@ class ServiceControlCliArgumentsSuite extends KyuubiFunSuite {
          |                           The engine type this engine belong to.
          |  -es, --engine-subdomain <value>
          |                           The engine subdomain this engine belong to.
+         |  -esl, --engine-share-level <value>
+         |                           The engine share level this engine belong to.
          |
          |Command: list [server|engine] [options]
          |${"\t"}List all the service/engine nodes for a particular domain.
@@ -403,6 +407,8 @@ class ServiceControlCliArgumentsSuite extends KyuubiFunSuite {
          |                           The engine type this engine belong to.
          |  -es, --engine-subdomain <value>
          |                           The engine subdomain this engine belong to.
+         |  -esl, --engine-share-level <value>
+         |                           The engine share level this engine belong to.
          |
          |  -h, --help               Show help message and exit.""".stripMargin
 

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ServiceControlCliSuite.scala
@@ -479,4 +479,74 @@ class ServiceControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
     assert(getZkNamespace(new ServiceControlCliArguments(arg5)) ==
       s"/${namespace}_1.5.0_USER_SPARK_SQL/$user/sub_1")
   }
+
+  test("test get zk namespace for different share level engines") {
+    val arg1 = Array(
+      "list",
+      "engine",
+      "--zk-quorum",
+      zkServer.getConnectString,
+      "--namespace",
+      namespace,
+      "--user",
+      user)
+    assert(getZkNamespace(new ServiceControlCliArguments(arg1)) ==
+      s"/${namespace}_${KYUUBI_VERSION}_USER_SPARK_SQL/$user/default")
+
+    val arg2 = Array(
+      "list",
+      "engine",
+      "--zk-quorum",
+      zkServer.getConnectString,
+      "--namespace",
+      namespace,
+      "--user",
+      user,
+      "--engine-share-level",
+      "CONNECTION")
+    assert(getZkNamespace(new ServiceControlCliArguments(arg2)) ==
+      s"/${namespace}_${KYUUBI_VERSION}_CONNECTION_SPARK_SQL/$user/default")
+
+    val arg3 = Array(
+      "list",
+      "engine",
+      "--zk-quorum",
+      zkServer.getConnectString,
+      "--namespace",
+      namespace,
+      "--user",
+      user,
+      "--engine-share-level",
+      "USER")
+    assert(getZkNamespace(new ServiceControlCliArguments(arg3)) ==
+      s"/${namespace}_${KYUUBI_VERSION}_USER_SPARK_SQL/$user/default")
+
+    val arg4 = Array(
+      "list",
+      "engine",
+      "--zk-quorum",
+      zkServer.getConnectString,
+      "--namespace",
+      namespace,
+      "--user",
+      user,
+      "--engine-share-level",
+      "GROUP")
+    assert(getZkNamespace(new ServiceControlCliArguments(arg4)) ==
+      s"/${namespace}_${KYUUBI_VERSION}_GROUP_SPARK_SQL/$user/default")
+
+    val arg5 = Array(
+      "list",
+      "engine",
+      "--zk-quorum",
+      zkServer.getConnectString,
+      "--namespace",
+      namespace,
+      "--user",
+      user,
+      "--engine-share-level",
+      "SERVER")
+    assert(getZkNamespace(new ServiceControlCliArguments(arg5)) ==
+      s"/${namespace}_${KYUUBI_VERSION}_SERVER_SPARK_SQL/$user/default")
+  }
 }


### PR DESCRIPTION
### _Why are the changes needed?_
close #2456
Now only supports the management of engines whose share level is user level.
Add engine share level parameter(`--engine-share-level`).

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
