### PR TITLE
[SUB-TASK][KPIP-4] Support to mark the batch session closed by remote kyuubi instance if it is not reachable

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -984,6 +984,18 @@ object KyuubiConf {
       .timeConf
       .createWithDefault(Duration.ofSeconds(20).toMillis)
 
+  val BATCH_CHECK_INTERVAL: ConfigEntry[Long] =
+    buildConf("kyuubi.batch.check.interval")
+      .internal
+      .doc("The interval to check the batch session state. For batch session, it is not" +
+        " stateless, and some operations, such as close batch session, must be processed in the" +
+        " local kyuubi instance. But sometimes, the kyuubi instance might be unreachable, we" +
+        " need mark the batch session be CLOSED state in remote kyuubi instance. And the kyuubi" +
+        " instance should check whether there are local batch session are marked as CLOSED" +
+        " by remote kyuubi instance and close them periodically.")
+      .timeConf
+      .createWithDefault(Duration.ofSeconds(5).toMillis)
+
   val SERVER_EXEC_POOL_SIZE: ConfigEntry[Int] =
     buildConf("kyuubi.backend.server.exec.pool.size")
       .doc("Number of threads in the operation execution thread pool of Kyuubi server")

--- a/kyuubi-server/src/main/resources/sql/derby/metadata-store-schema-derby.sql
+++ b/kyuubi-server/src/main/resources/sql/derby/metadata-store-schema-derby.sql
@@ -22,7 +22,8 @@ CREATE TABLE metadata(
     engine_url varchar(1024), -- the engine tracking url
     engine_state varchar(128), -- the engine application state
     engine_error clob, -- the engine application diagnose
-    end_time bigint  -- the metadata end time
+    end_time bigint,  -- the metadata end time
+    remote_closed boolean default FALSE -- closed by remote kyuubi instance
 );
 
 CREATE INDEX metadata_kyuubi_instance_index ON metadata(kyuubi_instance);

--- a/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
+++ b/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
@@ -23,6 +23,7 @@ CREATE TABLE metadata(
     engine_state varchar(128) COMMENT 'the engine application state',
     engine_error mediumtext COMMENT 'the engine application diagnose',
     end_time bigint COMMENT 'the metadata end time',
+    remote_closed boolean default '0' COMMENT 'closed by remote kyuubi instance',
     INDEX kyuubi_instance_index(kyuubi_instance),
     UNIQUE INDEX unique_identifier_index(identifier),
     INDEX user_name_index(user_name),

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -37,6 +37,7 @@ import org.apache.kyuubi.operation.{FetchOrientation, OperationState}
 import org.apache.kyuubi.server.api.ApiRequestContext
 import org.apache.kyuubi.server.api.v1.BatchesResource._
 import org.apache.kyuubi.server.http.authentication.AuthenticationFilter
+import org.apache.kyuubi.server.metadata.api.Metadata
 import org.apache.kyuubi.service.authentication.KyuubiAuthenticationFactory
 import org.apache.kyuubi.session.{KyuubiBatchSessionImpl, KyuubiSessionManager, SessionHandle}
 
@@ -264,6 +265,11 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
               val appMgrKillResp = sessionManager.applicationManager.killApplication(
                 metadata.clusterManager,
                 batchId)
+              info(
+                s"Marking batch[$batchId/${metadata.kyuubiInstance}] closed by ${fe.connectionUrl}")
+              sessionManager.updateMetadata(Metadata(
+                identifier = batchId,
+                remoteClosed = true))
               if (appMgrKillResp._1) {
                 new CloseBatchResponse(appMgrKillResp._1, appMgrKillResp._2)
               } else {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataStore.scala
@@ -19,8 +19,7 @@ package org.apache.kyuubi.server.metadata
 
 import java.io.Closeable
 
-import org.apache.kyuubi.server.metadata.api.Metadata
-import org.apache.kyuubi.session.SessionType.SessionType
+import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
 
 trait MetadataStore extends Closeable {
 
@@ -39,26 +38,14 @@ trait MetadataStore extends Closeable {
 
   /**
    * Get the metadata list with filter conditions, offset and size.
-   * @param sessionType the session type.
-   * @param engineType the engine type.
-   * @param userName the user name.
-   * @param state the state.
-   * @param kyuubiInstance the kyuubi instance.
-   * @param createTime the metadata create time.
-   * @param endTime the end time.
-   * @param from the batch offset.
-   * @param size the batch size to get.
+   * @param filter the metadata filter conditions.
+   * @param from the metadata offset.
+   * @param size the size to get.
    * @param stateOnly only return the state related column values.
    * @return selected metadata list.
    */
   def getMetadataList(
-      sessionType: SessionType,
-      engineType: String,
-      userName: String,
-      state: String,
-      kyuubiInstance: String,
-      createTime: Long,
-      endTime: Long,
+      filter: MetadataFilter,
       from: Int,
       size: Int,
       stateOnly: Boolean): Seq[Metadata]

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/Metadata.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/Metadata.scala
@@ -47,6 +47,7 @@ import org.apache.kyuubi.session.SessionType.SessionType
  * @param engineState the engine state.
  * @param engineError the engine error diagnose.
  * @param endTime the end time.
+ * @param remoteClosed closed by remote kyuubi instance.
  */
 case class Metadata(
     identifier: String,
@@ -69,4 +70,5 @@ case class Metadata(
     engineUrl: String = null,
     engineState: String = null,
     engineError: Option[String] = None,
-    endTime: Long = 0L)
+    endTime: Long = 0L,
+    remoteClosed: Boolean = false)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/MetadataFilter.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/MetadataFilter.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.server.metadata.api
+
+import org.apache.kyuubi.session.SessionType.SessionType
+
+/**
+ * The conditions to filter the metadata.
+ */
+case class MetadataFilter(
+    sessionType: SessionType = null,
+    engineType: String = null,
+    username: String = null,
+    state: String = null,
+    kyuubiInstance: String = null,
+    createTime: Long = 0L,
+    endTime: Long = 0L,
+    remoteClosed: Boolean = false)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -33,11 +33,10 @@ import org.apache.kyuubi.{KyuubiException, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.operation.OperationState
 import org.apache.kyuubi.server.metadata.MetadataStore
-import org.apache.kyuubi.server.metadata.api.Metadata
+import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
 import org.apache.kyuubi.server.metadata.jdbc.DatabaseType._
 import org.apache.kyuubi.server.metadata.jdbc.JDBCMetadataStoreConf._
 import org.apache.kyuubi.session.SessionType
-import org.apache.kyuubi.session.SessionType.SessionType
 
 class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
   import JDBCMetadataStore._
@@ -169,13 +168,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
   }
 
   override def getMetadataList(
-      sessionType: SessionType,
-      engineType: String,
-      userName: String,
-      state: String,
-      kyuubiInstance: String,
-      createTime: Long,
-      endTime: Long,
+      filter: MetadataFilter,
       from: Int,
       size: Int,
       stateOnly: Boolean): Seq[Metadata] = {
@@ -187,34 +180,38 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
       queryBuilder.append(s"SELECT $METADATA_ALL_COLUMNS FROM $METADATA_TABLE")
     }
     val whereConditions = ListBuffer[String]()
-    Option(sessionType).foreach { _ =>
+    Option(filter.sessionType).foreach { sessionType =>
       whereConditions += " session_type = ?"
       params += sessionType.toString
     }
-    Option(engineType).filter(_.nonEmpty).foreach { _ =>
+    Option(filter.engineType).filter(_.nonEmpty).foreach { engineType =>
       whereConditions += " UPPER(engine_type) = ? "
       params += engineType.toUpperCase(Locale.ROOT)
     }
-    Option(userName).filter(_.nonEmpty).foreach { _ =>
+    Option(filter.username).filter(_.nonEmpty).foreach { username =>
       whereConditions += " user_name = ? "
-      params += userName
+      params += username
     }
-    Option(state).filter(_.nonEmpty).foreach { _ =>
+    Option(filter.state).filter(_.nonEmpty).foreach { state =>
       whereConditions += " state = ? "
       params += state.toUpperCase(Locale.ROOT)
     }
-    Option(kyuubiInstance).filter(_.nonEmpty).foreach { _ =>
+    Option(filter.kyuubiInstance).filter(_.nonEmpty).foreach { kyuubiInstance =>
       whereConditions += " kyuubi_instance = ? "
       params += kyuubiInstance
     }
-    if (createTime > 0) {
+    if (filter.createTime > 0) {
       whereConditions += " create_time >= ? "
-      params += createTime
+      params += filter.createTime
     }
-    if (endTime > 0) {
+    if (filter.endTime > 0) {
       whereConditions += " end_time > 0 "
       whereConditions += " end_time <= ? "
-      params += endTime
+      params += filter.endTime
+    }
+    if (filter.remoteClosed) {
+      whereConditions += " remote_closed = ? "
+      params += filter.remoteClosed
     }
     if (whereConditions.nonEmpty) {
       queryBuilder.append(whereConditions.mkString(" WHERE ", " AND ", " "))
@@ -261,6 +258,10 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
     metadata.engineError.foreach { error =>
       setClauses += " engine_error = ? "
       params += error
+    }
+    if (metadata.remoteClosed) {
+      setClauses += " remote_closed = ? "
+      params += metadata.remoteClosed
     }
     if (setClauses.nonEmpty) {
       queryBuilder.append(setClauses.mkString(" SET ", " , ", " "))
@@ -310,6 +311,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
         val engineState = resultSet.getString("engine_state")
         val engineError = Option(resultSet.getString("engine_error"))
         val endTime = resultSet.getLong("end_time")
+        val remoteClosed = resultSet.getBoolean("remote_closed")
 
         var resource: String = null
         var className: String = null
@@ -343,7 +345,8 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
           engineUrl = engineUrl,
           engineState = engineState,
           engineError = engineError,
-          endTime = endTime)
+          endTime = endTime,
+          remoteClosed = remoteClosed)
         metadataList += metadata
       }
       metadataList
@@ -403,6 +406,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
         case l: Long => statement.setLong(index + 1, l)
         case d: Double => statement.setDouble(index + 1, d)
         case f: Float => statement.setFloat(index + 1, f)
+        case b: Boolean => statement.setBoolean(index + 1, b)
         case _ => throw new KyuubiException(s"Unsupported param type ${param.getClass.getName}")
       }
     }
@@ -464,7 +468,8 @@ object JDBCMetadataStore {
     "engine_url",
     "engine_state",
     "engine_error",
-    "end_time").mkString(",")
+    "end_time",
+    "remote_closed").mkString(",")
   private val METADATA_ALL_COLUMNS = Seq(
     METADATA_STATE_ONLY_COLUMNS,
     "resource",

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
@@ -242,6 +242,16 @@ class KyuubiSessionManager private (name: String) extends SessionManager(name) {
     }
   }
 
+  def getRemoteClosedBatchSessions(kyuubiInstance: String): Seq[Metadata] = {
+    Seq(OperationState.PENDING, OperationState.RUNNING).flatMap { stateToKill =>
+      metadataManager.getRemoteClosedBatchesMetadata(
+        stateToKill.toString,
+        kyuubiInstance,
+        0,
+        Int.MaxValue)
+    }
+  }
+
   override protected def isServer: Boolean = true
 
   private def initSessionLimiter(conf: KyuubiConf): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

For batch session, it is not stateless, and some operations, such as close PENDING batch session, must be processed in the local kyuubi instance.
 But sometimes, the kyuubi instance might be unreachable, we need mark the batch session be CLOSED state in remote kyuubi instance.

In this pr, I introduce a new field `remoteClosed` to present whether it has been marked as CLOSED state by remote kyuubi instance.

The `remoteClosed` should only be updated by remote kyuubi instance and set its value to true, so there is no race condition.

- When opening the batch session in recovery mode, if `remoteClosed` is true, set the state to CANCELED directly
- check the local batch sessions that is marked as remoteClosed periodically and close them.
### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
