### PR TITLE
[GA] Separate log archive name

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -49,19 +49,23 @@ jobs:
           - '3.3'
         spark-archive: [""]
         exclude-tags: [""]
+        comment: ["normal"]
         include:
           - java: 8
             spark: '3.2'
             spark-archive: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.0.3 -Dspark.archive.name=spark-3.0.3-bin-hadoop2.7.tgz'
             exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
+            comment: 'verify-spark-3.0'
           - java: 8
             spark: '3.2'
             spark-archive: '-Dspark.archive.mirror=https://archive.apache.org/dist/spark/spark-3.1.3 -Dspark.archive.name=spark-3.1.3-bin-hadoop3.2.tgz'
             exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
+            comment: 'verify-spark-3.1'
           - java: 8
             spark: '3.2'
             spark-archive: '-Dspark.archive.mirror=https://dist.apache.org/repos/dist/dev/spark/v3.3.0-rc3-bin -Dspark.archive.name=spark-3.3.0-bin-hadoop3.tgz'
             exclude-tags: '-Dmaven.plugin.scalatest.exclude.tags=org.apache.kyuubi.tags.ExtendedSQLTest,org.apache.kyuubi.tags.DeltaTest,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.IcebergTest'
+            comment: 'verify-spark-3.3'
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -98,7 +102,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: unit-tests-log
+          name: unit-tests-log-${{ matrix.java }}-${{ matrix.spark }}-${{ matrix.comment }}
           path: |
             **/target/unit-tests.log
             **/kyuubi-flink-sql-engine.log*
@@ -171,7 +175,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: unit-tests-log
+          name: unit-tests-log-kyuubi-on-k8s-it
           path: |
             **/target/unit-tests.log
 
@@ -215,7 +219,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v2
         with:
-          name: unit-tests-log
+          name: unit-tests-log-spark-on-k8s-it
           path: |
             **/target/unit-tests.log
             **/kyuubi-spark-sql-engine.log*


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently the GA jobs share the name log archive file name, it may overwrite each other if multi jobs fail.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
