### PR TITLE
Client should not assume launch engine has completed on exception

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiReservedKeys.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiReservedKeys.scala
@@ -21,4 +21,8 @@ object KyuubiReservedKeys {
   final val KYUUBI_SESSION_USER_KEY = "kyuubi.session.user"
   final val KYUUBI_STATEMENT_ID_KEY = "kyuubi.statement.id"
   final val KYUUBI_ENGINE_SUBMIT_TIME_KEY = "kyuubi.engine.submit.time"
+  final val KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_GUID =
+    "kyuubi.session.engine.launch.handle.guid"
+  final val KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_SECRET =
+    "kyuubi.session.engine.launch.handle.secret"
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/Operation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/Operation.scala
@@ -49,4 +49,7 @@ trait Operation {
 object Operation {
   val DEFAULT_FETCH_ORIENTATION_SET: Set[FetchOrientation] =
     Set(FetchOrientation.FETCH_NEXT, FetchOrientation.FETCH_FIRST, FetchOrientation.FETCH_PRIOR)
+
+  val LAUNCH_ENGINE_GUID = "kyuubi.session.engine.launch.handle.guid"
+  val LAUNCH_ENGINE_SECRET = "kyuubi.session.engine.launch.handle.secret"
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/Operation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/Operation.scala
@@ -49,7 +49,4 @@ trait Operation {
 object Operation {
   val DEFAULT_FETCH_ORIENTATION_SET: Set[FetchOrientation] =
     Set(FetchOrientation.FETCH_NEXT, FetchOrientation.FETCH_FIRST, FetchOrientation.FETCH_PRIOR)
-
-  val LAUNCH_ENGINE_GUID = "kyuubi.session.engine.launch.handle.guid"
-  val LAUNCH_ENGINE_SECRET = "kyuubi.session.engine.launch.handle.secret"
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/HiveJDBCTestHelper.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/HiveJDBCTestHelper.scala
@@ -93,6 +93,12 @@ trait HiveJDBCTestHelper extends JDBCTestHelper {
     TClientTestUtils.withSessionHandle(hostAndPort, sessionConfigs)(f)
   }
 
+  def withSessionAndLaunchEngineHandle[T](
+      f: (TCLIService.Iface, TSessionHandle, Option[TOperationHandle]) => T): T = {
+    val hostAndPort = jdbcUrl.stripPrefix(URL_PREFIX).split("/;").head
+    TClientTestUtils.withSessionAndLaunchEngineHandle(hostAndPort, sessionConfigs)(f)
+  }
+
   def checkGetSchemas(rs: ResultSet, dbNames: Seq[String], catalogName: String = ""): Unit = {
     var count = 0
     while (rs.next()) {

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
@@ -28,7 +28,7 @@ import org.apache.thrift.protocol.TBinaryProtocol
 import org.apache.thrift.transport.TSocket
 
 import org.apache.kyuubi.{Logging, Utils}
-import org.apache.kyuubi.operation.Operation._
+import org.apache.kyuubi.config.KyuubiReservedKeys._
 import org.apache.kyuubi.service.FrontendService
 import org.apache.kyuubi.service.authentication.PlainSASLHelper
 
@@ -90,8 +90,8 @@ object TClientTestUtils extends Logging {
       val resp = client.OpenSession(req)
       val sessionHandle = resp.getSessionHandle
 
-      val guid = resp.getConfiguration.get(LAUNCH_ENGINE_GUID)
-      val secret = resp.getConfiguration.get(LAUNCH_ENGINE_SECRET)
+      val guid = resp.getConfiguration.get(KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_GUID)
+      val secret = resp.getConfiguration.get(KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_SECRET)
 
       val launchOpHandleOpt =
         if (guid != null && secret != null) {

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
@@ -17,14 +17,18 @@
 
 package org.apache.kyuubi.operation
 
+import java.nio.ByteBuffer
+import java.util.Base64
+
 import scala.collection.JavaConverters._
 
-import org.apache.hive.service.rpc.thrift.{TCLIService, TCloseSessionReq, TOpenSessionReq, TSessionHandle}
+import org.apache.hive.service.rpc.thrift.{TCLIService, TCloseSessionReq, THandleIdentifier, TOpenSessionReq, TOperationHandle, TOperationType, TSessionHandle}
 import org.apache.hive.service.rpc.thrift.TCLIService.Iface
 import org.apache.thrift.protocol.TBinaryProtocol
 import org.apache.thrift.transport.TSocket
 
 import org.apache.kyuubi.{Logging, Utils}
+import org.apache.kyuubi.operation.Operation._
 import org.apache.kyuubi.service.FrontendService
 import org.apache.kyuubi.service.authentication.PlainSASLHelper
 
@@ -71,6 +75,40 @@ object TClientTestUtils extends Logging {
           client.CloseSession(tCloseSessionReq)
         } catch {
           case e: Exception => error(s"Failed to close $handle", e)
+        }
+      }
+    }
+  }
+
+  def withSessionAndLaunchEngineHandle[T](url: String, configs: Map[String, String])(
+      f: (TCLIService.Iface, TSessionHandle, Option[TOperationHandle]) => T): T = {
+    withThriftClient(url) { client =>
+      val req = new TOpenSessionReq()
+      req.setUsername(Utils.currentUser)
+      req.setPassword("anonymous")
+      req.setConfiguration(configs.asJava)
+      val resp = client.OpenSession(req)
+      val sessionHandle = resp.getSessionHandle
+
+      val guid = resp.getConfiguration.get(LAUNCH_ENGINE_GUID)
+      val secret = resp.getConfiguration.get(LAUNCH_ENGINE_SECRET)
+
+      val launchOpHandleOpt =
+        if (guid != null && secret != null) {
+          val launchHandleId = new THandleIdentifier(
+            ByteBuffer.wrap(Base64.getMimeDecoder.decode(guid)),
+            ByteBuffer.wrap(Base64.getMimeDecoder.decode(secret)))
+          Some(new TOperationHandle(launchHandleId, TOperationType.UNKNOWN, false))
+        } else None
+
+      try {
+        f(client, sessionHandle, launchOpHandleOpt)
+      } finally {
+        val tCloseSessionReq = new TCloseSessionReq(sessionHandle)
+        try {
+          client.CloseSession(tCloseSessionReq)
+        } catch {
+          case e: Exception => error(s"Failed to close $sessionHandle", e)
         }
       }
     }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/TClientTestUtils.scala
@@ -22,7 +22,7 @@ import java.util.Base64
 
 import scala.collection.JavaConverters._
 
-import org.apache.hive.service.rpc.thrift.{TCLIService, TCloseSessionReq, THandleIdentifier, TOpenSessionReq, TOperationHandle, TOperationType, TSessionHandle}
+import org.apache.hive.service.rpc.thrift._
 import org.apache.hive.service.rpc.thrift.TCLIService.Iface
 import org.apache.thrift.protocol.TBinaryProtocol
 import org.apache.thrift.transport.TSocket

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -1704,18 +1704,11 @@ public class KyuubiConnection implements java.sql.Connection, KyuubiLoggable {
     if (launchEngineOpHandle == null) return;
 
     TGetOperationStatusReq statusReq = new TGetOperationStatusReq(launchEngineOpHandle);
-    TGetOperationStatusResp statusResp = null;
 
     // Poll on the operation status, till the operation is complete
     while (!launchEngineOpCompleted) {
       try {
-        try {
-          statusResp = client.GetOperationStatus(statusReq);
-        } catch (Exception e) {
-          LOG.debug("Failed to get launch engine operation status, assume it has completed", e);
-          launchEngineOpCompleted = true;
-          break;
-        }
+        TGetOperationStatusResp statusResp = client.GetOperationStatus(statusReq);
         Utils.verifySuccessWithInfo(statusResp.getStatus());
         if (statusResp.isSetOperationState()) {
           switch (statusResp.getOperationState()) {
@@ -1747,7 +1740,7 @@ public class KyuubiConnection implements java.sql.Connection, KyuubiLoggable {
         engineLogInflight = false;
         closeOnLaunchEngineFailure();
         if (e instanceof SQLException) {
-          throw e;
+          throw (SQLException) e;
         } else {
           throw new SQLException(e.getMessage(), "08S01", e);
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -23,6 +23,7 @@ import org.apache.hive.service.rpc.thrift.{TOpenSessionReq, TOpenSessionResp, TR
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.ha.client.{KyuubiServiceDiscovery, ServiceDiscovery}
+import org.apache.kyuubi.operation.Operation._
 import org.apache.kyuubi.service.{Serverable, Service, TBinaryFrontendService}
 import org.apache.kyuubi.service.TFrontendService.{CURRENT_SERVER_CONTEXT, OK_STATUS}
 import org.apache.kyuubi.session.KyuubiSessionImpl
@@ -52,10 +53,10 @@ final class KyuubiTBinaryFrontendService(
 
       val opHandleIdentifier = launchEngineOp.getHandle.identifier.toTHandleIdentifier
       respConfiguration.put(
-        "kyuubi.session.engine.launch.handle.guid",
+        LAUNCH_ENGINE_GUID,
         Base64.getMimeEncoder.encodeToString(opHandleIdentifier.getGuid))
       respConfiguration.put(
-        "kyuubi.session.engine.launch.handle.secret",
+        LAUNCH_ENGINE_SECRET,
         Base64.getMimeEncoder.encodeToString(opHandleIdentifier.getSecret))
 
       resp.setSessionHandle(sessionHandle.toTSessionHandle)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTBinaryFrontendService.scala
@@ -19,11 +19,11 @@ package org.apache.kyuubi.server
 
 import java.util.Base64
 
-import org.apache.hive.service.rpc.thrift.{TOpenSessionReq, TOpenSessionResp, TRenewDelegationTokenReq, TRenewDelegationTokenResp}
+import org.apache.hive.service.rpc.thrift._
 
 import org.apache.kyuubi.KyuubiSQLException
+import org.apache.kyuubi.config.KyuubiReservedKeys._
 import org.apache.kyuubi.ha.client.{KyuubiServiceDiscovery, ServiceDiscovery}
-import org.apache.kyuubi.operation.Operation._
 import org.apache.kyuubi.service.{Serverable, Service, TBinaryFrontendService}
 import org.apache.kyuubi.service.TFrontendService.{CURRENT_SERVER_CONTEXT, OK_STATUS}
 import org.apache.kyuubi.session.KyuubiSessionImpl
@@ -53,10 +53,10 @@ final class KyuubiTBinaryFrontendService(
 
       val opHandleIdentifier = launchEngineOp.getHandle.identifier.toTHandleIdentifier
       respConfiguration.put(
-        LAUNCH_ENGINE_GUID,
+        KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_GUID,
         Base64.getMimeEncoder.encodeToString(opHandleIdentifier.getGuid))
       respConfiguration.put(
-        LAUNCH_ENGINE_SECRET,
+        KYUUBI_SESSION_ENGINE_LAUNCH_HANDLE_SECRET,
         Base64.getMimeEncoder.encodeToString(opHandleIdentifier.getSecret))
 
       resp.setSessionHandle(sessionHandle.toTSessionHandle)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -135,7 +135,8 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         assert(executeStmtResp.getStatus.getErrorMessage.contains("kyuubi-spark-sql-engine.log"))
 
         val launchEngineResp = client.GetOperationStatus(new TGetOperationStatusReq(launchOpHandle))
-        assert(launchEngineResp.getStatus.getStatusCode == TStatusCode.INVALID_HANDLE_STATUS)
+        assert(launchEngineResp.getStatus.getStatusCode == TStatusCode.SUCCESS_STATUS)
+        assert(launchEngineResp.getOperationState == TOperationState.ERROR_STATE)
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`LaunchEngineOp` will never close until session is closed, the client should not assume launch engine has completed on exception.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
