### PR TITLE
[KYUUBI #2493][FOLLOWUP] Fix the exception that occurred when beeline rendered spark progress

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkProgressMonitor.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SparkProgressMonitor.scala
@@ -90,7 +90,8 @@ class SparkProgressMonitor(spark: SparkSession, jobGroup: String) {
           String.valueOf(complete),
           String.valueOf(running),
           String.valueOf(pending),
-          String.valueOf(failed))
+          String.valueOf(failed),
+          "")
     }.toList.asJavaCollection
     new util.ArrayList[util.List[String]](progressRows)
   }
@@ -165,7 +166,8 @@ object SparkProgressMonitor {
     "COMPLETED",
     "RUNNING",
     "PENDING",
-    "FAILED")
+    "FAILED",
+    "")
 
   private val COLUMN_1_WIDTH = 16
 

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationProgressSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationProgressSuite.scala
@@ -68,15 +68,16 @@ class SparkOperationProgressSuite extends WithSparkSQLEngine with HiveJDBCTestHe
           "COMPLETED",
           "RUNNING",
           "PENDING",
-          "FAILED"))(headers.asScala)
+          "FAILED",
+          ""))(headers.asScala)
         assert(rows.size() == 1)
         progress match {
           case 0.0 =>
-            assert(Seq(s"Stage-$initStageId ", "0", "PENDING", "2", "0", "0", "2", "0")
+            assert(Seq(s"Stage-$initStageId ", "0", "PENDING", "2", "0", "0", "2", "0", "")
               == rows.get(0).asScala ||
-              Seq(s"Stage-$initStageId ", "0", "RUNNING", "2", "0", "1", "1", "0")
+              Seq(s"Stage-$initStageId ", "0", "RUNNING", "2", "0", "1", "1", "0", "")
               == rows.get(0).asScala ||
-              Seq(s"Stage-$initStageId ", "0", "RUNNING", "2", "0", "2", "0", "0")
+              Seq(s"Stage-$initStageId ", "0", "RUNNING", "2", "0", "2", "0", "0", "")
               == rows.get(0).asScala)
             assert("STAGES: 00/01" === footerSummary)
             assert(TJobExecutionStatus.IN_PROGRESS === status)
@@ -90,7 +91,8 @@ class SparkOperationProgressSuite extends WithSparkSQLEngine with HiveJDBCTestHe
               "1",
               "1",
               "0",
-              "0"))(
+              "0",
+              ""))(
               rows.get(0).asScala)
             assert("STAGES: 00/01" === footerSummary)
             assert(TJobExecutionStatus.IN_PROGRESS === status)
@@ -104,7 +106,8 @@ class SparkOperationProgressSuite extends WithSparkSQLEngine with HiveJDBCTestHe
               "2",
               "0",
               "0",
-              "0"))(
+              "0",
+              ""))(
               rows.get(0).asScala)
             assert("STAGES: 01/01" === footerSummary)
             checkFlag3 = true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

followup #2493 

As discussed in https://github.com/apache/incubator-kyuubi/pull/2529#issuecomment-1120440354, we still need to add the last empty column to prevent exceptions when the beeline renders spark progress.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Add screenshots for manual tests if appropriate
![image](https://user-images.githubusercontent.com/17894939/167349075-b9ab7e40-2941-4d33-824f-1e7bcc5f3838.png)
![image](https://user-images.githubusercontent.com/17894939/167349125-61ef4ef5-40d0-4986-8c06-bc48b065ec3a.png)

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
