### PR TITLE
[KYUUBI #2427][FOLLOWUP] Flaky test: deregister when meeting specified exception

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/spark/kyuubi/SparkSQLEngineDeregisterSuite.scala
@@ -72,8 +72,10 @@ class SparkSQLEngineDeregisterMsgSuite extends SparkSQLEngineDeregisterSuite {
   override def withKyuubiConf: Map[String, String] = {
     super.withKyuubiConf ++ Map(ENGINE_DEREGISTER_EXCEPTION_MESSAGES.key ->
       // see https://issues.apache.org/jira/browse/SPARK-38926
-      // upper case SQL types in error messages
-      "to int causes overflow,to INT causes overflow")
+      // Upper case SQL types in error messages
+      // see https://issues.apache.org/jira/browse/SPARK-39007
+      // Use double quotes for SQL configs in error messages
+      "to int causes overflow,to \"INT\" causes overflow")
   }
 }
 


### PR DESCRIPTION
### _Why are the changes needed?_
https://github.com/apache/incubator-kyuubi/issues/2427

master nightly [log](https://github.com/apache/incubator-kyuubi/actions/runs/2273625147) :
```
04:23:04.585 Executor task launch worker for task 0.0 in stage 2.0 (TID 2) ERROR Executor: Exception in task 0.0 in stage 2.0 (TID 2)
org.apache.spark.SparkArithmeticException: Casting 2.147483648E9D to "INT" causes overflow. To return NULL instead, use 'try_cast'. If necessary set "spark.sql.ansi.enabled" to false to bypass this error.
	at org.apache.spark.sql.errors.QueryExecutionErrors$.castingCauseOverflowError(QueryExecutionErrors.scala:95) ~[spark-catalyst_2.12-3.3.0-SNAPSHOT.jar:3.3.0-SNAPSHOT]
````

[[SPARK-39007](https://issues.apache.org/jira/browse/SPARK-39007)][SQL] Use double quotes for SQL configs in error messages



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
