### PR TITLE
Support SHOW CATALOGS syntax in Spark extensions

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-common/src/main/antlr4/org/apache/kyuubi/sql/KyuubiSparkSQL.g4
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/antlr4/org/apache/kyuubi/sql/KyuubiSparkSQL.g4
@@ -51,6 +51,7 @@ singleStatement
 
 statement
     : OPTIMIZE multipartIdentifier whereClause? zorderClause        #optimizeZorder
+    | SHOW CATALOGS (LIKE? pattern=STRING)?                         #showCatalogs
     | .*?                                                           #passThrough
     ;
 
@@ -119,11 +120,14 @@ quotedIdentifier
 nonReserved
     : AND
     | BY
+    | CATALOGS
     | FALSE
     | DATE
     | INTERVAL
+    | LIKE
     | OPTIMIZE
     | OR
+    | SHOW
     | TABLE
     | TIMESTAMP
     | TRUE
@@ -133,12 +137,15 @@ nonReserved
 
 AND: 'AND';
 BY: 'BY';
+CATALOGS: 'CATALOGS';
 FALSE: 'FALSE';
 DATE: 'DATE';
 INTERVAL: 'INTERVAL';
+LIKE: 'LIKE';
 NULL: 'NULL';
 OPTIMIZE: 'OPTIMIZE';
 OR: 'OR';
+SHOW: 'SHOW';
 TABLE: 'TABLE';
 TIMESTAMP: 'TIMESTAMP';
 TRUE: 'TRUE';

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLAstBuilder.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLAstBuilder.scala
@@ -28,6 +28,7 @@ import org.antlr.v4.runtime.ParserRuleContext
 import org.antlr.v4.runtime.tree.{ParseTree, TerminalNode}
 import org.apache.commons.codec.binary.Hex
 import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalog.ShowCatalogsCommand
 import org.apache.spark.sql.catalyst.analysis.{UnresolvedAttribute, UnresolvedRelation, UnresolvedStar}
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.catalyst.parser.ParseException
@@ -96,6 +97,10 @@ abstract class KyuubiSparkSQLAstBuilderBase extends KyuubiSparkSQLBaseVisitor[An
         Project(Seq(UnresolvedStar(None)), tableWithFilter))
 
     buildOptimizeZorderStatement(tableIdent, query)
+  }
+
+  override def visitShowCatalogs(ctx: ShowCatalogsContext): LogicalPlan = withOrigin(ctx) {
+    ShowCatalogsCommand(Option(ctx.pattern).map(string))
   }
 
   override def visitPassThrough(ctx: PassThroughContext): LogicalPlan = null

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/spark/sql/catalog/ShowCatalogsCommand.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/spark/sql/catalog/ShowCatalogsCommand.scala
@@ -19,15 +19,16 @@ package org.apache.spark.sql.catalog
 
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.util.StringUtils
 import org.apache.spark.sql.connector.catalog.CatalogManager
-import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.execution.command.RunnableCommand
 import org.apache.spark.sql.types.StringType
 
 /**
  * The command for `SHOW CATALOGS`.
  */
