### PR TITLE
[KYUUBI #2643][FOLLOWUP] Using javax AuthenticationException instead of hadoop AuthenticationException

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/util/AuthUtil.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/util/AuthUtil.java
@@ -21,8 +21,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.Base64;
+import javax.security.sasl.AuthenticationException;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.security.authentication.client.AuthenticationException;
 import org.ietf.jgss.GSSContext;
 import org.ietf.jgss.GSSException;
 import org.ietf.jgss.GSSManager;
@@ -74,7 +74,7 @@ public final class AuthUtil {
                       Base64.getEncoder().encode(outToken), StandardCharsets.US_ASCII);
                 } catch (GSSException e) {
                   LOG.error("Error: ", e);
-                  throw new AuthenticationException(e);
+                  throw new AuthenticationException("Failed to generate token", e);
                 }
               }
             });


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Using javax.security.sasl.AuthenticationException instead of hadoop AuthenticationException
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
