### PR TITLE
Kyuubi Spark TPC-DS Connector - Rework SupportsReportStatistics and code refactor

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-tpcds/pom.xml
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/pom.xml
@@ -40,26 +40,14 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.logging.log4j</groupId>
-            <artifactId>log4j-core</artifactId>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-client-api</artifactId>
             <scope>provided</scope>
         </dependency>
 
@@ -106,6 +94,12 @@
             <artifactId>kyuubi-common_${scala.binary.version}</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/SparkUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/SparkUtils.scala
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.spark.connector.tpcds
+
+import org.apache.spark.SPARK_VERSION
+
+object SparkUtils {
+
+  /**
+   * Given a Kyuubi/Spark/Hive version string,
+   * return the (major version number, minor version number).
+   * E.g., for 2.0.1-SNAPSHOT, return (2, 0).
+   */
+  def majorMinorVersion(version: String): (Int, Int) = {
+    """^(\d+)\.(\d+)(\..*)?$""".r.findFirstMatchIn(version) match {
+      case Some(m) =>
+        (m.group(1).toInt, m.group(2).toInt)
+      case None =>
+        throw new IllegalArgumentException(s"Tried to parse '$version' as a project" +
+          s" version string, but it could not find the major and minor version numbers.")
+    }
+  }
+
+  /**
+   * Given a Kyuubi/Spark/Hive version string, return the major version number.
+   * E.g., for 2.0.1-SNAPSHOT, return 2.
+   */
+  def majorVersion(version: String): Int = majorMinorVersion(version)._1
+
+  /**
+   * Given a Kyuubi/Spark/Hive version string, return the minor version number.
+   * E.g., for 2.0.1-SNAPSHOT, return 0.
+   */
+  def minorVersion(version: String): Int = majorMinorVersion(version)._2
+
+  def isSparkVersionAtMost(ver: String): Boolean = {
+    val runtimeMajor = majorVersion(SPARK_VERSION)
+    val targetMajor = majorVersion(ver)
+    (runtimeMajor < targetMajor) || {
+      val runtimeMinor = minorVersion(SPARK_VERSION)
+      val targetMinor = minorVersion(ver)
+      runtimeMajor == targetMajor && runtimeMinor <= targetMinor
+    }
+  }
+
+  def isSparkVersionAtLeast(ver: String): Boolean = {
+    val runtimeMajor = majorVersion(SPARK_VERSION)
+    val targetMajor = majorVersion(ver)
+    (runtimeMajor > targetMajor) || {
+      val runtimeMinor = minorVersion(SPARK_VERSION)
+      val targetMinor = minorVersion(ver)
+      runtimeMajor == targetMajor && runtimeMinor >= targetMinor
+    }
+  }
+
+  def isSparkVersionEqualTo(ver: String): Boolean = {
+    val runtimeMajor = majorVersion(SPARK_VERSION)
+    val targetMajor = majorVersion(ver)
+    val runtimeMinor = minorVersion(SPARK_VERSION)
+    val targetMinor = minorVersion(ver)
+    runtimeMajor == targetMajor && runtimeMinor == targetMinor
+  }
+}

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSStatisticsUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSStatisticsUtils.scala
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.spark.connector.tpcds
+
+import io.trino.tpcds.{Scaling, Table}
+import io.trino.tpcds.Table._
+
+// https://tpc.org/TPC_Documents_Current_Versions/pdf/TPC-DS_v3.2.0.pdf
+// Page 42 Table 3-2 Database Row Counts
+object TPCDSStatisticsUtils {
+
+  val SCALES: Array[Int] = Array(0, 1, 10, 100, 300, 1000, 3000, 10000, 30000, 100000)
+
+  def numRows(table: Table, scale: Int): Long = {
+    require(SCALES.contains(scale), s"Unsupported scale $scale")
+    (table, scale) match {
+      case (_, 0) => 0L
+      case (CATALOG_RETURNS, 1) => 144067L
+      case (CATALOG_RETURNS, 10) => 1439749L
+      case (CATALOG_RETURNS, 100) => 14404374L
+      case (CATALOG_RETURNS, 300) => 43193472L
+      case (CATALOG_RETURNS, 1000) => 143996756L
+      case (CATALOG_RETURNS, 3000) => 432018033L
+      case (CATALOG_RETURNS, 10000) => 1440033112L
+      case (CATALOG_RETURNS, 30000) => 4319925093L
+      case (CATALOG_RETURNS, 100000) => 14400175879L
+      case (CATALOG_SALES, 1) => 1441548L
+      case (CATALOG_SALES, 10) => 14401261L
+      case (CATALOG_SALES, 100) => 143997065L
+      case (CATALOG_SALES, 300) => 431969836L
+      case (CATALOG_SALES, 1000) => 1439980416L
+      case (CATALOG_SALES, 3000) => 4320078880L
+      case (CATALOG_SALES, 10000) => 14399964710L
+      case (CATALOG_SALES, 30000) => 43200404822L
+      case (CATALOG_SALES, 100000) => 143999334399L
+      case (STORE_RETURNS, 1) => 287514L
+      case (STORE_RETURNS, 10) => 2875432L
+      case (STORE_RETURNS, 100) => 28795080L
+      case (STORE_RETURNS, 300) => 86393244L
+      case (STORE_RETURNS, 1000) => 287999764L
+      case (STORE_RETURNS, 3000) => 863989652L
+      case (STORE_RETURNS, 10000) => 2879970104L
+      case (STORE_RETURNS, 30000) => 8639952111L
+      case (STORE_RETURNS, 100000) => 28800018820L
+      case (STORE_SALES, 1) => 2880404L
+      case (STORE_SALES, 10) => 28800991L
+//      case (STORE_SALES, 100) =>
+//      case (STORE_SALES, 300) =>
+      case (STORE_SALES, 1000) => 2879987999L
+      case (STORE_SALES, 3000) => 8639936081L
+      case (STORE_SALES, 10000) => 28799983563L
+      case (STORE_SALES, 30000) => 86399341874L
+      case (STORE_SALES, 100000) => 287997818084L
+      case (WEB_RETURNS, 1) => 71763L
+      case (WEB_RETURNS, 10) => 719217L
+//      case (WEB_RETURNS, 100) =>
+//      case (WEB_RETURNS, 300) =>
+      case (WEB_RETURNS, 1000) => 71997522L
+      case (WEB_RETURNS, 3000) => 216003761L
+      case (WEB_RETURNS, 10000) => 720020485L
+      case (WEB_RETURNS, 30000) => 2160007345L
+      case (WEB_RETURNS, 100000) => 7199904459L
+      case (WEB_SALES, 1) => 719384L
+      case (WEB_SALES, 10) => 7197566L
+//      case (WEB_SALES, 100) =>
+//      case (WEB_SALES, 300) =>
+      case (WEB_SALES, 1000) => 720000376L
+      case (WEB_SALES, 3000) => 2159968881L
+      case (WEB_SALES, 10000) => 7199963324L
+      case (WEB_SALES, 30000) => 21600036511L
+      case (WEB_SALES, 100000) => 71999670164L
+      case (t, s) => new Scaling(s).getRowCount(t)
+    }
+  }
+
+  def sizeInBytes(table: Table, scale: Int): Long =
+    numRows(table, scale) * TABLE_AVG_ROW_BYTES(table)
+
+  private val TABLE_AVG_ROW_BYTES: Map[Table, Long] = Map(
+    CALL_CENTER -> 305,
+    CATALOG_PAGE -> 139,
+    CATALOG_RETURNS -> 166,
+    CATALOG_SALES -> 226,
+    CUSTOMER -> 132,
+    CUSTOMER_ADDRESS -> 110,
+    CUSTOMER_DEMOGRAPHICS -> 42,
+    DATE_DIM -> 141,
+    HOUSEHOLD_DEMOGRAPHICS -> 21,
+    INCOME_BAND -> 16,
+    INVENTORY -> 16,
+    ITEM -> 281,
+    PROMOTION -> 124,
+    REASON -> 38,
+    SHIP_MODE -> 56,
+    STORE -> 263,
+    STORE_RETURNS -> 134,
+    STORE_SALES -> 164,
+    TIME_DIM -> 59,
+    WAREHOUSE -> 117,
+    WEB_PAGE -> 96,
+    WEB_RETURNS -> 162,
+    WEB_SALES -> 226,
+    WEB_SITE -> 292)
+}

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSStatisticsUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSStatisticsUtils.scala
@@ -26,6 +26,7 @@ object TPCDSStatisticsUtils {
 
   val SCALES: Array[Int] = Array(0, 1, 10, 100, 300, 1000, 3000, 10000, 30000, 100000)
 
+  // https://github.com/Teradata/tpcds/issues/26
   def numRows(table: Table, scale: Int): Long = {
     require(SCALES.contains(scale), s"Unsupported scale $scale")
     (table, scale) match {

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSStatisticsUtils.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSStatisticsUtils.scala
@@ -59,8 +59,8 @@ object TPCDSStatisticsUtils {
       case (STORE_RETURNS, 100000) => 28800018820L
       case (STORE_SALES, 1) => 2880404L
       case (STORE_SALES, 10) => 28800991L
-//      case (STORE_SALES, 100) =>
-//      case (STORE_SALES, 300) =>
+      case (STORE_SALES, 100) => 287997024L
+      case (STORE_SALES, 300) => 864001869L
       case (STORE_SALES, 1000) => 2879987999L
       case (STORE_SALES, 3000) => 8639936081L
       case (STORE_SALES, 10000) => 28799983563L
@@ -68,8 +68,8 @@ object TPCDSStatisticsUtils {
       case (STORE_SALES, 100000) => 287997818084L
       case (WEB_RETURNS, 1) => 71763L
       case (WEB_RETURNS, 10) => 719217L
-//      case (WEB_RETURNS, 100) =>
-//      case (WEB_RETURNS, 300) =>
+      case (WEB_RETURNS, 100) => 7197670L
+      case (WEB_RETURNS, 300) => 21599377L
       case (WEB_RETURNS, 1000) => 71997522L
       case (WEB_RETURNS, 3000) => 216003761L
       case (WEB_RETURNS, 10000) => 720020485L
@@ -77,8 +77,8 @@ object TPCDSStatisticsUtils {
       case (WEB_RETURNS, 100000) => 7199904459L
       case (WEB_SALES, 1) => 719384L
       case (WEB_SALES, 10) => 7197566L
-//      case (WEB_SALES, 100) =>
-//      case (WEB_SALES, 300) =>
+      case (WEB_SALES, 100) => 72001237L
+      case (WEB_SALES, 300) => 216009853L
       case (WEB_SALES, 1000) => 720000376L
       case (WEB_SALES, 3000) => 2159968881L
       case (WEB_SALES, 10000) => 7199963324L

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSTable.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSTable.scala
@@ -77,9 +77,8 @@ class TPCDSTable(tbl: String, scale: Int, options: CaseInsensitiveStringMap)
   override def capabilities(): util.Set[TableCapability] =
     Set(TableCapability.BATCH_READ).asJava
 
-  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder = {
+  override def newScanBuilder(options: CaseInsensitiveStringMap): ScanBuilder =
     new TPCDSBatchScan(tpcdsTable, scale, schema)
-  }
 
   def toSparkDataType(tpcdsType: ColumnType): DataType = {
     (tpcdsType.getBase, tpcdsType.getPrecision.asScala, tpcdsType.getScale.asScala) match {

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSCatalogSuite.scala
@@ -80,8 +80,8 @@ class TPCDSCatalogSuite extends KyuubiFunSuite {
     // table *_returns and *_sales have different count in spark.table.count and stats.count
     assertStats("tpcds.sf1.call_center", 1830, 6)
     assertStats("tpcds.sf1.catalog_page", 1628802, 11718)
-    assertStats("tpcds.sf1.catalog_returns", 26560000, 160000)
-    assertStats("tpcds.sf1.catalog_sales", 36160000, 160000)
+    assertStats("tpcds.sf1.catalog_returns", 23915122, 144067)
+    assertStats("tpcds.sf1.catalog_sales", 325789848, 1441548)
     assertStats("tpcds.sf1.customer", 13200000, 100000)
     assertStats("tpcds.sf1.customer_address", 5500000, 50000)
     assertStats("tpcds.sf1.customer_demographics", 80673600, 1920800)
@@ -94,13 +94,13 @@ class TPCDSCatalogSuite extends KyuubiFunSuite {
     assertStats("tpcds.sf1.reason", 1330, 35)
     assertStats("tpcds.sf1.ship_mode", 1120, 20)
     assertStats("tpcds.sf1.store", 3156, 12)
-    assertStats("tpcds.sf1.store_returns", 32160000, 240000)
-    assertStats("tpcds.sf1.store_sales", 39360000, 240000)
+    assertStats("tpcds.sf1.store_returns", 38526876, 287514)
+    assertStats("tpcds.sf1.store_sales", 472386256, 2880404)
     assertStats("tpcds.sf1.time_dim", 5097600, 86400)
     assertStats("tpcds.sf1.warehouse", 585, 5)
     assertStats("tpcds.sf1.web_page", 5760, 60)
-    assertStats("tpcds.sf1.web_returns", 9720000, 60000)
-    assertStats("tpcds.sf1.web_sales", 13560000, 60000)
+    assertStats("tpcds.sf1.web_returns", 11625606, 71763)
+    assertStats("tpcds.sf1.web_sales", 162580784, 719384)
     assertStats("tpcds.sf1.web_site", 8760, 30)
   }
 

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSCatalogSuite.scala
@@ -77,7 +77,6 @@ class TPCDSCatalogSuite extends KyuubiFunSuite {
       }
     }
 
-    // table *_returns and *_sales have different count in spark.table.count and stats.count
     assertStats("tpcds.sf1.call_center", 1830, 6)
     assertStats("tpcds.sf1.catalog_page", 1628802, 11718)
     assertStats("tpcds.sf1.catalog_returns", 23915122, 144067)

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSCatalogSuite.scala
@@ -29,6 +29,8 @@ class TPCDSCatalogSuite extends KyuubiFunSuite {
       .config("spark.ui.enabled", "false")
       .config("spark.sql.catalogImplementation", "in-memory")
       .config("spark.sql.catalog.tpcds", classOf[TPCDSCatalog].getName)
+      .config("spark.sql.cbo.enabled", "true")
+      .config("spark.sql.cbo.planStats.enabled", "true")
       .getOrCreate()
   }
 
@@ -65,38 +67,41 @@ class TPCDSCatalogSuite extends KyuubiFunSuite {
     assert(spark.table("tpcds.sf1.web_site").count === 30)
   }
 
-  test("tpcds.sf1 size") {
-    def assertStats(tableName: String, sizeInBytes: BigInt = 1): Unit = {
+  test("tpcds.sf1 stats") {
+    def assertStats(tableName: String, sizeInBytes: BigInt, rowCount: BigInt): Unit = {
       val stats = spark.table(tableName).queryExecution.analyzed.stats
       assert(stats.sizeInBytes == sizeInBytes)
-      // See https://issues.apache.org/jira/browse/SPARK-33954
-      // stats.rowCount only has value in Spark3.2 and above
+      // stats.rowCount only has value after SPARK-33954
+      if (SparkUtils.isSparkVersionAtLeast("3.2")) {
+        assert(stats.rowCount.contains(rowCount), tableName)
+      }
     }
 
-    assertStats("tpcds.sf1.call_center", 1830)
-    assertStats("tpcds.sf1.catalog_page", 1628802)
-    assertStats("tpcds.sf1.catalog_returns", 26560000)
-    assertStats("tpcds.sf1.catalog_sales", 36160000)
-    assertStats("tpcds.sf1.customer", 13200000)
-    assertStats("tpcds.sf1.customer_address", 5500000)
-    assertStats("tpcds.sf1.customer_demographics", 80673600)
-    assertStats("tpcds.sf1.date_dim", 10299909)
-    assertStats("tpcds.sf1.household_demographics", 151200)
-    assertStats("tpcds.sf1.income_band", 320)
-    assertStats("tpcds.sf1.inventory", 187920000)
-    assertStats("tpcds.sf1.item", 5058000)
-    assertStats("tpcds.sf1.promotion", 37200)
-    assertStats("tpcds.sf1.reason", 1330)
-    assertStats("tpcds.sf1.ship_mode", 1120)
-    assertStats("tpcds.sf1.store", 3156)
-    assertStats("tpcds.sf1.store_returns", 32160000)
-    assertStats("tpcds.sf1.store_sales", 39360000)
-    assertStats("tpcds.sf1.time_dim", 5097600)
-    assertStats("tpcds.sf1.warehouse", 585)
-    assertStats("tpcds.sf1.web_page", 5760)
-    assertStats("tpcds.sf1.web_returns", 9720000)
-    assertStats("tpcds.sf1.web_sales", 13560000)
-    assertStats("tpcds.sf1.web_site", 8760)
+    // table *_returns and *_sales have different count in spark.table.count and stats.count
+    assertStats("tpcds.sf1.call_center", 1830, 6)
+    assertStats("tpcds.sf1.catalog_page", 1628802, 11718)
+    assertStats("tpcds.sf1.catalog_returns", 26560000, 160000)
+    assertStats("tpcds.sf1.catalog_sales", 36160000, 160000)
+    assertStats("tpcds.sf1.customer", 13200000, 100000)
+    assertStats("tpcds.sf1.customer_address", 5500000, 50000)
+    assertStats("tpcds.sf1.customer_demographics", 80673600, 1920800)
+    assertStats("tpcds.sf1.date_dim", 10299909, 73049)
+    assertStats("tpcds.sf1.household_demographics", 151200, 7200)
+    assertStats("tpcds.sf1.income_band", 320, 20)
+    assertStats("tpcds.sf1.inventory", 187920000, 11745000)
+    assertStats("tpcds.sf1.item", 5058000, 18000)
+    assertStats("tpcds.sf1.promotion", 37200, 300)
+    assertStats("tpcds.sf1.reason", 1330, 35)
+    assertStats("tpcds.sf1.ship_mode", 1120, 20)
+    assertStats("tpcds.sf1.store", 3156, 12)
+    assertStats("tpcds.sf1.store_returns", 32160000, 240000)
+    assertStats("tpcds.sf1.store_sales", 39360000, 240000)
+    assertStats("tpcds.sf1.time_dim", 5097600, 86400)
+    assertStats("tpcds.sf1.warehouse", 585, 5)
+    assertStats("tpcds.sf1.web_page", 5760, 60)
+    assertStats("tpcds.sf1.web_returns", 9720000, 60000)
+    assertStats("tpcds.sf1.web_sales", 13560000, 60000)
+    assertStats("tpcds.sf1.web_site", 8760, 30)
   }
 
   test("nonexistent table") {

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSTableSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSTableSuite.scala
@@ -59,7 +59,7 @@ class TPCDSTableSuite extends KyuubiFunSuite {
   }
 
   test("test nullable column") {
-    TPCDSTableUtils.BASE_TABLES.foreach { tpcdsTable =>
+    TPCDSSchemaUtils.BASE_TABLES.foreach { tpcdsTable =>
       val tableName = tpcdsTable.getName
       val sparkConf = new SparkConf().setMaster("local[*]")
         .set("spark.ui.enabled", "false")
@@ -69,7 +69,7 @@ class TPCDSTableSuite extends KyuubiFunSuite {
         val sparkTable = spark.table(s"tpcds.sf1.$tableName")
         var notNullBitMap = 0
         sparkTable.schema.fields.zipWithIndex.foreach { case (field, i) =>
-          val index = TPCDSTableUtils.reviseNullColumnIndex(tpcdsTable, i)
+          val index = TPCDSSchemaUtils.reviseNullColumnIndex(tpcdsTable, i)
           if (!field.nullable) {
             notNullBitMap |= 1 << index
           }
@@ -115,7 +115,7 @@ class TPCDSTableSuite extends KyuubiFunSuite {
       "CC_TAX_PERCENTAGE")
     Table.CALL_CENTER.getColumns.zipWithIndex.map {
       case (_, i) =>
-        assert(TPCDSTableUtils.reviseNullColumnIndex(Table.CALL_CENTER, i) ==
+        assert(TPCDSSchemaUtils.reviseNullColumnIndex(Table.CALL_CENTER, i) ==
           CallCenterGeneratorColumn.valueOf(getValuesColumns(i)).getGlobalColumnNumber -
           CallCenterGeneratorColumn.CC_CALL_CENTER_SK.getGlobalColumnNumber)
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
I notice that for tables `*_returns` and `*_sales`, the real records count is different from `new Scaling(scale).getRowCount(table)`, and after some investigation with @cxzl25, it's by design, see https://github.com/Teradata/tpcds/issues/26 for details. 

As the official document[1] provides the table row counts for most scales, I just calculate the absent(scale 10, 100, 300).

This PR fixes the `*_returns` and `*_sales` tables' statistics, and verifies `stats.rowCount` when Spark version >= 3.2.

[1] https://tpc.org/TPC_Documents_Current_Versions/pdf/TPC-DS_v3.2.0.pdf

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
