### PR TITLE
[SUB-TASK][KPIP-4] Get batch application status from resource manager for across instances get batch request

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -76,7 +76,7 @@ class BatchJobSubmission(
 
   private[kyuubi] val batchId: String = session.handle.identifier.toString
 
-  private var applicationStatus: Option[Map[String, String]] = None
+  private[kyuubi] var applicationStatus: Option[Map[String, String]] = None
 
   private var killMessage: KillResponse = (false, "UNKNOWN")
   def getKillMessage: KillResponse = killMessage

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -64,6 +64,7 @@ class BatchJobSubmission(
     batchArgs: Seq[String],
     recoveryMetadata: Option[Metadata])
   extends KyuubiOperation(OperationType.UNKNOWN_OPERATION, session) {
+  import BatchJobSubmission._
 
   override def statement: String = "BATCH_JOB_SUBMISSION"
 
@@ -189,16 +190,6 @@ class BatchJobSubmission(
         updateBatchMetadata()
       }
     }
-  }
-
-  private def applicationFailed(applicationStatus: Option[Map[String, String]]): Boolean = {
-    applicationStatus.map(_.get(ApplicationOperation.APP_STATE_KEY)).exists(s =>
-      s.contains("KILLED") || s.contains("FAILED"))
-  }
-
-  private def applicationTerminated(applicationStatus: Option[Map[String, String]]): Boolean = {
-    applicationStatus.map(_.get(ApplicationOperation.APP_STATE_KEY)).exists(s =>
-      s.contains("KILLED") || s.contains("FAILED") || s.contains("FINISHED"))
   }
 
   private def submitAndMonitorBatchJob(): Unit = {
@@ -338,5 +329,17 @@ class BatchJobSubmission(
 
   override def cancel(): Unit = {
     throw new IllegalStateException("Use close instead.")
+  }
+}
+
+object BatchJobSubmission {
+  def applicationFailed(applicationStatus: Option[Map[String, String]]): Boolean = {
+    applicationStatus.map(_.get(ApplicationOperation.APP_STATE_KEY)).exists(s =>
+      s.contains("KILLED") || s.contains("FAILED"))
+  }
+
+  def applicationTerminated(applicationStatus: Option[Map[String, String]]): Boolean = {
+    applicationStatus.map(_.get(ApplicationOperation.APP_STATE_KEY)).exists(s =>
+      s.contains("KILLED") || s.contains("FAILED") || s.contains("FINISHED"))
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -76,6 +76,7 @@ class BatchJobSubmission(
 
   private[kyuubi] val batchId: String = session.handle.identifier.toString
 
+  @volatile
   private[kyuubi] var applicationStatus: Option[Map[String, String]] = None
 
   private var killMessage: KillResponse = (false, "UNKNOWN")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -238,6 +238,7 @@ class BatchJobSubmission(
       throw new RuntimeException(s"$batchType batch[$batchId] job failed:" +
         applicationStatus.get.mkString(","))
     } else {
+      updateBatchMetadata()
       // TODO: add limit for max batch job submission lifetime
       while (applicationStatus.isDefined && !applicationTerminated(applicationStatus)) {
         Thread.sleep(applicationCheckInterval)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -76,8 +76,7 @@ class BatchJobSubmission(
 
   private[kyuubi] val batchId: String = session.handle.identifier.toString
 
-  @volatile
-  private[kyuubi] var applicationStatus: Option[Map[String, String]] = None
+  private var applicationStatus: Option[Map[String, String]] = None
 
   private var killMessage: KillResponse = (false, "UNKNOWN")
   def getKillMessage: KillResponse = killMessage

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -72,7 +72,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       session.user,
       batchOp.batchType,
       batchOp.batchName,
-      batchOp.currentApplicationState.getOrElse(Map.empty).asJava,
+      batchOp.applicationStatus.getOrElse(Map.empty).asJava,
       fe.connectionUrl,
       batchOpStatus.state.toString,
       session.createTime,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -83,13 +83,16 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       metadata: Metadata,
       batchAppStatus: Option[Map[String, String]]): Batch = {
     batchAppStatus.map { appStatus =>
-      var currentBatchState = metadata.state
-
-      if (BatchJobSubmission.applicationFailed(batchAppStatus)) {
-        currentBatchState = OperationState.ERROR.toString
-      } else if (BatchJobSubmission.applicationTerminated(batchAppStatus)) {
-        currentBatchState = OperationState.FINISHED.toString
-      }
+      val currentBatchState =
+        if (BatchJobSubmission.applicationFailed(batchAppStatus)) {
+          OperationState.ERROR.toString
+        } else if (BatchJobSubmission.applicationTerminated(batchAppStatus)) {
+          OperationState.FINISHED.toString
+        } else if (batchAppStatus.isDefined) {
+          OperationState.RUNNING.toString
+        } else {
+          metadata.state
+        }
 
       new Batch(
         metadata.identifier,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -33,11 +33,12 @@ import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.client.api.v1.dto._
 import org.apache.kyuubi.client.exception.KyuubiRestException
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.operation.{FetchOrientation, OperationState}
+import org.apache.kyuubi.operation.{BatchJobSubmission, FetchOrientation, OperationState}
 import org.apache.kyuubi.server.api.ApiRequestContext
 import org.apache.kyuubi.server.api.v1.BatchesResource._
 import org.apache.kyuubi.server.http.authentication.AuthenticationFilter
 import org.apache.kyuubi.server.metadata.MetadataManager
+import org.apache.kyuubi.server.metadata.api.Metadata
 import org.apache.kyuubi.service.authentication.KyuubiAuthenticationFactory
 import org.apache.kyuubi.session.{KyuubiBatchSessionImpl, KyuubiSessionManager, SessionHandle}
 
@@ -76,6 +77,31 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       batchOpStatus.state.toString,
       session.createTime,
       batchOpStatus.completed)
+  }
+
+  private def buildBatch(
+      metadata: Metadata,
+      batchAppStatus: Option[Map[String, String]]): Batch = {
+    batchAppStatus.map { appStatus =>
+      var realBatchState = metadata.state
+
+      if (BatchJobSubmission.applicationFailed(batchAppStatus)) {
+        realBatchState = OperationState.ERROR.toString
+      } else if (BatchJobSubmission.applicationTerminated(batchAppStatus)) {
+        realBatchState = OperationState.FINISHED.toString
+      }
+
+      new Batch(
+        metadata.identifier,
+        metadata.username,
+        metadata.engineType,
+        metadata.requestName,
+        appStatus.asJava,
+        metadata.kyuubiInstance,
+        realBatchState,
+        metadata.createTime,
+        metadata.endTime)
+    }.getOrElse(MetadataManager.buildBatch(metadata))
   }
 
   private def formatSessionHandle(sessionHandleStr: String): SessionHandle = {
@@ -131,23 +157,10 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
         if (OperationState.isTerminal(OperationState.withName(metadata.state))) {
           MetadataManager.buildBatch(metadata)
         } else {
-          val applicationStatus = sessionManager.applicationManager.getApplicationInfo(
+          val batchAppStatus = sessionManager.applicationManager.getApplicationInfo(
             metadata.clusterManager,
             batchId)
-          if (applicationStatus.isDefined) {
-            new Batch(
-              batchId,
-              metadata.username,
-              metadata.engineType,
-              metadata.requestName,
-              applicationStatus.get.asJava,
-              metadata.kyuubiInstance,
-              metadata.state,
-              metadata.createTime,
-              metadata.endTime)
-          } else {
-            MetadataManager.buildBatch(metadata)
-          }
+          buildBatch(metadata, batchAppStatus)
         }
       }.getOrElse {
         error(s"Invalid batchId: $batchId")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -72,7 +72,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       session.user,
       batchOp.batchType,
       batchOp.batchName,
-      batchOp.applicationStatus.getOrElse(Map.empty).asJava,
+      batchOp.currentApplicationState.getOrElse(Map.empty).asJava,
       fe.connectionUrl,
       batchOpStatus.state.toString,
       session.createTime,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -83,12 +83,12 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       metadata: Metadata,
       batchAppStatus: Option[Map[String, String]]): Batch = {
     batchAppStatus.map { appStatus =>
-      var realBatchState = metadata.state
+      var currentBatchState = metadata.state
 
       if (BatchJobSubmission.applicationFailed(batchAppStatus)) {
-        realBatchState = OperationState.ERROR.toString
+        currentBatchState = OperationState.ERROR.toString
       } else if (BatchJobSubmission.applicationTerminated(batchAppStatus)) {
-        realBatchState = OperationState.FINISHED.toString
+        currentBatchState = OperationState.FINISHED.toString
       }
 
       new Batch(
@@ -98,7 +98,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
         metadata.requestName,
         appStatus.asJava,
         metadata.kyuubiInstance,
-        realBatchState,
+        currentBatchState,
         metadata.createTime,
         metadata.endTime)
     }.getOrElse(MetadataManager.buildBatch(metadata))

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -33,6 +33,8 @@ import org.apache.kyuubi.session.SessionType
 import org.apache.kyuubi.util.{ClassUtils, ThreadUtils}
 
 class MetadataManager extends CompositeService("MetadataManager") {
+  import MetadataManager._
+
   private var _metadataStore: MetadataStore = _
 
   private val identifierRequestsRetryRefs =
@@ -146,28 +148,6 @@ class MetadataManager extends CompositeService("MetadataManager") {
 
   def cleanupMetadataById(batchId: String): Unit = {
     _metadataStore.cleanupMetadataByIdentifier(batchId)
-  }
-
-  private def buildBatch(batchMetadata: Metadata): Batch = {
-    val batchAppInfo = Map(
-      APP_ID_KEY -> Option(batchMetadata.engineId),
-      APP_NAME_KEY -> Option(batchMetadata.engineName),
-      APP_STATE_KEY -> Option(batchMetadata.engineState),
-      APP_URL_KEY -> Option(batchMetadata.engineUrl),
-      APP_ERROR_KEY -> batchMetadata.engineError)
-      .filter(_._2.isDefined)
-      .map(info => (info._1, info._2.get))
-
-    new Batch(
-      batchMetadata.identifier,
-      batchMetadata.username,
-      batchMetadata.engineType,
-      batchMetadata.requestName,
-      batchAppInfo.asJava,
-      batchMetadata.kyuubiInstance,
-      batchMetadata.state,
-      batchMetadata.createTime,
-      batchMetadata.endTime)
   }
 
   private def startMetadataCleaner(): Unit = {
@@ -289,5 +269,27 @@ object MetadataManager extends Logging {
         s"${KyuubiConf.METADATA_STORE_CLASS.key} cannot be empty.")
     }
     ClassUtils.createInstance(className, classOf[MetadataStore], conf)
+  }
+
+  def buildBatch(batchMetadata: Metadata): Batch = {
+    val batchAppInfo = Map(
+      APP_ID_KEY -> Option(batchMetadata.engineId),
+      APP_NAME_KEY -> Option(batchMetadata.engineName),
+      APP_STATE_KEY -> Option(batchMetadata.engineState),
+      APP_URL_KEY -> Option(batchMetadata.engineUrl),
+      APP_ERROR_KEY -> batchMetadata.engineError)
+      .filter(_._2.isDefined)
+      .map(info => (info._1, info._2.get))
+
+    new Batch(
+      batchMetadata.identifier,
+      batchMetadata.username,
+      batchMetadata.engineType,
+      batchMetadata.requestName,
+      batchAppInfo.asJava,
+      batchMetadata.kyuubiInstance,
+      batchMetadata.state,
+      batchMetadata.createTime,
+      batchMetadata.endTime)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Now, we do not update the metadata if there is no batch operation state change.

For the batch application state change, it might no be updated in time.
For example:
-  SUBMITTED => ACCEPTED
-  SUBMITTED => RUNNING

So, it is better to get batch application status from resource manager for get batch request.

BTW, there is some corner case.

For example:
We deploy kyuubi on k8s, if the pod re-schedule and it stuck in provision phase caused by resource insufficient or other issue.

The kyuubi server can not recover in short-time.

We need fetch the application status from resource manager and return the correct batch report to prevent to block the batch client, which might wait the batch finished.

```
kyuubi-ctl submit batch -f batch.yaml --waitCompletion=true
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
