### PR TITLE
[KYUUBI #2473] Add FilteredShowDatabasesCommand to AuthZ module

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleReplaceShowObjectCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleReplaceShowObjectCommands.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.plugin.spark.authz.ranger
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.catalyst.expressions.Attribute
-import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.{LogicalPlan, ShowNamespaces}
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.execution.command.RunnableCommand
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleReplaceShowObjectCommands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleReplaceShowObjectCommands.scala
@@ -68,7 +68,6 @@ case class FilteredShowDatabasesCommand(delegated: ShowNamespaces) extends Runna
 
   override def run(spark: SparkSession): Seq[Row] = {
     val catalog = spark.sessionState.catalog
-    // Seq[String]
     val dbs = catalog.listDatabases()
     val rows = dbs.map(s => Row(s))
     val ugi = AuthZUtils.getAuthzUgi(spark.sparkContext)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -281,7 +281,7 @@ abstract class RangerSparkExtensionSuite extends KyuubiFunSuite with SparkSessio
       doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $db1"))
       doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $db2"))
 
-      doAs("admin", assert(sql(s"show databases").collect().length === 1))
+      doAs("admin", assert(sql(s"show databases").collect().length === 2))
       doAs("bob", assert(sql(s"show databases").collect().length === 0))
       doAs("i_am_invisible", assert(sql(s"show databases").collect().length === 0))
     } finally {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -275,7 +275,7 @@ abstract class RangerSparkExtensionSuite extends KyuubiFunSuite with SparkSessio
   }
 
   test("show databases") {
-    val db = "default3"
+    val db = "default"
     try {
       doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $db"))
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -273,6 +273,19 @@ abstract class RangerSparkExtensionSuite extends KyuubiFunSuite with SparkSessio
       doAs("admin", sql(s"DROP DATABASE IF EXISTS $db"))
     }
   }
+
+  test("show databases") {
+    val db = "default3"
+    try {
+      doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $db"))
+
+      doAs("admin", assert(sql(s"show databases").collect().length === 1))
+      doAs("bob", assert(sql(s"show databases").collect().length === 0))
+      doAs("i_am_invisible", assert(sql(s"show databases").collect().length === 0))
+    } finally {
+      doAs("admin", sql(s"DROP DATABASE IF EXISTS $db"))
+    }
+  }
 }
 
 class InMemoryCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -275,15 +275,17 @@ abstract class RangerSparkExtensionSuite extends KyuubiFunSuite with SparkSessio
   }
 
   test("show databases") {
-    val db = "default"
+    val db1 = "default"
+    val db2 = "default2"
     try {
-      doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $db"))
+      doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $db1"))
+      doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $db2"))
 
       doAs("admin", assert(sql(s"show databases").collect().length === 1))
       doAs("bob", assert(sql(s"show databases").collect().length === 0))
       doAs("i_am_invisible", assert(sql(s"show databases").collect().length === 0))
     } finally {
-      doAs("admin", sql(s"DROP DATABASE IF EXISTS $db"))
+      doAs("admin", sql(s"DROP DATABASE IF EXISTS $db2"))
     }
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -282,7 +282,7 @@ abstract class RangerSparkExtensionSuite extends KyuubiFunSuite with SparkSessio
       doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $db2"))
 
       doAs("admin", assert(sql(s"show databases").collect().length === 2))
-      doAs("bob", assert(sql(s"show databases").collect().length === 0))
+      doAs("bob", assert(sql(s"show databases").collect().length === 1))
       doAs("i_am_invisible", assert(sql(s"show databases").collect().length === 0))
     } finally {
       doAs("admin", sql(s"DROP DATABASE IF EXISTS $db2"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->
### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When using Kyuubi to access the Spark database, the `show databases` command cannot be used to filter the database by Ranger, causing data security problems for multi-tenants.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
* step1: Grant database permissions through Ranger
  User meimei can access shdw database
  User tuantuan can access tjdw and default databases
![1651884398(1)](https://user-images.githubusercontent.com/19518068/167231209-b5bc280d-201b-42e7-a613-32d593efbad8.png)

* step2: 
Kyuubi integrates Ranger and then accesses it with the following command:
```
# meimei test
$ externals/spark-3.2.1-bin-hadoop3.2/bin/beeline -u jdbc:hive2://xx.xxx.xx.xxx:10011/default -n meimei -pxxxxxx
0: jdbc:hive2://xx.xxx.xx.xxx:10011/default>show databases;
+------------+
| namespace  |
+------------+
| shdw       |
+------------+
0: jdbc:hive2://10.2.1.6:10011/default> use tjdw;
Error: Error operating EXECUTE_STATEMENT: java.lang.RuntimeException: Permission denied: user [meimei] does not have [_any] privilege on [tjdw]

# tuantuan test
$ externals/spark-3.2.1-bin-hadoop3.2/bin/beeline -u jdbc:hive2://xx.xxx.xx.xxx:10011/default -n tuantuan -pxxxxxx
0: jdbc:hive2://xx.xxx.xx.xxx:10011/default>show databases;
+------------+
| namespace  |
+------------+
| default    |
| tjdw       |
+------------+
0: jdbc:hive2://10.2.1.6:10011/default> use shdw;
Error: Error operating EXECUTE_STATEMENT: java.lang.RuntimeException: Permission denied: user [tuantuan] does not have [_any] privilege on [shdw]
```
- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
