### PR TITLE
Introduce batch application state and rename BatchJobSubmission to SubmitBatchApp

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchAppState.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchAppState.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.operation
+
+object BatchAppState extends Enumeration {
+  type BatchAppState = Value
+
+  val SUBMITTING, RUNNING, FINISHED, FAILED, KILLED = Value
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchAppSubmissionState.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchAppSubmissionState.scala
@@ -20,5 +20,5 @@ package org.apache.kyuubi.operation
 object BatchAppSubmissionState extends Enumeration {
   type BatchAppSubmissionState = Value
 
-  val PENDING, RUNNING, FINISHED, FAILED, KILLED = Value
+  val PENDING, RUNNING, SUBMITTED, FAILED, KILLED = Value
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchAppSubmissionState.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchAppSubmissionState.scala
@@ -17,8 +17,8 @@
 
 package org.apache.kyuubi.operation
 
-object BatchAppState extends Enumeration {
-  type BatchAppState = Value
+object BatchAppSubmissionState extends Enumeration {
+  type BatchAppSubmissionState = Value
 
   val SUBMITTING, RUNNING, FINISHED, FAILED, KILLED = Value
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchAppSubmissionState.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchAppSubmissionState.scala
@@ -20,5 +20,5 @@ package org.apache.kyuubi.operation
 object BatchAppSubmissionState extends Enumeration {
   type BatchAppSubmissionState = Value
 
-  val SUBMITTING, RUNNING, FINISHED, FAILED, KILLED = Value
+  val PENDING, RUNNING, FINISHED, FAILED, KILLED = Value
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperationManager.scala
@@ -63,10 +63,10 @@ class KyuubiOperationManager private (name: String) extends OperationManager(nam
     addOperation(operation)
   }
 
-  def newBatchJobSubmissionOperation(
+  def newSubmitBatchAppOperation(
       session: KyuubiBatchSessionImpl,
-      batchRequest: BatchRequest): BatchJobSubmission = {
-    val operation = new BatchJobSubmission(session, batchRequest)
+      batchRequest: BatchRequest): SubmitBatchApp = {
+    val operation = new SubmitBatchApp(session, batchRequest)
     addOperation(operation)
     operation
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/SubmitBatchApp.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/SubmitBatchApp.scala
@@ -149,7 +149,7 @@ class SubmitBatchApp(session: KyuubiBatchSessionImpl, batchRequest: BatchRequest
           submissionState = BatchAppSubmissionState.FAILED
           throw new KyuubiException(s"Process exit with value ${process.exitValue()}")
         }
-        submissionState = BatchAppSubmissionState.FINISHED
+        submissionState = BatchAppSubmissionState.SUBMITTED
       }
     } finally {
       builder.close()

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/SubmitBatchApp.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/SubmitBatchApp.scala
@@ -52,7 +52,7 @@ class SubmitBatchApp(session: KyuubiBatchSessionImpl, batchRequest: BatchRequest
 
   private[kyuubi] val batchType: String = batchRequest.getBatchType
 
-  private var submissionState: BatchAppSubmissionState = BatchAppSubmissionState.SUBMITTING
+  private var submissionState: BatchAppSubmissionState = BatchAppSubmissionState.PENDING
 
   private[kyuubi] def getSubmissionState: BatchAppSubmissionState = submissionState
 
@@ -129,7 +129,7 @@ class SubmitBatchApp(session: KyuubiBatchSessionImpl, batchRequest: BatchRequest
       val process = builder.start
       var applicationStatus = currentApplicationState
       while (!applicationFailed(applicationStatus) && process.isAlive) {
-        if (submissionState == BatchAppSubmissionState.SUBMITTING && applicationStatus.isDefined) {
+        if (submissionState == BatchAppSubmissionState.PENDING && applicationStatus.isDefined) {
           submissionState = BatchAppSubmissionState.RUNNING
         }
         process.waitFor(applicationCheckInterval, TimeUnit.MILLISECONDS)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/SubmitBatchApp.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/SubmitBatchApp.scala
@@ -110,6 +110,14 @@ class SubmitBatchApp(session: KyuubiBatchSessionImpl, batchRequest: BatchRequest
     } catch onError("submitting batch job submission operation in background, request rejected")
   }
 
+  override protected def onError(action: String): PartialFunction[Throwable, Unit] = {
+    case e: Throwable =>
+      submissionState = BatchAppSubmissionState.FAILED
+      try {
+        throw e
+      } catch super.onError(action)
+  }
+
   private def applicationFailed(applicationStatus: Option[Map[String, String]]): Boolean = {
     applicationStatus.map(_.get(ApplicationOperation.APP_STATE_KEY)).exists(s =>
       s.contains("KILLED") || s.contains("FAILED"))

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -54,7 +54,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       batchOp.batchType,
       batchOp.currentApplicationState.getOrElse(Map.empty).asJava,
       fe.connectionUrl,
-      batchOp.getBatchAppState.toString)
+      batchOp.getSubmissionState.toString)
   }
 
   @ApiResponse(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiBatchSessionImpl.scala
@@ -46,8 +46,8 @@ class KyuubiBatchSessionImpl(
 
   batchRequest.setConf(normalizedConf.asJava)
 
-  private[kyuubi] lazy val batchJobSubmissionOp = sessionManager.operationManager
-    .newBatchJobSubmissionOperation(this, batchRequest)
+  private[kyuubi] lazy val submitBatchAppOp = sessionManager.operationManager
+    .newSubmitBatchAppOperation(this, batchRequest)
 
   private val sessionEvent = KyuubiSessionEvent(this)
   EventBus.post(sessionEvent)
@@ -65,7 +65,7 @@ class KyuubiBatchSessionImpl(
     // we should call super.open before running batch job submission operation
     super.open()
 
-    runOperation(batchJobSubmissionOp)
+    runOperation(submitBatchAppOp)
   }
 
   override def close(): Unit = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
@@ -168,7 +168,7 @@ class KyuubiSessionManager private (name: String) extends SessionManager(name) {
       } else {
         allSessions().filter {
           case batchSession: KyuubiBatchSessionImpl =>
-            batchSession.batchJobSubmissionOp.batchType.equalsIgnoreCase(batchType)
+            batchSession.submitBatchAppOp.batchType.equalsIgnoreCase(batchType)
           case _ => false
         }
       }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
@@ -127,10 +127,10 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
 
     assert(sessionHandle.identifier.secretId === KyuubiSessionManager.STATIC_BATCH_SECRET_UUID)
     val session = sessionManager.getSession(sessionHandle).asInstanceOf[KyuubiBatchSessionImpl]
-    val batchJobSubmissionOp = session.batchJobSubmissionOp
+    val batchOp = session.submitBatchAppOp
 
     eventually(timeout(3.minutes), interval(50.milliseconds)) {
-      val state = batchJobSubmissionOp.currentApplicationState
+      val state = batchOp.currentApplicationState
       assert(state.nonEmpty)
       assert(state.exists(_("id").startsWith("application_")))
       assert(state.exists(_("name") == preDefinedAppName))
@@ -145,10 +145,10 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
     assert(appInfo("state") === "KILLED")
 
     eventually(timeout(10.minutes), interval(50.milliseconds)) {
-      assert(batchJobSubmissionOp.getStatus.state === ERROR)
+      assert(batchOp.getStatus.state === ERROR)
     }
 
-    val resultColumns = batchJobSubmissionOp.getNextRowSet(FetchOrientation.FETCH_NEXT, 10)
+    val resultColumns = batchOp.getNextRowSet(FetchOrientation.FETCH_NEXT, 10)
       .getColumns.asScala
 
     val keys = resultColumns.head.getStringVal.getValues.asScala
@@ -160,7 +160,7 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
     val appUrl = rows("url")
     val appError = rows("error")
 
-    val state2 = batchJobSubmissionOp.currentApplicationState.get
+    val state2 = batchOp.currentApplicationState.get
     assert(appId === state2("id"))
     assert(appName === state2("name"))
     assert(appState === state2("state"))
@@ -192,11 +192,11 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
       batchRequest)
 
     val session = sessionManager.getSession(sessionHandle).asInstanceOf[KyuubiBatchSessionImpl]
-    val batchJobSubmissionOp = session.batchJobSubmissionOp
+    val batchOp = session.submitBatchAppOp
 
     eventually(timeout(3.minutes), interval(50.milliseconds)) {
-      assert(batchJobSubmissionOp.currentApplicationState.isEmpty)
-      assert(batchJobSubmissionOp.getStatus.state === OperationState.ERROR)
+      assert(batchOp.currentApplicationState.isEmpty)
+      assert(batchOp.getStatus.state === OperationState.ERROR)
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -46,7 +46,7 @@ class BatchesResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       .map(_.asInstanceOf[KyuubiBatchSessionImpl])
       .foreach { session =>
         try {
-          session.batchJobSubmissionOp.killBatchApplication()
+          session.submitBatchAppOp.killBatchApplication()
         } finally {
           sessionManager.closeSession(session.handle)
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Introduce batch application submission state.

The initialized state is `PENDING`, when it gets the applicationStatus at first time, it should update the status to `RUNNIGN`.

And when the batch operation terminates, update the final state to `FINISHED` or `FAILED` or `KILLED`.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
