### PR TITLE
[SUB-TASK][KPIP-4] Rest client supports retry request if catch net exception

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/BatchRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/BatchRestApi.java
@@ -89,7 +89,7 @@ public class BatchRestApi {
     return this.getClient().delete(path, params, CloseBatchResponse.class, client.getAuthHeader());
   }
 
-  private RestClient getClient() {
+  private IRestClient getClient() {
     return this.client.getHttpClient();
   }
 }

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/HttpClientFactory.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/HttpClientFactory.java
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory;
 public class HttpClientFactory {
   private static final Logger LOG = LoggerFactory.getLogger(HttpClientFactory.class);
 
-  public static CloseableHttpClient createHttpClient(RestConf conf) {
+  public static CloseableHttpClient createHttpClient(RestClientConf conf) {
     RequestConfig requestConfig =
         RequestConfig.custom()
             .setSocketTimeout(conf.getSocketTimeout())

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/HttpClientFactory.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/HttpClientFactory.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client;
+
+import javax.net.ssl.SSLContext;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
+import org.apache.http.conn.ssl.TrustStrategy;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.ssl.SSLContexts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HttpClientFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(HttpClientFactory.class);
+
+  public static CloseableHttpClient createHttpClient(RestConf conf) {
+    RequestConfig requestConfig =
+        RequestConfig.custom()
+            .setSocketTimeout(conf.getSocketTimeout())
+            .setConnectTimeout(conf.getConnectTimeout())
+            .build();
+    SSLConnectionSocketFactory sslSocketFactory;
+    try {
+      TrustStrategy acceptingTrustStrategy = (cert, authType) -> true;
+      SSLContext sslContext =
+          SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
+      sslSocketFactory = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
+    } catch (Exception e) {
+      LOG.error("Error: ", e);
+      throw new RuntimeException(e);
+    }
+
+    return HttpClientBuilder.create()
+        .setDefaultRequestConfig(requestConfig)
+        .setSSLSocketFactory(sslSocketFactory)
+        .build();
+  }
+}

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/IRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/IRestClient.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client;
+
+import java.util.Map;
+
+/** A underlying http client interface for common rest request. */
+public interface IRestClient extends AutoCloseable {
+  public <T> T get(String path, Map<String, Object> params, Class<T> type, String authHeader);
+
+  public String get(String path, Map<String, Object> params, String authHeader);
+
+  public <T> T post(String path, String body, Class<T> type, String authHeader);
+
+  public String post(String path, String body, String authHeader);
+
+  public <T> T delete(String path, Map<String, Object> params, Class<T> type, String authHeader);
+
+  public String delete(String path, Map<String, Object> params, String authHeader);
+}

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
@@ -63,7 +63,7 @@ public class KyuubiRestClient implements AutoCloseable {
       baseUrls.add(baseUrl);
     }
 
-    RestConf conf = new RestConf();
+    RestClientConf conf = new RestClientConf();
     conf.setConnectTimeout(builder.connectTimeout);
     conf.setSocketTimeout(builder.socketTimeout);
     conf.setMaxAttempts(builder.maxAttempts);
@@ -202,10 +202,15 @@ public class KyuubiRestClient implements AutoCloseable {
 
     public KyuubiRestClient build() {
       if (authHeaderMethod == AuthHeaderMethod.SPNEGO && StringUtils.isBlank(spnegoHost)) {
-        try {
-          this.spnegoHost = new URI(hostUrls.get(0)).getHost();
-        } catch (Exception e) {
+        if (hostUrls.size() > 1) {
           throw new IllegalArgumentException("spnegoHost is invalid.");
+        } else {
+          // follow the behavior of curl, use host url by default
+          try {
+            this.spnegoHost = new URI(hostUrls.get(0)).getHost();
+          } catch (Exception e) {
+            throw new IllegalArgumentException("spnegoHost is invalid.", e);
+          }
         }
       }
       return new KyuubiRestClient(this);

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
@@ -18,24 +18,15 @@
 package org.apache.kyuubi.client;
 
 import java.net.URI;
-import javax.net.ssl.SSLContext;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.conn.ssl.NoopHostnameVerifier;
-import org.apache.http.conn.ssl.SSLConnectionSocketFactory;
-import org.apache.http.conn.ssl.TrustStrategy;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.apache.http.ssl.SSLContexts;
 import org.apache.kyuubi.client.auth.*;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class KyuubiRestClient implements AutoCloseable {
 
-  private static final Logger LOG = LoggerFactory.getLogger(KyuubiRestClient.class);
-
-  private RestClient httpClient;
+  private IRestClient httpClient;
 
   private AuthHeaderGenerator authHeaderGenerator;
 
@@ -64,13 +55,21 @@ public class KyuubiRestClient implements AutoCloseable {
   private KyuubiRestClient() {}
 
   private KyuubiRestClient(Builder builder) {
-    // Remove the trailing "/" from the hostUrl if present
-    String hostUrl = builder.hostUrl.replaceAll("/$", "");
-    String baseUrl = String.format("%s/%s", hostUrl, builder.version.getApiNamespace());
+    List<String> baseUrls = new LinkedList<>();
+    for (String hostUrl : builder.hostUrls) {
+      // Remove the trailing "/" from the hostUrl if present
+      String baseUrl =
+          String.format("%s/%s", hostUrl.replaceAll("/$", ""), builder.version.getApiNamespace());
+      baseUrls.add(baseUrl);
+    }
 
-    CloseableHttpClient httpclient = initHttpClient(builder);
+    RestConf conf = new RestConf();
+    conf.setConnectTimeout(builder.connectTimeout);
+    conf.setSocketTimeout(builder.socketTimeout);
+    conf.setMaxAttempts(builder.maxAttempts);
+    conf.setAttemptWaitTime(builder.attemptWaitTime);
 
-    this.httpClient = new RestClient(baseUrl, httpclient);
+    this.httpClient = RetryableRestClient.getRestClient(baseUrls, conf);
 
     switch (builder.authHeaderMethod) {
       case BASIC:
@@ -94,42 +93,25 @@ public class KyuubiRestClient implements AutoCloseable {
     return authHeaderGenerator.generateAuthHeader();
   }
 
-  public RestClient getHttpClient() {
+  public IRestClient getHttpClient() {
     return httpClient;
-  }
-
-  private CloseableHttpClient initHttpClient(Builder builder) {
-    RequestConfig requestConfig =
-        RequestConfig.custom()
-            .setSocketTimeout(builder.socketTimeout)
-            .setConnectTimeout(builder.connectTimeout)
-            .build();
-    SSLConnectionSocketFactory sslSocketFactory;
-    try {
-      TrustStrategy acceptingTrustStrategy = (cert, authType) -> true;
-      SSLContext sslContext =
-          SSLContexts.custom().loadTrustMaterial(null, acceptingTrustStrategy).build();
-      sslSocketFactory = new SSLConnectionSocketFactory(sslContext, NoopHostnameVerifier.INSTANCE);
-    } catch (Exception e) {
-      LOG.error("Error: ", e);
-      throw new RuntimeException(e);
-    }
-
-    CloseableHttpClient httpclient =
-        HttpClientBuilder.create()
-            .setDefaultRequestConfig(requestConfig)
-            .setSSLSocketFactory(sslSocketFactory)
-            .build();
-    return httpclient;
   }
 
   public static Builder builder(String hostUrl) {
     return new Builder(hostUrl);
   }
 
+  public static Builder builder(String... hostUrls) {
+    return new Builder(Arrays.asList(hostUrls));
+  }
+
+  public static Builder builder(List<String> hostUrls) {
+    return new Builder(hostUrls);
+  }
+
   public static class Builder {
 
-    private String hostUrl;
+    private List<String> hostUrls;
 
     private String spnegoHost;
 
@@ -147,8 +129,23 @@ public class KyuubiRestClient implements AutoCloseable {
 
     private int connectTimeout = 3000;
 
+    private int maxAttempts = 3;
+
+    private int attemptWaitTime = 3000;
+
     public Builder(String hostUrl) {
-      this.hostUrl = hostUrl;
+      if (hostUrl == null) {
+        throw new IllegalArgumentException("hostUrl cannot be blank.");
+      }
+      this.hostUrls = new LinkedList<>();
+      this.hostUrls.add(hostUrl);
+    }
+
+    public Builder(List<String> hostUrls) {
+      if (hostUrls.isEmpty()) {
+        throw new IllegalArgumentException("hostUrls cannot be blank.");
+      }
+      this.hostUrls = hostUrls;
     }
 
     public Builder spnegoHost(String host) {
@@ -193,14 +190,20 @@ public class KyuubiRestClient implements AutoCloseable {
       return this;
     }
 
-    public KyuubiRestClient build() {
-      if (StringUtils.isBlank(hostUrl)) {
-        throw new IllegalArgumentException("hostUrl cannot be blank.");
-      }
+    public Builder maxAttempts(int maxAttempts) {
+      this.maxAttempts = maxAttempts;
+      return this;
+    }
 
+    public Builder attemptWaitTime(int attemptWaitTime) {
+      this.attemptWaitTime = attemptWaitTime;
+      return this;
+    }
+
+    public KyuubiRestClient build() {
       if (authHeaderMethod == AuthHeaderMethod.SPNEGO && StringUtils.isBlank(spnegoHost)) {
         try {
-          this.spnegoHost = new URI(hostUrl).getHost();
+          this.spnegoHost = new URI(hostUrls.get(0)).getHost();
         } catch (Exception e) {
           throw new IllegalArgumentException("spnegoHost is invalid.");
         }

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/KyuubiRestClient.java
@@ -134,7 +134,7 @@ public class KyuubiRestClient implements AutoCloseable {
     private int attemptWaitTime = 3000;
 
     public Builder(String hostUrl) {
-      if (hostUrl == null) {
+      if (StringUtils.isBlank(hostUrl)) {
         throw new IllegalArgumentException("hostUrl cannot be blank.");
       }
       this.hostUrls = new LinkedList<>();

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RestClientConf.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RestClientConf.java
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.client;
 
-public class RestConf {
+public class RestClientConf {
   private int maxAttempts;
   private int attemptWaitTime;
   private int socketTimeout;

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RestConf.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RestConf.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client;
+
+public class RestConf {
+  private int maxAttempts;
+  private int attemptWaitTime;
+  private int socketTimeout;
+  private int connectTimeout;
+
+  public int getMaxAttempts() {
+    return maxAttempts;
+  }
+
+  public void setMaxAttempts(int maxAttempts) {
+    this.maxAttempts = maxAttempts;
+  }
+
+  public int getAttemptWaitTime() {
+    return attemptWaitTime;
+  }
+
+  public void setAttemptWaitTime(int attemptWaitTime) {
+    this.attemptWaitTime = attemptWaitTime;
+  }
+
+  public int getSocketTimeout() {
+    return socketTimeout;
+  }
+
+  public void setSocketTimeout(int socketTimeout) {
+    this.socketTimeout = socketTimeout;
+  }
+
+  public int getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  public void setConnectTimeout(int connectTimeout) {
+    this.connectTimeout = connectTimeout;
+  }
+}

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RetryableRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RetryableRestClient.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.List;
+import java.util.Random;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.kyuubi.client.exception.KyuubiRetryableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A retryable rest client that catches the {@link KyuubiRetryableException} which is thrown by
+ * underlying rest client and use a new server uri to the next attempt.
+ */
+public class RetryableRestClient implements InvocationHandler {
+
+  private Logger LOG = LoggerFactory.getLogger(RetryableRestClient.class);
+
+  private List<String> uris;
+  private int currentUriIndex;
+  private final RestConf conf;
+  private IRestClient restClient;
+
+  private RetryableRestClient(List<String> uris, RestConf conf) {
+    this.conf = conf;
+    this.uris = uris;
+    this.currentUriIndex = new Random(System.currentTimeMillis()).nextInt(uris.size());
+    newRestClient();
+  }
+
+  public static IRestClient getRestClient(List<String> uris, RestConf conf) {
+    RetryableRestClient client = new RetryableRestClient(uris, conf);
+    return (IRestClient)
+        Proxy.newProxyInstance(
+            Thread.currentThread().getContextClassLoader(),
+            new Class[] {IRestClient.class},
+            client);
+  }
+
+  private void newRestClient() {
+    if (restClient != null) {
+      try {
+        restClient.close();
+        restClient = null;
+      } catch (Exception e) {
+        LOG.warn("Failed to close rest client", e);
+      }
+    }
+
+    CloseableHttpClient httpclient = HttpClientFactory.createHttpClient(conf);
+    assert currentUriIndex < uris.size();
+    this.restClient = new RestClient(uris.get(currentUriIndex), httpclient);
+    LOG.info("current connect server uri {}", uris.get(currentUriIndex));
+  }
+
+  @Override
+  public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    int retryTimes = 0;
+    while (true) {
+      try {
+        return method.invoke(restClient, args);
+      } catch (IllegalAccessException ignored) {
+      } catch (InvocationTargetException e) {
+        if (e.getCause() == null) {
+          throw e;
+        } else if (e.getCause() instanceof KyuubiRetryableException) {
+          // the remote server has some issues or the client machine has some issues
+          retryTimes++;
+          if (retryTimes <= conf.getMaxAttempts()) {
+            Thread.sleep(conf.getAttemptWaitTime());
+          } else {
+            LOG.error("Attempt over {} times", conf.getMaxAttempts(), e.getCause());
+            throw e.getCause();
+          }
+          if (currentUriIndex == uris.size() - 1) {
+            currentUriIndex = 0;
+          } else {
+            currentUriIndex++;
+          }
+          newRestClient();
+        } else {
+          throw e.getCause();
+        }
+      }
+    }
+  }
+}

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RetryableRestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RetryableRestClient.java
@@ -36,19 +36,19 @@ public class RetryableRestClient implements InvocationHandler {
 
   private Logger LOG = LoggerFactory.getLogger(RetryableRestClient.class);
 
-  private List<String> uris;
+  private final RestClientConf conf;
+  private final List<String> uris;
   private int currentUriIndex;
-  private final RestConf conf;
   private IRestClient restClient;
 
-  private RetryableRestClient(List<String> uris, RestConf conf) {
+  private RetryableRestClient(List<String> uris, RestClientConf conf) {
     this.conf = conf;
     this.uris = uris;
     this.currentUriIndex = new Random(System.currentTimeMillis()).nextInt(uris.size());
     newRestClient();
   }
 
-  public static IRestClient getRestClient(List<String> uris, RestConf conf) {
+  public static IRestClient getRestClient(List<String> uris, RestClientConf conf) {
     RetryableRestClient client = new RetryableRestClient(uris, conf);
     return (IRestClient)
         Proxy.newProxyInstance(
@@ -70,7 +70,7 @@ public class RetryableRestClient implements InvocationHandler {
     CloseableHttpClient httpclient = HttpClientFactory.createHttpClient(conf);
     assert currentUriIndex < uris.size();
     this.restClient = new RestClient(uris.get(currentUriIndex), httpclient);
-    LOG.info("current connect server uri {}", uris.get(currentUriIndex));
+    LOG.info("Current connect server uri {}", uris.get(currentUriIndex));
   }
 
   @Override

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/exception/KyuubiRetryableException.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/exception/KyuubiRetryableException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client.exception;
+
+/**
+ * A retryable exception which is thrown by underlying rest client. The call side can do retry by
+ * catching this exception.
+ */
+public class KyuubiRetryableException extends KyuubiRestException {
+  public KyuubiRetryableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/BatchRestClientTest.java
+++ b/kyuubi-rest-client/src/test/java/org/apache/kyuubi/client/BatchRestClientTest.java
@@ -55,8 +55,10 @@ public class BatchRestClientTest {
             .build();
     spnegoBatchRestApi = new BatchRestApi(spnegoClient);
 
+    // https://localhost:8442 is a fake server url and it is used to test retryable rest client
+    // the retryable rest client will shuffle the input host urls
     basicClient =
-        KyuubiRestClient.builder("https://localhost:8443")
+        KyuubiRestClient.builder("https://localhost:8443", "https://localhost:8442")
             .authHeaderMethod(KyuubiRestClient.AuthHeaderMethod.BASIC)
             .username(TEST_USERNAME)
             .password(TEST_PASSWORD)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
close #2880

The main changes:
- Add a interface IRestClient for the underlying rest client
- Add KyuubiRetryableException to make call side aware whether attempts
- Add RetryableRestClient which delegates the request to the real RestClient and provide a functionality of request attempts
- Make KyuubiRestClient supports multi-hostUrls

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
