### PR TITLE
[TEST] Optimize the output of ExceptionThrowingDelegationTokenProvider in the Test

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HadoopCredentialsManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/credentials/HadoopCredentialsManagerSuite.scala
@@ -33,6 +33,16 @@ class HadoopCredentialsManagerSuite extends KyuubiFunSuite {
   private val appUser = "who"
   private val send = (_: String) => {}
 
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    ExceptionThrowingDelegationTokenProvider.IN_PROVIDER_TEST = true
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    ExceptionThrowingDelegationTokenProvider.IN_PROVIDER_TEST = false
+  }
+
   private def withStartedManager(kyuubiConf: KyuubiConf)(f: HadoopCredentialsManager => Unit)
       : Unit = {
     val manager = new HadoopCredentialsManager()
@@ -215,7 +225,9 @@ class HadoopCredentialsManagerSuite extends KyuubiFunSuite {
 
 private class ExceptionThrowingDelegationTokenProvider extends HadoopDelegationTokenProvider {
   ExceptionThrowingDelegationTokenProvider.constructed = true
-  throw new IllegalArgumentException
+  if (ExceptionThrowingDelegationTokenProvider.IN_PROVIDER_TEST) {
+    throw new IllegalArgumentException
+  }
 
   override def serviceName: String = "throw"
 
@@ -229,6 +241,7 @@ private class ExceptionThrowingDelegationTokenProvider extends HadoopDelegationT
 
 private object ExceptionThrowingDelegationTokenProvider {
   var constructed = false
+  var IN_PROVIDER_TEST = false
 }
 
 private class UnRequiredDelegationTokenProvider extends HadoopDelegationTokenProvider {


### PR DESCRIPTION
### _Why are the changes needed?_

Now kyuubi-server runs some tests that are not `HadoopCredentialsManagerSuite`, `ExceptionThrowingDelegationTokenProvider` still throws exception.
```
Caused by: java.lang.IllegalArgumentException
	at org.apache.kyuubi.credentials.ExceptionThrowingDelegationTokenProvider.<init>(HadoopCredentialsManagerSuite.scala:229) 
```

In this PR, I limit it to `HadoopCredentialsManagerSuite` to allow exceptions to be thrown. Other suites can load this provider by default, but it does not affect other suite tests.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
