### PR TITLE
Verify whether yarn client is valid in YarnApplicationOperation initialization

### DIFF
--- a/kyuubi-common/src/test/resources/kyuubi-defaults.conf
+++ b/kyuubi-common/src/test/resources/kyuubi-defaults.conf
@@ -26,3 +26,8 @@ ___userc___.spark.user.test c
 
 abc=xyz
 xyz=abc
+
+# yarn client timeout parameters, for YarnApplicationOperation
+# Using KyuubiConf().loadFileDefaults to load this.
+ipc.client.connect.max.retries=1
+yarn.client.failover-max-attempts=1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

For UT, without `MiniYarnService`, yarn cluster manager is not supported.

If I specify the spark.master to yarn, it will use YarnApplicationOperation to killApplication.

In fact, the yarn client in YarnApplicationOperation is invalid, so the killApplication will stuck for about 20 minutes and then fail.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
