### PR TITLE
[KYUUBI #2690] Make ProcessBuilder.commands immutable

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -167,14 +167,14 @@ private[kyuubi] class EngineRef(
     builder = engineType match {
       case SPARK_SQL =>
         conf.setIfMissing(SparkProcessBuilder.APP_KEY, defaultEngineName)
-        new SparkProcessBuilder(appUser, conf, extraEngineLog, engineRefId)
+        new SparkProcessBuilder(appUser, conf, engineRefId, extraEngineLog)
       case FLINK_SQL =>
         conf.setIfMissing(FlinkProcessBuilder.APP_KEY, defaultEngineName)
-        new FlinkProcessBuilder(appUser, conf, extraEngineLog, engineRefId)
+        new FlinkProcessBuilder(appUser, conf, engineRefId, extraEngineLog)
       case TRINO =>
-        new TrinoProcessBuilder(appUser, conf, extraEngineLog, engineRefId)
+        new TrinoProcessBuilder(appUser, conf, engineRefId, extraEngineLog)
       case HIVE_SQL =>
-        new HiveProcessBuilder(appUser, conf, extraEngineLog, engineRefId)
+        new HiveProcessBuilder(appUser, conf, engineRefId, extraEngineLog)
     }
 
     MetricsSystem.tracing(_.incCount(ENGINE_TOTAL))

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -167,21 +167,15 @@ private[kyuubi] class EngineRef(
     builder = engineType match {
       case SPARK_SQL =>
         conf.setIfMissing(SparkProcessBuilder.APP_KEY, defaultEngineName)
-        new SparkProcessBuilder(appUser, conf, extraEngineLog)
+        new SparkProcessBuilder(appUser, conf, extraEngineLog, engineRefId)
       case FLINK_SQL =>
         conf.setIfMissing(FlinkProcessBuilder.APP_KEY, defaultEngineName)
-        new FlinkProcessBuilder(appUser, conf, extraEngineLog)
+        new FlinkProcessBuilder(appUser, conf, extraEngineLog, engineRefId)
       case TRINO =>
-        new TrinoProcessBuilder(appUser, conf, extraEngineLog)
+        new TrinoProcessBuilder(appUser, conf, extraEngineLog, engineRefId)
       case HIVE_SQL =>
-        new HiveProcessBuilder(appUser, conf, extraEngineLog)
+        new HiveProcessBuilder(appUser, conf, extraEngineLog, engineRefId)
     }
-    // TODO: Better to do this inside ProcBuilder
-    KyuubiApplicationManager.tagApplication(
-      engineRefId,
-      builder.shortName,
-      builder.clusterManager(),
-      builder.conf)
 
     MetricsSystem.tracing(_.incCount(ENGINE_TOTAL))
     try {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -100,9 +100,9 @@ object KyuubiApplicationManager {
   }
 
   private def setupFlinkK8sTag(tag: String, conf: KyuubiConf): Unit = {
-    val originalTag = conf.getOption(FlinkProcessBuilder.APP_KEY).map(_ + ",")
+    val originalTag = conf.getOption(FlinkProcessBuilder.TAG_KEY).map(_ + ",")
     val newTag = s"${originalTag}KYUUBI" + Some(tag).map("," + _).getOrElse("")
-    conf.set(FlinkProcessBuilder.APP_KEY, newTag)
+    conf.set(FlinkProcessBuilder.TAG_KEY, newTag)
   }
 
   /**

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -91,7 +91,7 @@ class KyuubiApplicationManager extends AbstractService("KyuubiApplicationManager
 object KyuubiApplicationManager {
   private def setupSparkYarnTag(tag: String, conf: KyuubiConf): Unit = {
     val originalTag = conf.getOption(SparkProcessBuilder.TAG_KEY).map(_ + ",").getOrElse("")
-    val newTag = s"${originalTag}KYUUBI" + Some(tag).map("," + _).getOrElse("")
+    val newTag = s"${originalTag}KYUUBI" + Some(tag).filterNot(_.isEmpty).map("," + _).getOrElse("")
     conf.set(SparkProcessBuilder.TAG_KEY, newTag)
   }
 
@@ -100,8 +100,8 @@ object KyuubiApplicationManager {
   }
 
   private def setupFlinkK8sTag(tag: String, conf: KyuubiConf): Unit = {
-    val originalTag = conf.getOption(FlinkProcessBuilder.TAG_KEY).map(_ + ",")
-    val newTag = s"${originalTag}KYUUBI" + Some(tag).map("," + _).getOrElse("")
+    val originalTag = conf.getOption(FlinkProcessBuilder.TAG_KEY).map(_ + ",").getOrElse("")
+    val newTag = s"${originalTag}KYUUBI" + Some(tag).filterNot(_.isEmpty).map("," + _).getOrElse("")
     conf.set(FlinkProcessBuilder.TAG_KEY, newTag)
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -23,6 +23,8 @@ import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
 import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.engine.flink.FlinkProcessBuilder
+import org.apache.kyuubi.engine.spark.SparkProcessBuilder
 import org.apache.kyuubi.service.AbstractService
 
 class KyuubiApplicationManager extends AbstractService("KyuubiApplicationManager") {
@@ -88,7 +90,7 @@ class KyuubiApplicationManager extends AbstractService("KyuubiApplicationManager
 
 object KyuubiApplicationManager {
   private def setupSparkYarnTag(tag: String, conf: KyuubiConf): Unit = {
-    val originalTag = conf.getOption("spark.yarn.tags").map(_ + ",").getOrElse("")
+    val originalTag = conf.getOption(SparkProcessBuilder.TAG_KEY).map(_ + ",").getOrElse("")
     val newTag = s"${originalTag}KYUUBI,$tag"
     conf.set("spark.yarn.tags", newTag)
   }
@@ -98,10 +100,9 @@ object KyuubiApplicationManager {
   }
 
   private def setupFlinkK8sTag(tag: String, conf: KyuubiConf): Unit = {
-    // TODO: yarn.tags or flink.yarn.tags, the mess of flink settings confuses me now.
-    val originalTag = conf.getOption("yarn.tags").map(_ + ",")
+    val originalTag = conf.getOption(FlinkProcessBuilder.APP_KEY).map(_ + ",")
     val newTag = s"${originalTag}KYUUBI,$tag"
-    conf.set("yarn.tags", newTag)
+    conf.set(FlinkProcessBuilder.APP_KEY, newTag)
   }
 
   /**

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -91,8 +91,8 @@ class KyuubiApplicationManager extends AbstractService("KyuubiApplicationManager
 object KyuubiApplicationManager {
   private def setupSparkYarnTag(tag: String, conf: KyuubiConf): Unit = {
     val originalTag = conf.getOption(SparkProcessBuilder.TAG_KEY).map(_ + ",").getOrElse("")
-    val newTag = s"${originalTag}KYUUBI,$tag"
-    conf.set("spark.yarn.tags", newTag)
+    val newTag = s"${originalTag}KYUUBI" + Some(tag).map("," + _).getOrElse("")
+    conf.set(SparkProcessBuilder.TAG_KEY, newTag)
   }
 
   private def setupSparkK8sTag(tag: String, conf: KyuubiConf): Unit = {
@@ -101,7 +101,7 @@ object KyuubiApplicationManager {
 
   private def setupFlinkK8sTag(tag: String, conf: KyuubiConf): Unit = {
     val originalTag = conf.getOption(FlinkProcessBuilder.APP_KEY).map(_ + ",")
-    val newTag = s"${originalTag}KYUUBI,$tag"
+    val newTag = s"${originalTag}KYUUBI" + Some(tag).map("," + _).getOrElse("")
     conf.set(FlinkProcessBuilder.APP_KEY, newTag)
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ProcBuilder.scala
@@ -97,7 +97,7 @@ trait ProcBuilder {
 
   protected def proxyUser: String
 
-  protected def commands: Array[String]
+  protected val commands: Array[String]
 
   def conf: KyuubiConf
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilder.scala
@@ -28,7 +28,7 @@ import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_USER_KEY
-import org.apache.kyuubi.engine.ProcBuilder
+import org.apache.kyuubi.engine.{KyuubiApplicationManager, ProcBuilder}
 import org.apache.kyuubi.operation.log.OperationLog
 
 /**
@@ -37,7 +37,8 @@ import org.apache.kyuubi.operation.log.OperationLog
 class FlinkProcessBuilder(
     override val proxyUser: String,
     override val conf: KyuubiConf,
-    val extraEngineLog: Option[OperationLog] = None)
+    val extraEngineLog: Option[OperationLog] = None,
+    val engineRefId: String = "")
   extends ProcBuilder {
 
   private val flinkHome: String = getEngineHome(shortName)
@@ -49,6 +50,7 @@ class FlinkProcessBuilder(
   override protected def mainClass: String = "org.apache.kyuubi.engine.flink.FlinkSQLEngine"
 
   override protected def commands: Array[String] = {
+    KyuubiApplicationManager.tagApplication(engineRefId, shortName, clusterManager(), conf)
     val buffer = new ArrayBuffer[String]()
     buffer += executable
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilder.scala
@@ -56,7 +56,7 @@ class FlinkProcessBuilder(
 
   override protected def mainClass: String = "org.apache.kyuubi.engine.flink.FlinkSQLEngine"
 
-  override protected def commands: Array[String] = {
+  override protected val commands: Array[String] = {
     KyuubiApplicationManager.tagApplication(engineRefId, shortName, clusterManager(), conf)
     val buffer = new ArrayBuffer[String]()
     buffer += executable

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilder.scala
@@ -24,6 +24,8 @@ import java.util.LinkedHashSet
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
+import com.google.common.annotations.VisibleForTesting
+
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
@@ -37,9 +39,14 @@ import org.apache.kyuubi.operation.log.OperationLog
 class FlinkProcessBuilder(
     override val proxyUser: String,
     override val conf: KyuubiConf,
-    val extraEngineLog: Option[OperationLog] = None,
-    val engineRefId: String = "")
+    val engineRefId: String,
+    val extraEngineLog: Option[OperationLog] = None)
   extends ProcBuilder {
+
+  @VisibleForTesting
+  def this(proxyUser: String, conf: KyuubiConf) {
+    this(proxyUser, conf, "")
+  }
 
   private val flinkHome: String = getEngineHome(shortName)
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/hive/HiveProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/hive/HiveProcessBuilder.scala
@@ -53,7 +53,7 @@ class HiveProcessBuilder(
 
   override protected def mainClass: String = "org.apache.kyuubi.engine.hive.HiveSQLEngine"
 
-  override protected def commands: Array[String] = {
+  override protected val commands: Array[String] = {
     KyuubiApplicationManager.tagApplication(engineRefId, shortName, clusterManager(), conf)
     val buffer = new ArrayBuffer[String]()
     buffer += executable

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/hive/HiveProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/hive/HiveProcessBuilder.scala
@@ -28,13 +28,14 @@ import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_HIVE_EXTRA_CLASSPATH, ENGINE_HIVE_JAVA_OPTIONS, ENGINE_HIVE_MEMORY}
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_USER_KEY
-import org.apache.kyuubi.engine.ProcBuilder
+import org.apache.kyuubi.engine.{KyuubiApplicationManager, ProcBuilder}
 import org.apache.kyuubi.operation.log.OperationLog
 
 class HiveProcessBuilder(
     override val proxyUser: String,
     override val conf: KyuubiConf,
-    val extraEngineLog: Option[OperationLog] = None)
+    val extraEngineLog: Option[OperationLog] = None,
+    val engineRefId: String = "")
   extends ProcBuilder with Logging {
 
   private val hiveHome: String = getEngineHome(shortName)
@@ -46,6 +47,7 @@ class HiveProcessBuilder(
   override protected def mainClass: String = "org.apache.kyuubi.engine.hive.HiveSQLEngine"
 
   override protected def commands: Array[String] = {
+    KyuubiApplicationManager.tagApplication(engineRefId, shortName, clusterManager(), conf)
     val buffer = new ArrayBuffer[String]()
     buffer += executable
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/hive/HiveProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/hive/HiveProcessBuilder.scala
@@ -24,6 +24,8 @@ import java.util.LinkedHashSet
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
+import com.google.common.annotations.VisibleForTesting
+
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_HIVE_EXTRA_CLASSPATH, ENGINE_HIVE_JAVA_OPTIONS, ENGINE_HIVE_MEMORY}
@@ -34,9 +36,14 @@ import org.apache.kyuubi.operation.log.OperationLog
 class HiveProcessBuilder(
     override val proxyUser: String,
     override val conf: KyuubiConf,
-    val extraEngineLog: Option[OperationLog] = None,
-    val engineRefId: String = "")
+    val engineRefId: String,
+    val extraEngineLog: Option[OperationLog] = None)
   extends ProcBuilder with Logging {
+
+  @VisibleForTesting
+  def this(proxyUser: String, conf: KyuubiConf) {
+    this(proxyUser, conf, "")
+  }
 
   private val hiveHome: String = getEngineHome(shortName)
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
@@ -37,7 +37,7 @@ class SparkBatchProcessBuilder(
 
   override def mainResource: Option[String] = Option(batchRequest.getResource)
 
-  override protected def commands: Array[String] = {
+  override protected val commands: Array[String] = {
     val buffer = new ArrayBuffer[String]()
     buffer += executable
     Option(mainClass).foreach { cla =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
@@ -30,7 +30,7 @@ class SparkBatchProcessBuilder(
     batchId: String,
     batchRequest: BatchRequest,
     override val extraEngineLog: Option[OperationLog])
-  extends SparkProcessBuilder(proxyUser, conf, extraEngineLog) {
+  extends SparkProcessBuilder(proxyUser, conf, batchId, extraEngineLog) {
   import SparkProcessBuilder._
 
   override def mainClass: String = batchRequest.getClassName

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
@@ -37,7 +37,7 @@ class SparkBatchProcessBuilder(
 
   override def mainResource: Option[String] = Option(batchRequest.getResource)
 
-  override protected val commands: Array[String] = {
+  override protected def commands: Array[String] = {
     val buffer = new ArrayBuffer[String]()
     buffer += executable
     Option(mainClass).foreach { cla =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -47,7 +47,7 @@ class SparkProcessBuilder(
 
   override def mainClass: String = "org.apache.kyuubi.engine.spark.SparkSQLEngine"
 
-  override protected val commands: Array[String] = {
+  override protected def commands: Array[String] = {
     val buffer = new ArrayBuffer[String]()
     buffer += executable
     buffer += CLASS

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -26,7 +26,7 @@ import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.engine.ProcBuilder
+import org.apache.kyuubi.engine.{KyuubiApplicationManager, ProcBuilder}
 import org.apache.kyuubi.ha.HighAvailabilityConf
 import org.apache.kyuubi.ha.client.AuthTypes
 import org.apache.kyuubi.operation.log.OperationLog
@@ -34,7 +34,8 @@ import org.apache.kyuubi.operation.log.OperationLog
 class SparkProcessBuilder(
     override val proxyUser: String,
     override val conf: KyuubiConf,
-    val extraEngineLog: Option[OperationLog] = None)
+    val extraEngineLog: Option[OperationLog] = None,
+    val engineRefId: String = "")
   extends ProcBuilder with Logging {
 
   import SparkProcessBuilder._
@@ -47,7 +48,8 @@ class SparkProcessBuilder(
 
   override def mainClass: String = "org.apache.kyuubi.engine.spark.SparkSQLEngine"
 
-  override protected def commands: Array[String] = {
+  override protected val commands: Array[String] = {
+    KyuubiApplicationManager.tagApplication(engineRefId, shortName, clusterManager(), conf)
     val buffer = new ArrayBuffer[String]()
     buffer += executable
     buffer += CLASS

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -22,6 +22,7 @@ import java.nio.file.Paths
 
 import scala.collection.mutable.ArrayBuffer
 
+import com.google.common.annotations.VisibleForTesting
 import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.kyuubi._
@@ -34,9 +35,14 @@ import org.apache.kyuubi.operation.log.OperationLog
 class SparkProcessBuilder(
     override val proxyUser: String,
     override val conf: KyuubiConf,
-    val extraEngineLog: Option[OperationLog] = None,
-    val engineRefId: String = "")
+    val engineRefId: String,
+    val extraEngineLog: Option[OperationLog] = None)
   extends ProcBuilder with Logging {
+
+  @VisibleForTesting
+  def this(proxyUser: String, conf: KyuubiConf) {
+    this(proxyUser, conf, "")
+  }
 
   import SparkProcessBuilder._
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/trino/TrinoProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/trino/TrinoProcessBuilder.scala
@@ -28,19 +28,22 @@ import org.apache.kyuubi.{Logging, SCALA_COMPILE_VERSION, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_TRINO_CONNECTION_CATALOG, ENGINE_TRINO_CONNECTION_URL, ENGINE_TRINO_EXTRA_CLASSPATH, ENGINE_TRINO_JAVA_OPTIONS, ENGINE_TRINO_MEMORY}
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_USER_KEY
-import org.apache.kyuubi.engine.ProcBuilder
+import org.apache.kyuubi.engine.{KyuubiApplicationManager, ProcBuilder}
 import org.apache.kyuubi.operation.log.OperationLog
 
 class TrinoProcessBuilder(
     override val proxyUser: String,
     override val conf: KyuubiConf,
-    val extraEngineLog: Option[OperationLog] = None) extends ProcBuilder with Logging {
+    val extraEngineLog: Option[OperationLog] = None,
+    val engineRefId: String = "")
+  extends ProcBuilder with Logging {
 
   override protected def module: String = "kyuubi-trino-engine"
 
   override protected def mainClass: String = "org.apache.kyuubi.engine.trino.TrinoSqlEngine"
 
   override protected def commands: Array[String] = {
+    KyuubiApplicationManager.tagApplication(engineRefId, shortName, clusterManager(), conf)
     require(
       conf.get(ENGINE_TRINO_CONNECTION_URL).nonEmpty,
       s"Trino server url can not be null! Please set ${ENGINE_TRINO_CONNECTION_URL.key}")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/trino/TrinoProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/trino/TrinoProcessBuilder.scala
@@ -49,7 +49,7 @@ class TrinoProcessBuilder(
 
   override protected def mainClass: String = "org.apache.kyuubi.engine.trino.TrinoSqlEngine"
 
-  override protected def commands: Array[String] = {
+  override protected val commands: Array[String] = {
     KyuubiApplicationManager.tagApplication(engineRefId, shortName, clusterManager(), conf)
     require(
       conf.get(ENGINE_TRINO_CONNECTION_URL).nonEmpty,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/trino/TrinoProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/trino/TrinoProcessBuilder.scala
@@ -24,6 +24,8 @@ import java.util.LinkedHashSet
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
+import com.google.common.annotations.VisibleForTesting
+
 import org.apache.kyuubi.{Logging, SCALA_COMPILE_VERSION, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_TRINO_CONNECTION_CATALOG, ENGINE_TRINO_CONNECTION_URL, ENGINE_TRINO_EXTRA_CLASSPATH, ENGINE_TRINO_JAVA_OPTIONS, ENGINE_TRINO_MEMORY}
@@ -34,9 +36,14 @@ import org.apache.kyuubi.operation.log.OperationLog
 class TrinoProcessBuilder(
     override val proxyUser: String,
     override val conf: KyuubiConf,
-    val extraEngineLog: Option[OperationLog] = None,
-    val engineRefId: String = "")
+    val engineRefId: String,
+    val extraEngineLog: Option[OperationLog] = None)
   extends ProcBuilder with Logging {
+
+  @VisibleForTesting
+  def this(proxyUser: String, conf: KyuubiConf) {
+    this(proxyUser, conf, "")
+  }
 
   override protected def module: String = "kyuubi-trino-engine"
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
@@ -102,10 +102,9 @@ class FlinkProcessBuilderSuite extends KyuubiFunSuite {
   }
 
   test("all hadoop related environment variables are configured except FLINK_HADOOP_CLASSPATH") {
-    val builder = new FlinkProcessBuilder("vinoyang", conf) {
+    assertThrows[KyuubiException](new FlinkProcessBuilder("vinoyang", conf) {
       override def env: Map[String, String] = envWithoutHadoopCLASSPATH
-    }
-    assertThrows[KyuubiException](builder.toString)
+    })
   }
 
   test("only FLINK_HADOOP_CLASSPATH environment variables are configured") {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
@@ -32,6 +32,7 @@ class FlinkProcessBuilderSuite extends KyuubiFunSuite {
     .set(
       ENGINE_FLINK_JAVA_OPTIONS,
       "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
+    .set("yarn.tags", "KYUUBI")
 
   private def envDefault: ListMap[String, String] = ListMap(
     "JAVA_HOME" -> s"${File.separator}jdk")
@@ -53,7 +54,7 @@ class FlinkProcessBuilderSuite extends KyuubiFunSuite {
       s"$confStr"
     info(s"\n\n actualCommands $actualCommands")
     info(s"\n\n expectedCommands $expectedCommands")
-    assert(actualCommands.equals(expectedCommands))
+    assert(actualCommands == expectedCommands)
   }
 
   private def constructClasspathStr(builder: FlinkProcessBuilder) = {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
@@ -32,7 +32,6 @@ class FlinkProcessBuilderSuite extends KyuubiFunSuite {
     .set(
       ENGINE_FLINK_JAVA_OPTIONS,
       "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5005")
-    .set("yarn.tags", "KYUUBI")
 
   private def envDefault: ListMap[String, String] = ListMap(
     "JAVA_HOME" -> s"${File.separator}jdk")
@@ -43,7 +42,9 @@ class FlinkProcessBuilderSuite extends KyuubiFunSuite {
   private def envWithAllHadoop: ListMap[String, String] = envWithoutHadoopCLASSPATH +
     ("FLINK_HADOOP_CLASSPATH" -> s"${File.separator}hadoop")
   private def confStr: String = {
-    conf.getAll.map { case (k, v) => s"\\\n\t--conf $k=$v" }.mkString(" ")
+    conf.clone.set("yarn.tags", "KYUUBI").getAll.map {
+      case (k, v) => s"\\\n\t--conf $k=$v"
+    }.mkString(" ")
   }
   private def compareActualAndExpected(builder: FlinkProcessBuilder) = {
     val actualCommands = builder.toString

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -263,17 +263,15 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
     assert(b1.toString.contains(s"--conf spark.files=$testKeytab"))
   }
 
-  test("SparkProcessBuilder commands mutable") {
+  test("SparkProcessBuilder commands immutable") {
     val conf = KyuubiConf(false)
-    val pb = new SparkProcessBuilder("", conf)
     val engineRefId = UUID.randomUUID().toString
-    assert(!pb.toString.contains(engineRefId))
-    conf.set("spark.yarn.tags", engineRefId)
+    val pb = new SparkProcessBuilder("", conf, engineRefId = engineRefId)
     assert(pb.toString.contains(engineRefId))
   }
 }
 
 class FakeSparkProcessBuilder(config: KyuubiConf)
   extends SparkProcessBuilder("fake", config) {
-  override protected def commands: Array[String] = Array("ls")
+  override protected val commands: Array[String] = Array("ls")
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -20,6 +20,7 @@ package org.apache.kyuubi.engine.spark
 import java.io.File
 import java.nio.file.{Files, Path, Paths, StandardOpenOption}
 import java.time.Duration
+import java.util.UUID
 import java.util.concurrent.{Executors, TimeUnit}
 
 import org.scalatest.time.SpanSugar._
@@ -260,11 +261,19 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
 
     val b1 = new SparkProcessBuilder("test", conf)
     assert(b1.toString.contains(s"--conf spark.files=$testKeytab"))
+  }
 
+  test("SparkProcessBuilder commands mutable") {
+    val conf = KyuubiConf(false)
+    val pb = new SparkProcessBuilder("", conf)
+    val engineRefId = UUID.randomUUID().toString
+    assert(!pb.toString.contains(engineRefId))
+    conf.set("spark.yarn.tags", engineRefId)
+    assert(pb.toString.contains(engineRefId))
   }
 }
 
 class FakeSparkProcessBuilder(config: KyuubiConf)
   extends SparkProcessBuilder("fake", config) {
-  override protected val commands: Array[String] = Array("ls")
+  override protected def commands: Array[String] = Array("ls")
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -266,7 +266,11 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
   test("SparkProcessBuilder commands immutable") {
     val conf = KyuubiConf(false)
     val engineRefId = UUID.randomUUID().toString
-    val pb = new SparkProcessBuilder("", conf, engineRefId = engineRefId)
+    val pb = new SparkProcessBuilder("", conf, engineRefId)
+    assert(pb.toString.contains(engineRefId))
+    val engineRefId2 = UUID.randomUUID().toString
+    conf.set("spark.yarn.tags", engineRefId2)
+    assert(!pb.toString.contains(engineRefId2))
     assert(pb.toString.contains(engineRefId))
   }
 }


### PR DESCRIPTION
### _Why are the changes needed?_
close #2690

When `SparkProcessBuilder` is constructed, the commands are generated according to `conf` and are immutable, so the tags will not take effect if they are set later.

- Make several existing `ProcessBuilder` commands immutable.
- Set tags when building commands.
- Fix Flink tags may not be set to the right value.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
