### PR TITLE
[KYUUBI #2807] Trino, Hive and JDBC Engine support session conf in newExecuteStatementOperation

### DIFF
--- a/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperationManager.scala
+++ b/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperationManager.scala
@@ -23,6 +23,7 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars
 import org.apache.hive.service.rpc.thrift.TRowSet
 
 import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.engine.hive.session.HiveSessionImpl
 import org.apache.kyuubi.operation.{Operation, OperationHandle, OperationManager}
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.session.Session
@@ -37,7 +38,10 @@ class HiveOperationManager() extends OperationManager("HiveOperationManager") {
       confOverlay: Map[String, String],
       runAsync: Boolean,
       queryTimeout: Long): Operation = {
-    if (session.sessionKyuubiConf.get(ENGINE_OPERATION_CONVERT_CATALOG_DATABASE_ENABLED)) {
+    val normalizedConf = session.asInstanceOf[HiveSessionImpl].normalizedConf
+    if (normalizedConf.get(ENGINE_OPERATION_CONVERT_CATALOG_DATABASE_ENABLED.key).map(
+        _.toBoolean).getOrElse(
+        session.sessionManager.getConf.get(ENGINE_OPERATION_CONVERT_CATALOG_DATABASE_ENABLED))) {
       val catalogDatabaseOperation = processCatalogDatabase(session, statement, confOverlay)
       if (catalogDatabaseOperation != null) {
         return catalogDatabaseOperation

--- a/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperationManager.scala
+++ b/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperationManager.scala
@@ -37,7 +37,7 @@ class HiveOperationManager() extends OperationManager("HiveOperationManager") {
       confOverlay: Map[String, String],
       runAsync: Boolean,
       queryTimeout: Long): Operation = {
-    if (session.sessionManager.getConf.get(ENGINE_OPERATION_CONVERT_CATALOG_DATABASE_ENABLED)) {
+    if (session.sessionKyuubiConf.get(ENGINE_OPERATION_CONVERT_CATALOG_DATABASE_ENABLED)) {
       val catalogDatabaseOperation = processCatalogDatabase(session, statement, confOverlay)
       if (catalogDatabaseOperation != null) {
         return catalogDatabaseOperation

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperationManager.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperationManager.scala
@@ -22,6 +22,7 @@ import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.OPERATION_INCREMENTAL_COLLECT
 import org.apache.kyuubi.engine.jdbc.dialect.{JdbcDialect, JdbcDialects}
+import org.apache.kyuubi.engine.jdbc.session.JdbcSessionImpl
 import org.apache.kyuubi.engine.jdbc.util.SupportServiceLoader
 import org.apache.kyuubi.operation.{Operation, OperationManager}
 import org.apache.kyuubi.session.Session
@@ -39,8 +40,10 @@ class JdbcOperationManager(conf: KyuubiConf) extends OperationManager("JdbcOpera
       confOverlay: Map[String, String],
       runAsync: Boolean,
       queryTimeout: Long): Operation = {
-    val conf = session.sessionManager.getConf
-    val incrementalCollect = conf.get(OPERATION_INCREMENTAL_COLLECT)
+    val normalizedConf = session.asInstanceOf[JdbcSessionImpl].normalizedConf
+    val incrementalCollect = normalizedConf.get(OPERATION_INCREMENTAL_COLLECT.key).map(
+      _.toBoolean).getOrElse(
+      session.sessionManager.getConf.get(OPERATION_INCREMENTAL_COLLECT))
     val executeStatement =
       new ExecuteStatement(session, statement, runAsync, queryTimeout, incrementalCollect)
     addOperation(executeStatement)

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
@@ -26,7 +26,6 @@ import org.apache.hive.service.rpc.thrift.TTableSchema
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.Utils
-import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.trino.TrinoContext
 import org.apache.kyuubi.engine.trino.schema.RowSet
 import org.apache.kyuubi.engine.trino.schema.SchemaHelper
@@ -43,8 +42,6 @@ abstract class TrinoOperation(opType: OperationType, session: Session)
   extends AbstractOperation(opType, session) {
 
   protected val trinoContext: TrinoContext = session.asInstanceOf[TrinoSessionImpl].trinoContext
-
-  protected val sessionConf: KyuubiConf = session.sessionKyuubiConf
 
   protected var trino: StatementClient = _
 

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
@@ -26,6 +26,7 @@ import org.apache.hive.service.rpc.thrift.TTableSchema
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.Utils
+import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.trino.TrinoContext
 import org.apache.kyuubi.engine.trino.schema.RowSet
 import org.apache.kyuubi.engine.trino.schema.SchemaHelper
@@ -42,6 +43,8 @@ abstract class TrinoOperation(opType: OperationType, session: Session)
   extends AbstractOperation(opType, session) {
 
   protected val trinoContext: TrinoContext = session.asInstanceOf[TrinoSessionImpl].trinoContext
+
+  protected val sessionConf: KyuubiConf = session.sessionKyuubiConf
 
   protected var trino: StatementClient = _
 

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperationManager.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperationManager.scala
@@ -34,13 +34,13 @@ class TrinoOperationManager extends OperationManager("TrinoOperationManager") {
       confOverlay: Map[String, String],
       runAsync: Boolean,
       queryTimeout: Long): Operation = {
-    if (session.sessionManager.getConf.get(ENGINE_OPERATION_CONVERT_CATALOG_DATABASE_ENABLED)) {
+    if (session.sessionKyuubiConf.get(ENGINE_OPERATION_CONVERT_CATALOG_DATABASE_ENABLED)) {
       val catalogDatabaseOperation = processCatalogDatabase(session, statement, confOverlay)
       if (catalogDatabaseOperation != null) {
         return catalogDatabaseOperation
       }
     }
-    val incrementalCollect = session.sessionManager.getConf.get(OPERATION_INCREMENTAL_COLLECT)
+    val incrementalCollect = session.sessionKyuubiConf.get(OPERATION_INCREMENTAL_COLLECT)
     val operation =
       new ExecuteStatement(session, statement, runAsync, queryTimeout, incrementalCollect)
     addOperation(operation)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -22,7 +22,6 @@ import scala.collection.JavaConverters._
 import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TProtocolVersion, TRowSet, TTableSchema}
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging}
-import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.operation.{Operation, OperationHandle}
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.log.OperationLog
@@ -52,14 +51,6 @@ abstract class AbstractSession(
   }
 
   val normalizedConf: Map[String, String] = sessionManager.validateAndNormalizeConf(conf)
-
-  lazy val sessionKyuubiConf: KyuubiConf = {
-    val conf = sessionManager.getConf.clone
-    normalizedConf.foreach {
-      case (key, value) => conf.set(key, value)
-    }
-    conf
-  }
 
   final private val opHandleSet = new java.util.HashSet[OperationHandle]
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -22,6 +22,7 @@ import scala.collection.JavaConverters._
 import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TProtocolVersion, TRowSet, TTableSchema}
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging}
+import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.operation.{Operation, OperationHandle}
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.log.OperationLog
@@ -51,6 +52,14 @@ abstract class AbstractSession(
   }
 
   val normalizedConf: Map[String, String] = sessionManager.validateAndNormalizeConf(conf)
+
+  lazy val sessionKyuubiConf: KyuubiConf = {
+    val conf = sessionManager.getConf.clone
+    normalizedConf.foreach {
+      case (key, value) => conf.set(key, value)
+    }
+    conf
+  }
 
   final private val opHandleSet = new java.util.HashSet[OperationHandle]
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -243,7 +243,7 @@ abstract class AbstractSession(
     }
   }
 
-  override def closeExpiredOperations: Unit = {
+  override def closeExpiredOperations(): Unit = {
     val operations = sessionManager.operationManager
       .removeExpiredOperations(opHandleSet.asScala.toSeq)
     operations.foreach { op =>

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
@@ -19,7 +19,6 @@ package org.apache.kyuubi.session
 
 import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TProtocolVersion, TRowSet, TTableSchema}
 
-import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.OperationHandle
 
@@ -29,8 +28,6 @@ trait Session {
   def handle: SessionHandle
 
   def conf: Map[String, String]
-
-  def sessionKyuubiConf: KyuubiConf
 
   def user: String
   def password: String

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
@@ -19,6 +19,7 @@ package org.apache.kyuubi.session
 
 import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TProtocolVersion, TRowSet, TTableSchema}
 
+import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.OperationHandle
 
@@ -28,6 +29,8 @@ trait Session {
   def handle: SessionHandle
 
   def conf: Map[String, String]
+
+  def sessionKyuubiConf: KyuubiConf
 
   def user: String
   def password: String

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
@@ -94,5 +94,5 @@ trait Session {
       maxRows: Int,
       fetchLog: Boolean): TRowSet
 
-  def closeExpiredOperations: Unit
+  def closeExpiredOperations(): Unit
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
@@ -304,7 +304,7 @@ abstract class SessionManager(name: String) extends CompositeService(name) {
                   warn(s"Error closing idle session ${session.handle}", e)
               }
             } else {
-              session.closeExpiredOperations
+              session.closeExpiredOperations()
             }
           }
         }


### PR DESCRIPTION
### _Why are the changes needed?_
Now Trino, Hive and JDBC Engine use session manager configuration in `newExecuteStatementOperation`, ignoring session level configuration.

Supporting session conf also helps with testing `withSessionConf`.

close #2807


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
