### PR TITLE
Fix NPE when invoking YarnApplicationOperation::getApplicationInfoByTag

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -78,7 +78,9 @@ class KyuubiApplicationManager extends AbstractService("KyuubiApplicationManager
   def getApplicationInfo(
       clusterManager: Option[String],
       tag: String): Option[Map[String, String]] = {
-    operations.find(_.isSupported(clusterManager)).map(_.getApplicationInfoByTag(tag))
+    operations.find(_.isSupported(clusterManager)).flatMap { m =>
+      Option(m.getApplicationInfoByTag(tag))
+    }
   }
 }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -78,8 +78,10 @@ class KyuubiApplicationManager extends AbstractService("KyuubiApplicationManager
   def getApplicationInfo(
       clusterManager: Option[String],
       tag: String): Option[Map[String, String]] = {
-    operations.find(_.isSupported(clusterManager)).flatMap { m =>
-      Option(m.getApplicationInfoByTag(tag))
+    val operation = operations.find(_.isSupported(clusterManager))
+    operation match {
+      case Some(op) => Option(op.getApplicationInfoByTag(tag))
+      case None => None
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiBatchYarnClusterSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiBatchYarnClusterSuite.scala
@@ -80,7 +80,10 @@ class KyuubiBatchYarnClusterSuite extends WithKyuubiServerOnYarn {
     val appInfo = yarnOperation.getApplicationInfoByTag(sessionHandle.identifier.toString)
 
     assert(appInfo("state") === "KILLED")
-    assert(batchJobSubmissionOp.getStatus.state === ERROR)
+
+    eventually(timeout(10.seconds), interval(50.milliseconds)) {
+      assert(batchJobSubmissionOp.getStatus.state === ERROR)
+    }
 
     val resultColumns = batchJobSubmissionOp.getNextRowSet(FetchOrientation.FETCH_NEXT, 10)
       .getColumns.asScala


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
null value might be returned for YarnApplicationOperation::getApplicationInfoByTag

I met NPE issue yesterday.

<img width="1061" alt="image" src="https://user-images.githubusercontent.com/6757692/165871836-ad1e4290-34ee-4941-9463-6cc4384f502e.png">
<img width="1329" alt="image" src="https://user-images.githubusercontent.com/6757692/165871885-3b216dda-ab4f-4663-966d-15c0be5f110f.png">

Here the state might be null, because Some(null) is nonEmpty.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
