### PR TITLE
[KYUUBI #2285] trino's result fetching method is changed to a streaming iterator mode to avoid hold data at server side

### DIFF
--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatement.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatement.scala
@@ -17,16 +17,11 @@
 
 package org.apache.kyuubi.engine.trino
 
-import java.util.ArrayList
-import java.util.concurrent.ArrayBlockingQueue
 import java.util.concurrent.Executors
 
+import scala.annotation.tailrec
 import scala.collection.JavaConverters._
-import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.concurrent.duration
-import scala.concurrent.duration.Duration
 
 import com.google.common.base.Verify
 import io.trino.client.ClientSession
@@ -38,7 +33,6 @@ import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.trino.TrinoConf.DATA_PROCESSING_POOL_SIZE
-import org.apache.kyuubi.engine.trino.TrinoStatement._
 
 /**
  * Trino client communicate with trino cluster.
@@ -80,63 +74,34 @@ class TrinoStatement(
     }
   }
 
-  /**
-   * Execute sql and return ResultSet.
-   */
-  def execute(): Iterable[List[Any]] = {
-    val rowQueue = new ArrayBlockingQueue[List[Any]](MAX_QUEUED_ROWS)
-
-    val dataProcessing = Future[Unit] {
-      while (trino.isRunning) {
-        val data = trino.currentData().getData()
-        if (data != null) {
-          data.asScala.map(_.asScala.toList)
-            .foreach(e => putOrThrow(rowQueue, e))
-        }
-        trino.advance()
-      }
-    }
-    dataProcessing.onComplete {
-      case _ => putOrThrow(rowQueue, END_TOKEN)
-    }
-
-    val rowBuffer = new ArrayList[List[Any]](MAX_BUFFERED_ROWS)
-    var bufferStart = System.nanoTime()
-    val result = ArrayBuffer[List[Any]]()
-
-    var getDataEnd = false
-    while (!dataProcessing.isCompleted && !getDataEnd) {
-      val atEnd = drainDetectingEnd(rowQueue, rowBuffer, MAX_BUFFERED_ROWS, END_TOKEN)
-      if (!atEnd) {
-        // Flush if needed
-        if (rowBuffer.size() >= MAX_BUFFERED_ROWS ||
-          Duration.fromNanos(bufferStart).compareTo(MAX_BUFFER_TIME) >= 0) {
-          result ++= rowBuffer.asScala
-          rowBuffer.clear()
-          bufferStart = System.nanoTime()
-        }
-
-        val row = rowQueue.poll(MAX_BUFFER_TIME.toMillis, duration.MILLISECONDS)
-        row match {
-          case END_TOKEN => getDataEnd = true
-          case null =>
-          case _ => rowBuffer.add(row)
+  def execute(): Iterator[List[Any]] = {
+    Iterator.continually {
+      @tailrec
+      def getData(): (Boolean, List[List[Any]]) = {
+        if (trino.isRunning) {
+          val data = trino.currentData().getData()
+          trino.advance()
+          if (data != null) {
+            (true, data.asScala.toList.map(_.asScala.toList))
+          } else {
+            getData()
+          }
+        } else {
+          Verify.verify(trino.isFinished)
+          val finalStatus = trino.finalStatusInfo()
+          if (finalStatus.getError() != null) {
+            throw KyuubiSQLException(
+              s"Query ${finalStatus.getId} failed: ${finalStatus.getError.getMessage}")
+          }
+          updateTrinoContext()
+          (false, List[List[Any]]())
         }
       }
+      getData()
     }
-    if (!rowQueue.isEmpty()) {
-      drainDetectingEnd(rowQueue, rowBuffer, Integer.MAX_VALUE, END_TOKEN)
-    }
-    result ++= rowBuffer.asScala
+      .takeWhile(_._1)
+      .flatMap(_._2)
 
-    val finalStatus = trino.finalStatusInfo()
-    if (finalStatus.getError() != null) {
-      throw KyuubiSQLException(
-        s"Query ${finalStatus.getId} failed: ${finalStatus.getError.getMessage}")
-    }
-    updateTrinoContext()
-
-    result
   }
 
   def updateTrinoContext(): Unit = {
@@ -165,38 +130,9 @@ class TrinoStatement(
 
     trinoContext.clientSession.set(builder.build())
   }
-
-  private def drainDetectingEnd(
-      rowQueue: ArrayBlockingQueue[List[Any]],
-      buffer: ArrayList[List[Any]],
-      maxBufferSize: Int,
-      endToken: List[Any]): Boolean = {
-    val drained = rowQueue.drainTo(buffer, maxBufferSize - buffer.size)
-    if (drained > 0 && buffer.get(buffer.size() - 1) == endToken) {
-      buffer.remove(buffer.size() - 1);
-      true
-    } else {
-      false
-    }
-  }
-
-  private def putOrThrow(rowQueue: ArrayBlockingQueue[List[Any]], e: List[Any]): Unit = {
-    try {
-      rowQueue.put(e)
-    } catch {
-      case e: InterruptedException =>
-        Thread.currentThread().interrupt()
-        throw new RuntimeException(e)
-    }
-  }
 }
 
 object TrinoStatement {
-  final private val MAX_QUEUED_ROWS = 50000
-  final private val MAX_BUFFERED_ROWS = 10000
-  final private val MAX_BUFFER_TIME = Duration(3, duration.SECONDS)
-  final private val END_TOKEN = List[Any]()
-
   def apply(trinoContext: TrinoContext, kyuubiConf: KyuubiConf, sql: String): TrinoStatement = {
     new TrinoStatement(trinoContext, kyuubiConf, sql)
   }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetCatalogs.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetCatalogs.scala
@@ -18,8 +18,7 @@
 package org.apache.kyuubi.engine.trino.operation
 
 import org.apache.kyuubi.engine.trino.TrinoStatement
-import org.apache.kyuubi.operation.IterableFetchIterator
-import org.apache.kyuubi.operation.OperationType
+import org.apache.kyuubi.operation.{ArrayFetchIterator, OperationType}
 import org.apache.kyuubi.session.Session
 
 class GetCatalogs(session: Session)
@@ -33,7 +32,7 @@ class GetCatalogs(session: Session)
         "SELECT TABLE_CAT FROM system.jdbc.catalogs")
       schema = trinoStatement.getColumns
       val resultSet = trinoStatement.execute()
-      iter = new IterableFetchIterator(resultSet)
+      iter = new ArrayFetchIterator(resultSet.toArray)
     } catch onError()
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetColumns.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetColumns.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.commons.lang3.StringUtils
 
 import org.apache.kyuubi.engine.trino.TrinoStatement
-import org.apache.kyuubi.operation.{IterableFetchIterator, OperationType}
+import org.apache.kyuubi.operation.{ArrayFetchIterator, OperationType}
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant.{COLUMN_NAME, TABLE_CAT, TABLE_NAME, TABLE_SCHEM}
 import org.apache.kyuubi.session.Session
 
@@ -71,7 +71,7 @@ class GetColumns(
         TrinoStatement(trinoContext, session.sessionManager.getConf, query.toString)
       schema = trinoStatement.getColumns
       val resultSet = trinoStatement.execute()
-      iter = new IterableFetchIterator(resultSet)
+      iter = new ArrayFetchIterator(resultSet.toArray)
     } catch onError()
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetSchemas.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetSchemas.scala
@@ -22,8 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.commons.lang3.StringUtils
 
 import org.apache.kyuubi.engine.trino.TrinoStatement
-import org.apache.kyuubi.operation.IterableFetchIterator
-import org.apache.kyuubi.operation.OperationType
+import org.apache.kyuubi.operation.{ArrayFetchIterator, OperationType}
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant.TABLE_CATALOG
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant.TABLE_SCHEM
 import org.apache.kyuubi.session.Session
@@ -56,7 +55,7 @@ class GetSchemas(session: Session, catalogName: String, schemaPattern: String)
         query.toString)
       schema = trinoStatement.getColumns
       val resultSet = trinoStatement.execute()
-      iter = new IterableFetchIterator(resultSet)
+      iter = new ArrayFetchIterator(resultSet.toArray)
     } catch onError()
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTables.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTables.scala
@@ -22,7 +22,7 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.commons.lang3.StringUtils
 
 import org.apache.kyuubi.engine.trino.TrinoStatement
-import org.apache.kyuubi.operation.{IterableFetchIterator, OperationType}
+import org.apache.kyuubi.operation.{ArrayFetchIterator, OperationType}
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant.{TABLE_CAT, TABLE_NAME, TABLE_SCHEM, TABLE_TYPE}
 import org.apache.kyuubi.session.Session
 
@@ -70,7 +70,7 @@ class GetTables(
         TrinoStatement(trinoContext, session.sessionManager.getConf, query.toString)
       schema = trinoStatement.getColumns
       val resultSet = trinoStatement.execute()
-      iter = new IterableFetchIterator(resultSet)
+      iter = new ArrayFetchIterator(resultSet.toArray)
     } catch onError()
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTypeInfo.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTypeInfo.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.engine.trino.operation
 
 import org.apache.kyuubi.engine.trino.TrinoStatement
-import org.apache.kyuubi.operation.{IterableFetchIterator, OperationType}
+import org.apache.kyuubi.operation.{ArrayFetchIterator, OperationType}
 import org.apache.kyuubi.session.Session
 
 class GetTypeInfo(session: Session)
@@ -38,7 +38,7 @@ class GetTypeInfo(session: Session)
           |""".stripMargin)
       schema = trinoStatement.getColumns
       val resultSet = trinoStatement.execute()
-      iter = new IterableFetchIterator(resultSet)
+      iter = new ArrayFetchIterator(resultSet.toArray)
     } catch onError()
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
@@ -32,10 +32,7 @@ import org.apache.kyuubi.engine.trino.schema.SchemaHelper
 import org.apache.kyuubi.engine.trino.session.TrinoSessionImpl
 import org.apache.kyuubi.operation.AbstractOperation
 import org.apache.kyuubi.operation.FetchIterator
-import org.apache.kyuubi.operation.FetchOrientation.FETCH_FIRST
-import org.apache.kyuubi.operation.FetchOrientation.FETCH_NEXT
-import org.apache.kyuubi.operation.FetchOrientation.FETCH_PRIOR
-import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
+import org.apache.kyuubi.operation.FetchOrientation.{FETCH_FIRST, FETCH_NEXT, FETCH_PRIOR, FetchOrientation}
 import org.apache.kyuubi.operation.OperationState
 import org.apache.kyuubi.operation.OperationType.OperationType
 import org.apache.kyuubi.operation.log.OperationLog
@@ -60,8 +57,8 @@ abstract class TrinoOperation(opType: OperationType, session: Session)
     setHasResultSet(true)
     order match {
       case FETCH_NEXT => iter.fetchNext()
-      case FETCH_PRIOR => iter.fetchPrior(rowSetSize);
-      case FETCH_FIRST => iter.fetchAbsolute(0);
+      case FETCH_PRIOR => iter.fetchPrior(rowSetSize)
+      case FETCH_FIRST => iter.fetchAbsolute(0)
     }
     val taken = iter.take(rowSetSize)
     val resultRowSet = RowSet.toTRowSet(taken.toList, schema, getProtocolVersion)

--- a/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/TrinoStatementSuite.scala
+++ b/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/TrinoStatementSuite.scala
@@ -52,8 +52,8 @@ class TrinoStatementSuite extends WithTrinoContainerServer {
       assert(this.schema === trinoStatement.getCurrentDatabase)
 
       val trinoStatement2 = TrinoStatement(trinoContext, kyuubiConf, "use sf1")
-      trinoStatement2.execute()
-
+      // if trinoStatement.execute return iterator is lazy, call toArray to strict evaluation
+      trinoStatement2.execute().toArray
       assert("sf1" === trinoStatement2.getCurrentDatabase)
     }
   }
@@ -61,7 +61,7 @@ class TrinoStatementSuite extends WithTrinoContainerServer {
   test("test exception") {
     withTrinoContainer { trinoContext =>
       val trinoStatement = TrinoStatement(trinoContext, kyuubiConf, "use kyuubi")
-      val e1 = intercept[KyuubiSQLException](trinoStatement.execute())
+      val e1 = intercept[KyuubiSQLException](trinoStatement.execute().toArray)
       assert(e1.getMessage.contains("Schema does not exist: tpch.kyuubi"))
     }
   }

--- a/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperationIncrementCollectSuite.scala
+++ b/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperationIncrementCollectSuite.scala
@@ -17,22 +17,10 @@
 
 package org.apache.kyuubi.engine.trino.operation
 
-import org.apache.kyuubi.engine.trino.TrinoStatement
-import org.apache.kyuubi.operation.{ArrayFetchIterator, OperationType}
-import org.apache.kyuubi.session.Session
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_TRINO_CONNECTION_CATALOG, OPERATION_INCREMENTAL_COLLECT}
 
-class GetTableTypes(session: Session)
-  extends TrinoOperation(OperationType.GET_TABLE_TYPES, session) {
-
-  override protected def runInternal(): Unit = {
-    try {
-      val trinoStatement = TrinoStatement(
-        trinoContext,
-        session.sessionManager.getConf,
-        "SELECT TABLE_TYPE FROM system.jdbc.table_types")
-      schema = trinoStatement.getColumns
-      val resultSet = trinoStatement.execute()
-      iter = new ArrayFetchIterator(resultSet.toArray)
-    } catch onError()
-  }
+class TrinoOperationIncrementCollectSuite extends TrinoOperationSuite {
+  override def withKyuubiConf: Map[String, String] = Map(
+    ENGINE_TRINO_CONNECTION_CATALOG.key -> "memory",
+    OPERATION_INCREMENTAL_COLLECT.key -> "true")
 }

--- a/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperationSuite.scala
+++ b/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperationSuite.scala
@@ -34,7 +34,7 @@ import org.apache.hive.service.rpc.thrift.TOperationState
 import org.apache.hive.service.rpc.thrift.TStatusCode
 
 import org.apache.kyuubi.KyuubiSQLException
-import org.apache.kyuubi.config.KyuubiConf.ENGINE_TRINO_CONNECTION_CATALOG
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_TRINO_CONNECTION_CATALOG, OPERATION_INCREMENTAL_COLLECT}
 import org.apache.kyuubi.engine.trino.TrinoQueryTests
 import org.apache.kyuubi.engine.trino.WithTrinoEngine
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
@@ -609,19 +609,27 @@ class TrinoOperationSuite extends WithTrinoEngine with TrinoQueryTests {
       val idSeq2 = tFetchResultsResp2.getResults.getColumns.get(0).getI32Val.getValues.asScala.toSeq
       assertResult(Seq(1L))(idSeq2)
 
-      // fetch prior from second row, expected got first row
       val tFetchResultsReq3 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_PRIOR, 1)
       val tFetchResultsResp3 = client.FetchResults(tFetchResultsReq3)
-      assert(tFetchResultsResp3.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
-      val idSeq3 = tFetchResultsResp3.getResults.getColumns.get(0).getI32Val.getValues.asScala.toSeq
-      assertResult(Seq(0L))(idSeq3)
+      if (kyuubiConf.get(OPERATION_INCREMENTAL_COLLECT)) {
+        assert(tFetchResultsResp3.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+      } else {
+        assert(tFetchResultsResp3.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq3 =
+          tFetchResultsResp3.getResults.getColumns.get(0).getI32Val.getValues.asScala.toSeq
+        assertResult(Seq(0L))(idSeq3)
+      }
 
-      // fetch first
       val tFetchResultsReq4 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_FIRST, 3)
       val tFetchResultsResp4 = client.FetchResults(tFetchResultsReq4)
-      assert(tFetchResultsResp4.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
-      val idSeq4 = tFetchResultsResp4.getResults.getColumns.get(0).getI32Val.getValues.asScala.toSeq
-      assertResult(Seq(0L, 1L))(idSeq4)
+      if (kyuubiConf.get(OPERATION_INCREMENTAL_COLLECT)) {
+        assert(tFetchResultsResp4.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+      } else {
+        assert(tFetchResultsResp4.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq4 =
+          tFetchResultsResp4.getResults.getColumns.get(0).getI32Val.getValues.asScala.toSeq
+        assertResult(Seq(0L, 1L))(idSeq4)
+      }
     }
   }
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/FetchIterator.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/FetchIterator.scala
@@ -109,3 +109,26 @@ class IterableFetchIterator[A](iterable: Iterable[A]) extends FetchIterator[A] {
     }
   }
 }
+
+object FetchIterator {
+
+  def fromIterator[A](iter: Iterator[A]): FetchIterator[A] = new FetchIterator[A] {
+
+    private var fetchStart: Long = 0
+
+    private var position: Long = 0
+
+    override def fetchNext(): Unit = fetchStart = position
+    override def hasNext: Boolean = iter.hasNext
+    override def next(): A = {
+      position += 1
+      iter.next()
+    }
+
+    override def fetchAbsolute(pos: Long): Unit = {}
+
+    override def getFetchStart: Long = fetchStart
+
+    override def getPosition: Long = position
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. Change to a true iterator implementation to get the results of Trino Server to avoid caching data in memory.
2. Supports FETCH_NEXT mode only, consistent with Trino Server's capabilities


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
