### PR TITLE
[KYUUBI #2676] Flaky Test: SparkOperationProgressSuite: test operation progress

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationProgressSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationProgressSuite.scala
@@ -31,6 +31,7 @@ class SparkOperationProgressSuite extends WithSparkSQLEngine with HiveJDBCTestHe
   override protected def jdbcUrl: String = getJdbcUrl
   override def withKyuubiConf: Map[String, String] = Map(
     "spark.master" -> "local[1]",
+    "spark.ui.liveUpdate.period" -> "0",
     "kyuubi.operation.progress.enabled" -> "true",
     "kyuubi.operation.status.polling.timeout" -> "1000")
 


### PR DESCRIPTION
### _Why are the changes needed?_
The update of `statusStore` is not timely. If the event interval is too short, less than the default value of `100ms`, the `statusStore` will not be updated.

org.apache.spark.status.AppStatusListener#onTaskStart
org.apache.spark.status.AppStatusListener#onTaskEnd
```scala
        maybeUpdate(stage, now)
```

close #2676


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
