### PR TITLE
[WIP][KYUUBI #2231][FOLLOWUP] Clean up active spark session

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithSparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithSparkSQLEngine.scala
@@ -24,13 +24,13 @@ import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.sparkMajorMinorVersion
 
 trait WithSparkSQLEngine extends KyuubiFunSuite {
-  protected var spark: SparkSession = _
-  protected var engine: SparkSQLEngine = _
+  @volatile protected var spark: SparkSession = _
+  @volatile protected var engine: SparkSQLEngine = _
   // conf will be loaded until start spark engine
   def withKyuubiConf: Map[String, String]
   def kyuubiConf: KyuubiConf = SparkSQLEngine.kyuubiConf
 
-  protected var connectionUrl: String = _
+  @volatile protected var connectionUrl: String = _
 
   // Affected by such configuration' default value
   //    engine.initialize.sql='SHOW DATABASES'
@@ -93,6 +93,8 @@ trait WithSparkSQLEngine extends KyuubiFunSuite {
       spark.stop()
       spark = null
     }
+    SparkSession.getActiveSession.foreach(_.close())
+    SparkSession.getDefaultSession.foreach(_.close())
     SparkSession.clearActiveSession()
     SparkSession.clearDefaultSession()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Follow up #2231

As commented in https://github.com/apache/incubator-kyuubi/pull/2529#issuecomment-1114258671 , SparkApp still doesn't cleaned up correctly.

`SparkSession` is first created in the `ScalaTest-main-running-DiscoverySuite` thread.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
