### PR TITLE
[KYUUBI #2463] Redact `kyuubi.ha.zookeeper.auth.digest` in Spark engine

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -153,6 +153,10 @@ object SparkSQLEngine extends Logging {
     _sparkConf.setIfMissing("spark.sql.legacy.castComplexTypesToString.enabled", "true")
     _sparkConf.setIfMissing("spark.master", "local")
     _sparkConf.setIfMissing("spark.ui.port", "0")
+    _sparkConf.set(
+      "spark.redaction.regex",
+      _sparkConf.get("spark.redaction.regex", "(?i)secret|password|token|access[.]key")
+        + "|zookeeper.auth.digest")
     // register the repl's output dir with the file server.
     // see also `spark.repl.classdir`
     _sparkConf.set("spark.repl.class.outputDir", outputDir.toFile.getAbsolutePath)


### PR DESCRIPTION
### _Why are the changes needed?_
close #2463

`spark.kyuubi.ha.zookeeper.auth.digest` configuration item will see account and password in Spark UI.
use `spark.redaction.regex`.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
