### PR TITLE
[KYUUBI #2694] EngineEvent.toString outputs application tags

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/EngineEvent.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/events/EngineEvent.scala
@@ -74,9 +74,13 @@ case class EngineEvent(
       } else {
         settings.getOrElse("spark.executor.instances", 2)
       }
+    val tags = settings.getOrElse(
+      "spark.yarn.tags",
+      settings.getOrElse("spark.kubernetes.driver.label.kyuubi_unique_tag", ""))
     s"""
        |    Spark application name: $applicationName
        |          application ID:  $applicationId
+       |          application tags: $tags
        |          application web UI: $webUrl
        |          master: $master
        |          version: $sparkVersion


### PR DESCRIPTION
### _Why are the changes needed?_
close #2694

Now `engineRefId` is part of the application name and is output in the engine log, such as SparkBatch, or some UTs cover the app name. At this time, it is difficult to correlate the engine log.
Now `engineRefId` is also part of tags, so we can output tags when outputting logs.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