-case class ShowCatalogsCommand(pattern: Option[String]) extends LeafRunnableCommand {
+case class ShowCatalogsCommand(pattern: Option[String]) extends RunnableCommand {
   override val output: Seq[Attribute] = Seq(
     AttributeReference("catalog", StringType, nullable = false)())
 
@@ -41,4 +42,7 @@ case class ShowCatalogsCommand(pattern: Option[String]) extends LeafRunnableComm
     val allCatalogs = (configuredCatalogs + CatalogManager.SESSION_CATALOG_NAME).toSeq.sorted
     pattern.map(StringUtils.filterPattern(allCatalogs, _)).getOrElse(allCatalogs).map(Row(_))
   }
+
+  protected def withNewChildrenInternal(newChildren: IndexedSeq[LogicalPlan]): LogicalPlan =
+    this.asInstanceOf[LogicalPlan]
 }

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/spark/sql/catalog/ShowCatalogsCommand.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/spark/sql/catalog/ShowCatalogsCommand.scala
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.catalog
+
+import org.apache.spark.sql.{Row, SparkSession}
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference}
+import org.apache.spark.sql.catalyst.util.StringUtils
+import org.apache.spark.sql.connector.catalog.CatalogManager
+import org.apache.spark.sql.execution.command.LeafRunnableCommand
+import org.apache.spark.sql.types.StringType
+
+/**
+ * The command for `SHOW CATALOGS`.
+ */
+case class ShowCatalogsCommand(pattern: Option[String]) extends LeafRunnableCommand {
+  override val output: Seq[Attribute] = Seq(
+    AttributeReference("catalog", StringType, nullable = false)())
+
+  // The implementation use eager strategy to list catalog, which is different from SPARK-35973
+  override def run(sparkSession: SparkSession): Seq[Row] = {
+    val registeredCatalogs = sparkSession.sessionState.conf.getAllConfs.keys
+      .filter { _ startsWith "spark.sql.catalog." }
+      .map { _ stripPrefix "spark.sql.catalog." }
+      .filterNot { _ contains "." }
+      .toSet
+    val allCatalogs = (registeredCatalogs + CatalogManager.SESSION_CATALOG_NAME).toSeq.sorted
+    pattern.map(StringUtils.filterPattern(allCatalogs, _)).getOrElse(allCatalogs).map(Row(_))
+  }
+}

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/spark/sql/catalog/ShowCatalogsCommand.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/spark/sql/catalog/ShowCatalogsCommand.scala
@@ -33,12 +33,12 @@ case class ShowCatalogsCommand(pattern: Option[String]) extends LeafRunnableComm
 
   // The implementation use eager strategy to list catalog, which is different from SPARK-35973
   override def run(sparkSession: SparkSession): Seq[Row] = {
-    val registeredCatalogs = sparkSession.sessionState.conf.getAllConfs.keys
+    val configuredCatalogs = sparkSession.sessionState.conf.getAllConfs.keys
       .filter { _ startsWith "spark.sql.catalog." }
       .map { _ stripPrefix "spark.sql.catalog." }
       .filterNot { _ contains "." }
       .toSet
-    val allCatalogs = (registeredCatalogs + CatalogManager.SESSION_CATALOG_NAME).toSeq.sorted
+    val allCatalogs = (configuredCatalogs + CatalogManager.SESSION_CATALOG_NAME).toSeq.sorted
     pattern.map(StringUtils.filterPattern(allCatalogs, _)).getOrElse(allCatalogs).map(Row(_))
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-common/src/test/scala/org/apache/spark/sql/CatalogSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/test/scala/org/apache/spark/sql/CatalogSuite.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.catalog.ShowCatalogsCommand
+import org.apache.spark.sql.internal.StaticSQLConf
+
+class CatalogSuite extends KyuubiSparkSQLExtensionTest {
+
+  override def sparkConf(): SparkConf = {
+    super.sparkConf()
+      .set(
+        StaticSQLConf.SPARK_SESSION_EXTENSIONS.key,
+        "org.apache.kyuubi.sql.KyuubiSparkSQLCommonExtension")
+      .set("spark.sql.catalog.clickhouse", "ClickHouseCatalogImpl")
+      .set("spark.sql.catalog.kudu", "KuduClickHouseImpl")
+  }
+
+  test("Analyze: SHOW CATALOGS") {
+    comparePlans(
+      sql("SHOW CATALOGS").queryExecution.analyzed,
+      ShowCatalogsCommand(None))
+    comparePlans(
+      sql("SHOW CATALOGS LIKE 'defau*'").queryExecution.analyzed,
+      ShowCatalogsCommand(Some("defau*")))
+  }
+
+  test("Execute: SHOW CATALOGS") {
+    checkAnswer(
+      sql("SHOW CATALOGS"),
+      Array(Row("clickhouse"), Row("kudu"), Row("spark_catalog")))
+
+    checkAnswer(
+      sql("SHOW CATALOGS LIKE 'click*'"),
+      Array(Row("clickhouse")))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Spark support multi-catalogs since 3.0, and it's important to Kyuubi as Kyuubi aim to be a Gateway of LakeHouse.

The implementation is different from SPARK-35973 (available since 3.3.0).

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
