### PR TITLE
[KYUUBI #2211] [Improvement] Add CHANGELOG.md to codebase for maintaining release notes

### DIFF
--- a/build/release/generate_changelog.sh
+++ b/build/release/generate_changelog.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o pipefail
+set -e
+
+LAST_RELEASE_TAG=$1
+CURRENT_RELEASE_TAG=$2
+
+KYUUBI_DIR="$(cd "$(dirname "$0")"/../..; pwd)"
+CHANGELOG_DIR=$KYUUBI_DIR/docs/changelog
+RELEASE_VERSION="$(echo $CURRENT_RELEASE_TAG | cut -d "-" -f 1,2)"  ## use cut to remove -rc symbol
+CHANGELOG_PATH=$CHANGELOG_DIR/"$RELEASE_VERSION.md"
+KYUUBI_GITHUB_COMMIT_URL="https://github.com/apache/incubator-kyuubi/commit/"
+
+function usage {
+  set +x
+  echo "./generate_changelog.sh - Tool for generate changelog for Kyuubi"
+  echo ""
+  echo "Usage:"
+  echo "+--------------------------------------------------------------------+"
+  echo "| ./generate_changelog.sh <LAST_RELEASE_TAG> <CURRENT_RELEASE_TAG>   |"
+  echo "+--------------------------------------------------------------------+"
+  echo "LAST_RELEASE_TAG:     -  last release tag of kyuubi e.g. v1.5.0-incubating"
+  echo "CURRENT_RELEASE_TAG:  -  current release tag of kyuubi e.g. v1.5.1-incubating-rc0"
+  echo ""
+}
+
+source "$KYUUBI_DIR/build/util.sh"
+
+if [ "${LAST_RELEASE_TAG}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+## Add title for changelog doc.
+echo "## Changelog for Apache Incubating Kyuubi $RELEASE_VERSION  " > $CHANGELOG_PATH
+## Append well-formatted git log to changelog file.
+git log --pretty="- [%s]($KYUUBI_GITHUB_COMMIT_URL%h)  " $LAST_RELEASE_TAG..$CURRENT_RELEASE_TAG | grep -v "\[RELEASE\]" >> $CHANGELOG_PATH

--- a/docs/changelog/v1.5.1-incubating.md
+++ b/docs/changelog/v1.5.1-incubating.md
@@ -1,0 +1,10 @@
+## Changelog for Apache Incubating Kyuubi v1.5.1-incubating  
+- [[KYUUBI #2354] Fix NPE in process builder log capture thread](https://github.com/apache/incubator-kyuubi/commit/5e76334)  
+- [[KYUUBI #2296] Fix operation log file handler leak](https://github.com/apache/incubator-kyuubi/commit/809ea2a)  
+- [[KYUUBI #2266] The default value of frontend.connection.url.use.hostname should be set to true to be consistent with previous versions](https://github.com/apache/incubator-kyuubi/commit/d3e25f0)  
+- [[KYUUBI #2255]The engine state of Spark's EngineEvent is hardcoded with 0](https://github.com/apache/incubator-kyuubi/commit/2af8bbb)  
+- [[KYUUBI #2008][FOLLOWUP] Support engine type and subdomain in kyuubi-ctl](https://github.com/apache/incubator-kyuubi/commit/d1a2dda)  
+- [[KYUUBI #2156][FOLLOWUP] Fix configuration format in document](https://github.com/apache/incubator-kyuubi/commit/5225b54)  
+- [[KYUUBI #2156] Change log to reflect exactly why getting token failed](https://github.com/apache/incubator-kyuubi/commit/21ca754)  
+- [[KYUUBI #2134] Respect Spark bundled log4j in extension modules](https://github.com/apache/incubator-kyuubi/commit/30dc84b)  
+- [[KYUUBI #2150] [DOCS] Fix Getting Started With Kyuubi on Kubernetes](https://github.com/apache/incubator-kyuubi/commit/e232a83)  


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Add generate_changelog.sh script to simple generate changelog for Apache Incubating Kyuubi.

I've searched there are generaly three ways to generate changelog  
1. add change log manually in ervery pr  ([Apache Skywalking](https://github.com/apache/skywalking/pull/8881/files#diff-e4d10d406c447edb82b7e7958bebc5ff8ca9123076cf138b4e0ba037fa873055))
2. use github action to generate ([sqlfluff](https://github.com/sqlfluff/sqlfluff/blob/main/.github/release-drafter.yml))
3. use script to generate changelog  

I choose to write a script to generate changelog, it does not rely on github and we can use it more conviniently as there maybe mutiple release candidates in the release process.

I add a script to generate changelog once we prepare a new release version, it allows release manager to easy generate changelog between last release tag and current release tag.   

And the changelog doc structure is:  

$KYUUBI_DIR  
&ensp;&ensp;&ensp;&ensp;/docs  
&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;/changelog  
&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;/v1.5.1-incubating.md  
&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;&ensp;...  

### _How was this patch tested?_
use `./generate_changelog.sh v1.5.0-incubating v1.5.1-incubating-rc0` to generate v1.5.1-incubating changelog