### PR TITLE
[KYUUBI #2831] Spark engine supports local mode in kerberos environment

### DIFF
--- a/externals/kyuubi-spark-sql-engine/pom.xml
+++ b/externals/kyuubi-spark-sql-engine/pom.xml
@@ -59,6 +59,12 @@
 
         <dependency>
             <groupId>org.apache.spark</groupId>
+            <artifactId>spark-hive_${scala.binary.version}</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.spark</groupId>
             <artifactId>spark-repl_${scala.binary.version}</artifactId>
             <scope>provided</scope>
         </dependency>
@@ -103,12 +109,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-hive_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -180,6 +180,9 @@ object SparkSQLEngine extends Logging {
 
   def createSpark(): SparkSession = {
     val session = SparkSession.builder.config(_sparkConf).getOrCreate
+    SparkContextHelper.obtainHiveDelegationTokenIfNeeded(
+      _sparkConf,
+      session.sparkContext.hadoopConfiguration)
     KyuubiSparkUtil.initializeSparkSession(
       session,
       kyuubiConf.get(ENGINE_INITIALIZE_SQL) ++ kyuubiConf.get(ENGINE_SESSION_INITIALIZE_SQL))


### PR DESCRIPTION
### _Why are the changes needed?_

Now in the kerberos environment, the spark engine cannot access the Hive meta store using `spark-submit --master=local --proxy-user xxx`.

```
beeline -u "jdbc:hive2://XXXX/default;principal=XXXX/_HOST@XXXX;#kyuubi.engine.share.level=CONNECTION;spark.master=local;spark.submit.deployMode=client;"
```


```
javax.security.sasl.SaslException: GSS initiate failed [Caused by GSSException: No valid credentials provided (Mechanism level: Failed to find any Kerberos tgt)]

        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1743)
        at org.apache.hadoop.hive.thrift.client.TUGIAssumingTransport.open(TUGIAssumingTransport.java:49)
        at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.open(HiveMetaStoreClient.java:483)
```

close #2831

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
