### PR TITLE
[KYUUBI #2890] Get the db From Sparksession When TableIdentifier's Database Field Is Empty

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -567,7 +567,7 @@ object PrivilegesBuilder {
    */
   def build(
       plan: LogicalPlan,
-      spark: SparkSession = null): (Seq[PrivilegeObject], Seq[PrivilegeObject]) = {
+      spark: SparkSession): (Seq[PrivilegeObject], Seq[PrivilegeObject]) = {
     val inputObjs = new ArrayBuffer[PrivilegeObject]
     val outputObjs = new ArrayBuffer[PrivilegeObject]
     plan match {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -77,7 +77,6 @@ object PrivilegesBuilder {
       tableIdent
     }
   }
- }
 
   /**
    * Build PrivilegeObjects from Spark LogicalPlan

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -381,7 +381,7 @@ object PrivilegesBuilder {
         outputObjs += tablePrivileges(target)
 
       case "CreateTempViewUsing" =>
-        outputObjs += tablePrivileges(getPlanField[TableIdentifier]("tableIdent"))
+        outputObjs += tablePrivileges(getTableIdent)
 
       case "DescribeColumnCommand" =>
         val table = getPlanField[TableIdentifier]("table")

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -30,7 +30,6 @@ import org.apache.spark.sql.types.StructField
 
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType._
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 object PrivilegesBuilder {
@@ -162,12 +161,11 @@ object PrivilegesBuilder {
     def getDatabaseForTableIndent(tableIdent: TableIdentifier): TableIdentifier = {
 
       def getDatabaseFromSparkSession: Option[String] = {
-        if (AuthZUtils.isSparkVersionAtMost("2.4")) {
+        if (isSparkVersionAtMost("2.4")) {
           return Some(spark.catalog.currentDatabase)
-        } else if (AuthZUtils.isSparkVersionAtLeast("3.0")) {
-          val catalogManager = AuthZUtils.invoke(spark.sessionState, "catalogManager")
-          val currentNamespace =
-            AuthZUtils.invoke(catalogManager.asInstanceOf[AnyRef], "currentNamespace")
+        } else if (isSparkVersionAtLeast("3.0")) {
+          val catalogManager = invoke(spark.sessionState, "catalogManager")
+          val currentNamespace = invoke(catalogManager.asInstanceOf[AnyRef], "currentNamespace")
           val namespaces: Array[String] = currentNamespace.asInstanceOf[Array[String]]
           if (namespaces != null && namespaces.length == 1) {
             return Some(namespaces.head)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -67,7 +67,7 @@ object PrivilegesBuilder {
     expr.collect { case p: NamedExpression if p.children.isEmpty => p }
   }
 
-   private def setCurrentDBIfNecessary(
+  private def setCurrentDBIfNecessary(
       tableIdent: TableIdentifier,
       spark: SparkSession): TableIdentifier = {
 
@@ -77,13 +77,7 @@ object PrivilegesBuilder {
       tableIdent
     }
   }
-
-    if (spark != null && tableIdent != null && tableIdent.database.isEmpty) {
-      tableIdent.copy(database = getDbFromSparkSession)
-    } else {
-      tableIdent
-    }
-  }
+ }
 
   /**
    * Build PrivilegeObjects from Spark LogicalPlan

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -40,7 +40,7 @@ object RuleAuthorization {
     val auditHandler = new SparkRangerAuditHandler
     val ugi = getAuthzUgi(spark.sparkContext)
     val opType = OperationType(plan.nodeName)
-    val (inputs, outputs) = PrivilegesBuilder.build(plan)
+    val (inputs, outputs) = PrivilegesBuilder.build(plan, spark)
     val requests = new ArrayBuffer[AccessRequest]()
     if (inputs.isEmpty && opType == OperationType.SHOWDATABASES) {
       val resource = AccessResource(DATABASE, null)

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilderSuite.scala
@@ -55,7 +55,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
   }
 
   protected def checkColumns(plan: LogicalPlan, cols: Seq[String]): Unit = {
-    val (in, out) = PrivilegesBuilder.build(plan)
+    val (in, out) = PrivilegesBuilder.build(plan, spark)
     assert(out.isEmpty, "Queries shall not check output privileges")
     val po = in.head
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
@@ -101,7 +101,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql("ALTER DATABASE default SET DBPROPERTIES (abc = '123')").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ALTERDATABASE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.isEmpty)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -124,7 +124,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
           s" RENAME TO $t").queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === ALTERTABLE_RENAME)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.isEmpty)
       assert(tuple._2.size === 2)
       tuple._2.foreach { po =>
@@ -143,7 +143,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       val plan = sql(s"CREATE DATABASE $db").queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === CREATEDATABASE)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.isEmpty)
       assert(tuple._2.size === 1)
       val po = tuple._2.head
@@ -163,7 +163,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       val plan = sql(s"DROP DATABASE DropDatabaseCommand").queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === DROPDATABASE)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.isEmpty)
       assert(tuple._2.size === 1)
       val po = tuple._2.head
@@ -182,7 +182,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ALTERTABLE_ADDPARTS)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.isEmpty)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -200,7 +200,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ALTERTABLE_DROPPARTS)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.isEmpty)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -231,7 +231,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       val plan = sql(sqlStr).queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === MSCK)
-      val (inputs, outputs) = PrivilegesBuilder.build(plan)
+      val (inputs, outputs) = PrivilegesBuilder.build(plan, spark)
 
       assert(inputs.isEmpty)
 
@@ -256,7 +256,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ALTERTABLE_RENAMEPART)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.isEmpty)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -277,7 +277,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ALTERTABLE_LOCATION)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.isEmpty)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -298,7 +298,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
         .queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === ALTERTABLE_PROPERTIES)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.isEmpty)
       assert(tuple._2.size === 1)
       val po = tuple._2.head
@@ -318,7 +318,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ALTERVIEW_AS)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -346,7 +346,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       s" COMPUTE STATISTICS FOR COLUMNS key").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ANALYZE_TABLE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -366,7 +366,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       s" PARTITION (pid = 1) COMPUTE STATISTICS").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ANALYZE_TABLE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -386,7 +386,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ANALYZE_TABLE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -407,7 +407,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ANALYZE_TABLE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -426,7 +426,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(s"REFRESH TABLE $reusedTable").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -444,7 +444,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(s"CACHE LAZY TABLE $reusedTable").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === CREATEVIEW)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     if (isSparkV32OrGreater) {
       assert(tuple._1.size === 1)
       val po0 = tuple._1.head
@@ -475,7 +475,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === CREATEVIEW)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -506,7 +506,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === CREATEVIEW)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -539,7 +539,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
         .queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === CREATETABLE)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.size === 0)
       assert(tuple._2.size === 1)
       val po = tuple._2.head
@@ -558,7 +558,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === CREATEFUNCTION)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 0)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -578,7 +578,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === DROPFUNCTION)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 0)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -599,7 +599,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === RELOADFUNCTION)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 0)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -619,7 +619,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       val operationType = OperationType(plan.nodeName)
 
       assert(operationType === CREATETABLE)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.size === 1)
       val po0 = tuple._1.head
       assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -679,7 +679,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val operationType = OperationType(plan.nodeName)
 
     assert(operationType === CREATEVIEW)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 0)
 
     assert(tuple._2.size === 1)
@@ -697,7 +697,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(s"DESC TABLE $reusedTable key").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === DESCTABLE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po = tuple._1.head
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
@@ -715,7 +715,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(s"DESC TABLE $reusedTable").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === DESCTABLE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po = tuple._1.head
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
@@ -733,7 +733,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(s"DESC DATABASE $reusedDb").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === DESCDATABASE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po = tuple._1.head
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
@@ -752,7 +752,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       val plan = sql(s"USE $reusedDb").queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === SWITCHDATABASE)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.size === 1)
 
       val po0 = tuple._1.head
@@ -775,7 +775,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === TRUNCATETABLE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.isEmpty)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -792,7 +792,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(s"SHOW COLUMNS IN $reusedTable").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === SHOWCOLUMNS)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -810,7 +810,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(s"SHOW CREATE TABLE $reusedTable").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === SHOW_CREATETABLE)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -828,7 +828,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(s"SHOW TBLPROPERTIES $reusedTable ").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === SHOW_TBLPROPERTIES)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -846,7 +846,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql("SHOW FUNCTIONS").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === SHOWFUNCTIONS)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 0)
     assert(tuple._2.size === 0)
   }
@@ -856,7 +856,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === SHOWPARTITIONS)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -888,7 +888,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       val plan = sql(sqlStr).queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === MSCK)
-      val (inputs, outputs) = PrivilegesBuilder.build(plan)
+      val (inputs, outputs) = PrivilegesBuilder.build(plan, spark)
 
       assert(inputs.isEmpty)
 
@@ -907,7 +907,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
 
   test("Query: Star") {
     val plan = sql(s"SELECT * FROM $reusedTable").queryExecution.optimizedPlan
-    val po = PrivilegesBuilder.build(plan)._1.head
+    val po = PrivilegesBuilder.build(plan, spark)._1.head
     assert(po.actionType === PrivilegeObjectActionType.OTHER)
     assert(po.privilegeObjectType === PrivilegeObjectType.TABLE_OR_VIEW)
     assert(po.dbname equalsIgnoreCase reusedDb)
@@ -961,7 +961,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
          |                FROM $reusedPartTable WHERE pid > 1)
          |""".stripMargin).queryExecution.optimizedPlan
 
-    val (in, _) = PrivilegesBuilder.build(plan)
+    val (in, _) = PrivilegesBuilder.build(plan, spark)
 
     assert(in.size === 2)
     assert(in.find(_.objectName equalsIgnoreCase reusedTableShort).head.columns ===
@@ -980,7 +980,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
          |""".stripMargin).queryExecution.optimizedPlan
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     tuple._1.foreach { po =>
       assert(po.actionType === PrivilegeObjectActionType.OTHER)
@@ -1006,7 +1006,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
          |""".stripMargin).queryExecution.optimizedPlan
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     tuple._1.foreach { po =>
       assert(po.actionType === PrivilegeObjectActionType.OTHER)
@@ -1034,7 +1034,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(sqlStr).queryExecution.optimizedPlan
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
 
     assert(tuple._1.size === 2)
     tuple._1.foreach { po =>
@@ -1062,7 +1062,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(sqlStr).queryExecution.optimizedPlan
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
 
     assert(tuple._1.size === 1)
     tuple._1.foreach { po =>
@@ -1091,7 +1091,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
     val plan = sql(sqlStr).queryExecution.optimizedPlan
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
 
     assert(tuple._1.size === 2)
     tuple._1.foreach { po =>
@@ -1117,7 +1117,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
          |""".stripMargin).queryExecution.optimizedPlan
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     tuple._1.foreach { po =>
       assert(po.actionType === PrivilegeObjectActionType.OTHER)
@@ -1142,7 +1142,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
          |""".stripMargin).queryExecution.optimizedPlan
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     tuple._1.foreach { po =>
       assert(po.actionType === PrivilegeObjectActionType.OTHER)
@@ -1167,7 +1167,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
          |SELECT pid, value
          |FROM $reusedPartTable
          |""".stripMargin).queryExecution.optimizedPlan
-    val (in, _) = PrivilegesBuilder.build(plan)
+    val (in, _) = PrivilegesBuilder.build(plan, spark)
     assert(in.size === 2)
   }
 
@@ -1184,7 +1184,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       s" ADD COLUMNS (a int)").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ALTERTABLE_ADDCOLS)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.isEmpty)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -1203,7 +1203,7 @@ abstract class PrivilegesBuilderSuite extends AnyFunSuite
       s" ALTER COLUMN value COMMENT 'alter column'").queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ALTERTABLE_REPLACECOLS)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.isEmpty)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -1228,7 +1228,7 @@ class InMemoryPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === ALTERDATABASE_LOCATION)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.isEmpty)
     assert(tuple._2.size === 1)
     val po = tuple._2.head
@@ -1248,7 +1248,7 @@ class InMemoryPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
     val operationType = OperationType(plan.nodeName)
 
     assert(operationType === CREATETABLE_AS_SELECT)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -1289,7 +1289,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
         .queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === ALTERTABLE_SERDEPROPERTIES)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.isEmpty)
       assert(tuple._2.size === 1)
       val po = tuple._2.head
@@ -1310,7 +1310,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
         .queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === CREATETABLE)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.size === 0)
       assert(tuple._2.size === 1)
       val po = tuple._2.head
@@ -1332,7 +1332,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
     val operationType = OperationType(plan.nodeName)
 
     assert(operationType === CREATETABLE_AS_SELECT)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -1369,7 +1369,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
         .queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === LOAD)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.isEmpty)
 
       assert(tuple._2.size === 1)
@@ -1396,7 +1396,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -1440,7 +1440,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       val plan = sql(sqlStr).queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === QUERY)
-      val (inputs, outputs) = PrivilegesBuilder.build(plan)
+      val (inputs, outputs) = PrivilegesBuilder.build(plan, spark)
 
       assert(inputs.size == 1)
       inputs.foreach { po =>
@@ -1480,7 +1480,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       val plan = sql(sqlStr).queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === QUERY)
-      val (inputs, outputs) = PrivilegesBuilder.build(plan)
+      val (inputs, outputs) = PrivilegesBuilder.build(plan, spark)
 
       assert(inputs.size == 1)
       inputs.foreach { po =>
@@ -1509,7 +1509,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       .queryExecution.analyzed
     val operationType = OperationType(plan.nodeName)
     assert(operationType === QUERY)
-    val tuple = PrivilegesBuilder.build(plan)
+    val tuple = PrivilegesBuilder.build(plan, spark)
     assert(tuple._1.size === 1)
     val po0 = tuple._1.head
     assert(po0.actionType === PrivilegeObjectActionType.OTHER)
@@ -1535,7 +1535,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       val plan = sql(sqlStr).queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === QUERY)
-      val (inputs, outputs) = PrivilegesBuilder.build(plan)
+      val (inputs, outputs) = PrivilegesBuilder.build(plan, spark)
 
       assert(inputs.isEmpty)
 
@@ -1559,7 +1559,7 @@ class HiveCatalogPrivilegeBuilderSuite extends PrivilegesBuilderSuite {
       val plan = sql(s"SHOW CREATE TABLE $t AS SERDE").queryExecution.analyzed
       val operationType = OperationType(plan.nodeName)
       assert(operationType === SHOW_CREATETABLE)
-      val tuple = PrivilegesBuilder.build(plan)
+      val tuple = PrivilegesBuilder.build(plan, spark)
       assert(tuple._1.size === 1)
       val po0 = tuple._1.head
       assert(po0.actionType === PrivilegeObjectActionType.OTHER)


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
to close #2890, and this issue is related to #2438

Get the db From Sparksession When TableIdentifier's Database Field Is Empty, but view's TableIdentifier would not. 
 

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
