### PR TITLE
Log4j2 layout pattern add date

### DIFF
--- a/conf/log4j2.properties.template
+++ b/conf/log4j2.properties.template
@@ -24,7 +24,7 @@ appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n
 
 appender.console.filter.1.type = Filters
 

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -498,7 +498,7 @@ appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n
 
 appender.console.filter.1.type = Filters
 

--- a/kyuubi-common/src/main/resources/log4j2-defaults.properties
+++ b/kyuubi-common/src/main/resources/log4j2-defaults.properties
@@ -24,7 +24,7 @@ appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss.SSS} %p %c: %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} %p %c: %m%n
 
 appender.console.filter.1.type = Filters
 


### PR DESCRIPTION
### _Why are the changes needed?_
Because `kyuubi-server` is a long-running service, its logs should preferably have dates.
When Log4j1 was used in previous versions, the default log and template had dates.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
