### PR TITLE
[KYUUBI #2642] Fix flaky test - JpsApplicationOperation with spark local mode

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
@@ -22,7 +22,6 @@ import java.nio.file.Paths
 import scala.sys.process._
 
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.engine.ApplicationOperation.NOT_FOUND
 
 class JpsApplicationOperation extends ApplicationOperation {
   import ApplicationOperation._
@@ -51,11 +50,7 @@ class JpsApplicationOperation extends ApplicationOperation {
       None
     } else {
       val pb = s"$runner -ml" #| s"grep $tag"
-      try {
-        pb.lineStream_!.headOption
-      } catch {
-        case _: Throwable => None
-      }
+      pb.lineStream_!.headOption
     }
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
@@ -50,7 +50,11 @@ class JpsApplicationOperation extends ApplicationOperation {
       None
     } else {
       val pb = s"$runner -ml" #| s"grep $tag"
-      pb.lineStream_!.headOption
+      try {
+        pb.lineStream_!.headOption
+      } catch {
+        case _: Throwable => None
+      }
     }
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
@@ -36,6 +36,7 @@ class JpsApplicationOperation extends ApplicationOperation {
     runner =
       try {
         jps.!!
+        jps
       } catch {
         case _: Throwable => null
       }
@@ -49,7 +50,7 @@ class JpsApplicationOperation extends ApplicationOperation {
     if (runner == null) {
       None
     } else {
-      val pb = "jps -ml" #| s"grep $tag"
+      val pb = s"$runner -ml" #| s"grep $tag"
       try {
         pb.lineStream_!.headOption
       } catch {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/JpsApplicationOperationSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/JpsApplicationOperationSuite.scala
@@ -81,11 +81,10 @@ class JpsApplicationOperationSuite extends KyuubiFunSuite {
       assert(desc1.contains("id"))
       assert(desc1("name").contains(id))
       assert(desc1("state") === "RUNNING")
+      val response = jps.killApplicationByTag(id)
+      assert(response._1, response._2)
+      assert(response._2 startsWith "Succeeded to terminate:")
     }
-
-    val response = jps.killApplicationByTag(id)
-    assert(response._1, response._2)
-    assert(response._2 startsWith "Succeeded to terminate:")
 
     val desc2 = jps.getApplicationInfoByTag(id)
     assert(!desc2.contains("id"))

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/JpsApplicationOperationSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/JpsApplicationOperationSuite.scala
@@ -86,10 +86,13 @@ class JpsApplicationOperationSuite extends KyuubiFunSuite {
       assert(response._2 startsWith "Succeeded to terminate:")
     }
 
-    val desc2 = jps.getApplicationInfoByTag(id)
-    assert(!desc2.contains("id"))
-    assert(!desc2.contains("name"))
-    assert(desc2("state") === "FINISHED")
+    eventually(Timeout(10.seconds)) {
+      val desc2 = jps.getApplicationInfoByTag(id)
+      assert(!desc2.contains("id"))
+      assert(!desc2.contains("name"))
+      assert(desc2("state") === "FINISHED")
+    }
+
     val response2 = jps.killApplicationByTag(id)
     assert(!response2._1)
     assert(response2._2 === ApplicationOperation.NOT_FOUND)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To close #2642 

In this PR, we put the `getApplicationInfoByTag` and `killApplicationByTag` into the same `eventually` block to try to fix the confused flaky test.
Since we kill the application with signal `SIGTERM`,  so the process is not terminated immediately.
[SIGTERM vs SIGKILL: What's the Difference?](https://linuxhandbook.com/sigterm-vs-sigkill/)
So we have to wrap the following `getApplicationInfoByTag` block(assert the application is finished) with `eventually` after `killApplicationByTag`.

BTW, we fix a potential issue in case that the `jps` command is not in the PATH.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
