### PR TITLE
[KYUUBI #2594][FOLLOWUP] Fix flaky Test - support engine alive probe to fast fail on engine broken

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -231,10 +231,10 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
   test("KYUUBI #2102 - support engine alive probe to fast fail on engine broken") {
     withSessionConf(Map(
       KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED.key -> "true",
-      KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL.key -> "100",
-      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "3000",
+      KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL.key -> "1000",
+      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "10000",
       KyuubiConf.OPERATION_THRIFT_CLIENT_REQUEST_MAX_ATTEMPTS.key -> "10000",
-      KyuubiConf.ENGINE_REQUEST_TIMEOUT.key -> "100"))(Map.empty)(Map.empty) {
+      KyuubiConf.ENGINE_REQUEST_TIMEOUT.key -> "1000"))(Map.empty)(Map.empty) {
       withSessionHandle { (client, handle) =>
         val preReq = new TExecuteStatementReq()
         preReq.setStatement("select engine_name()")
@@ -250,7 +250,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         val executeStmtResp = client.ExecuteStatement(executeStmtReq)
         assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
         val elapsedTime = System.currentTimeMillis() - startTime
-        assert(elapsedTime > 3 * 1000 && elapsedTime < 20 * 1000)
+        assert(elapsedTime > 10 * 1000 && elapsedTime < 20 * 1000)
       }
     }
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -232,7 +232,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
     withSessionConf(Map(
       KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED.key -> "true",
       KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL.key -> "1000",
-      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "10000",
+      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "3000",
       KyuubiConf.OPERATION_THRIFT_CLIENT_REQUEST_MAX_ATTEMPTS.key -> "10000",
       KyuubiConf.ENGINE_REQUEST_TIMEOUT.key -> "1000"))(Map.empty)(Map.empty) {
       withSessionHandle { (client, handle) =>
@@ -250,7 +250,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         val executeStmtResp = client.ExecuteStatement(executeStmtReq)
         assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
         val elapsedTime = System.currentTimeMillis() - startTime
-        assert(elapsedTime > 10 * 1000 && elapsedTime < 20 * 1000)
+        assert(elapsedTime > 3 * 1000 && elapsedTime < 20 * 1000)
       }
     }
   }


### PR DESCRIPTION
### _Why are the changes needed?_
#2594

In this test case, `ENGINE_REQUEST_TIMEOUT` is set to 100 milliseconds, `KyuubiSyncThriftClient#createTProtocol` sometimes exits directly due to `Read timed out`, session closes, and the test fails.

https://github.com/cxzl25/incubator-kyuubi/runs/6507912792?check_suite_focus=true

```
2022-05-19T13:59:50.9049182Z - KYUUBI #2102 - support engine alive probe to fast fail on engine broken *** FAILED ***
2022-05-19T13:59:50.9053749Z   2 was not greater than 3000 (KyuubiOperationPerConnectionSuite.scala:253)
```

```
13:59:50.401 KyuubiSessionManager-exec-pool: Thread-3608 ERROR KyuubiSessionImpl: Opening engine [kyuubi_CONNECTION_SPARK_SQL_runner_8df442d1-a6b0-4694-ac3a-bb6c758fe02b fv-az83-137:37443] for runner session failed
org.apache.thrift.transport.TTransportException: java.net.SocketTimeoutException: Read timed out
	at org.apache.thrift.transport.TIOStreamTransport.read(TIOStreamTransport.java:129) ~[libthrift-0.9.3.jar:0.9.3]
	at org.apache.thrift.transport.TTransport.readAll(TTransport.java:86) ~[libthrift-0.9.3.jar:0.9.3]
	at org.apache.thrift.transport.TSaslTransport.receiveSaslMessage(TSaslTransport.java:178) ~[libthrift-0.9.3.jar:0.9.3]
	at org.apache.thrift.transport.TSaslTransport.open(TSaslTransport.java:307) ~[libthrift-0.9.3.jar:0.9.3]
	at org.apache.thrift.transport.TSaslClientTransport.open(TSaslClientTransport.java:37) ~[libthrift-0.9.3.jar:0.9.3]
	at org.apache.kyuubi.client.KyuubiSyncThriftClient$.createTProtocol(KyuubiSyncThriftClient.scala:399) ~[classes/:?]
	at org.apache.kyuubi.client.KyuubiSyncThriftClient$.createClient(KyuubiSyncThriftClient.scala:417) ~[classes/:?]
	at org.apache.kyuubi.session.KyuubiSessionImpl.$anonfun$openEngineSession$1(KyuubiSessionImpl.scala:106) ~[classes/:?]
```



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
