### PR TITLE
[KYUUBI #2768] Use the default DB passed in by session in Flink

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/session/FlinkSessionImpl.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/session/FlinkSessionImpl.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.engine.flink.session
 
+import scala.util.control.NonFatal
+
 import org.apache.flink.table.client.gateway.{Executor, SqlExecutionException}
 import org.apache.flink.table.client.gateway.context.SessionContext
 import org.apache.hive.service.rpc.thrift.TProtocolVersion
@@ -48,6 +50,16 @@ class FlinkSessionImpl(
 
   override def open(): Unit = {
     normalizedConf.foreach {
+      case ("use:database", database) =>
+        val tableEnv = sessionContext.getExecutionContext.getTableEnvironment
+        try {
+          tableEnv.useDatabase(database)
+        } catch {
+          case NonFatal(e) =>
+            if (database != "default") {
+              throw e
+            }
+        }
       case (key, value) => setModifiableConfig(key, value)
     }
     super.open()


### PR DESCRIPTION
### _Why are the changes needed?_
Flink does not read `use:database` attribute as session default db.
close #2768

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
