### PR TITLE
Bump Hudi 0.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <hive.archive.mirror>${apache.archive.dist}/hive/hive-${hive.engine.hive.version}</hive.archive.mirror>
         <hive.archive.download.skip>false</hive.archive.download.skip>
         <httpclient.version>4.5.13</httpclient.version>
-        <hudi.version>0.11.0</hudi.version>
+        <hudi.version>0.11.1</hudi.version>
         <iceberg.name>iceberg-spark-runtime-3.2_${scala.binary.version}</iceberg.name>
         <iceberg.version>0.13.2</iceberg.version>
         <jackson.version>2.13.3</jackson.version>


### PR DESCRIPTION
### _Why are the changes needed?_
https://lists.apache.org/thread/72smzyoc516zqo7vbw87hx23qgdhzgql

[HUDI-4111](https://issues.apache.org/jira/browse/HUDI-4111) Bump ANTLR runtime version in Spark 3.x

The antlr version of hudi is aligned with the version used by Spark.

https://github.com/apache/hudi/compare/release-0.11.0...release-0.11.1


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
