### PR TITLE
Set JAVA_HOME in travis via javac

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
   - ./build/mvn --version
 
 before_script:
-  - export JAVA_HOME="/usr/lib/jvm/adoptopenjdk-8-hotspot-arm64"
+  - export JAVA_HOME="$(realpath -Pm "$(which javac)/../../")"
   - export MVN_ARGS="-Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
   - ./build/mvn clean install -DskipTests $MVN_ARGS
 


### PR DESCRIPTION
### _Why are the changes needed?_
Now `JAVA_HOME` is hardcoded, travis changed the `openjdk8` installation package, so the path also changed.
Now it is through `javac` to find the real java home directory.

**fail now**
https://app.travis-ci.com/github/apache/incubator-kyuubi/jobs/572250073

```
update-alternatives: using /usr/lib/jvm/temurin-8-jdk-arm64/bin/appletviewer to provide /usr/bin/appletviewer (appletviewer) in auto mode
```

**success before**
https://app.travis-ci.com/github/apache/incubator-kyuubi/jobs/572180707

```
update-alternatives: using /usr/lib/jvm/adoptopenjdk-8-hotspot-arm64/bin/appletviewer to provide /usr/bin/appletviewer (appletviewer) in auto mode
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
