### PR TITLE
[SUB-TASK][KPIP-4] If the kyuubi instance unreachable, support to backfill state from resource manager and mark batch closed by remote kyuubi instance 

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -984,6 +984,18 @@ object KyuubiConf {
       .timeConf
       .createWithDefault(Duration.ofSeconds(20).toMillis)
 
+  val BATCH_CHECK_INTERVAL: ConfigEntry[Long] =
+    buildConf("kyuubi.batch.check.interval")
+      .internal
+      .doc("The interval to check the batch session state. For batch session, it is not" +
+        " stateless, and some operations, such as close batch session, must be processed in the" +
+        " local kyuubi instance. But sometimes, the kyuubi instance might be unreachable, we" +
+        " need mark the batch session be CLOSED state in remote kyuubi instance. And the kyuubi" +
+        " instance should check whether there are local batch session are marked as CLOSED" +
+        " by remote kyuubi instance and close them periodically.")
+      .timeConf
+      .createWithDefault(Duration.ofSeconds(5).toMillis)
+
   val SERVER_EXEC_POOL_SIZE: ConfigEntry[Int] =
     buildConf("kyuubi.backend.server.exec.pool.size")
       .doc("Number of threads in the operation execution thread pool of Kyuubi server")

--- a/kyuubi-server/src/main/resources/sql/derby/metadata-store-schema-derby.sql
+++ b/kyuubi-server/src/main/resources/sql/derby/metadata-store-schema-derby.sql
@@ -22,7 +22,8 @@ CREATE TABLE metadata(
     engine_url varchar(1024), -- the engine tracking url
     engine_state varchar(128), -- the engine application state
     engine_error clob, -- the engine application diagnose
-    end_time bigint  -- the metadata end time
+    end_time bigint,  -- the metadata end time
+    remote_closed boolean default FALSE -- closed by remote kyuubi instance
 );
 
 CREATE INDEX metadata_kyuubi_instance_index ON metadata(kyuubi_instance);

--- a/kyuubi-server/src/main/resources/sql/derby/metadata-store-schema-derby.sql
+++ b/kyuubi-server/src/main/resources/sql/derby/metadata-store-schema-derby.sql
@@ -23,7 +23,7 @@ CREATE TABLE metadata(
     engine_state varchar(128), -- the engine application state
     engine_error clob, -- the engine application diagnose
     end_time bigint,  -- the metadata end time
-    remote_closed boolean default FALSE -- closed by remote kyuubi instance
+    peer_instance_closed boolean default FALSE -- closed by peer kyuubi instance
 );
 
 CREATE INDEX metadata_kyuubi_instance_index ON metadata(kyuubi_instance);

--- a/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
+++ b/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
@@ -23,6 +23,7 @@ CREATE TABLE metadata(
     engine_state varchar(128) COMMENT 'the engine application state',
     engine_error mediumtext COMMENT 'the engine application diagnose',
     end_time bigint COMMENT 'the metadata end time',
+    remote_closed boolean default '0' COMMENT 'closed by remote kyuubi instance',
     INDEX kyuubi_instance_index(kyuubi_instance),
     UNIQUE INDEX unique_identifier_index(identifier),
     INDEX user_name_index(user_name),

--- a/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
+++ b/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
@@ -23,7 +23,7 @@ CREATE TABLE metadata(
     engine_state varchar(128) COMMENT 'the engine application state',
     engine_error mediumtext COMMENT 'the engine application diagnose',
     end_time bigint COMMENT 'the metadata end time',
-    remote_closed boolean default '0' COMMENT 'closed by remote kyuubi instance',
+    peer_instance_closed boolean default '0' COMMENT 'closed by peer kyuubi instance',
     INDEX kyuubi_instance_index(kyuubi_instance),
     UNIQUE INDEX unique_identifier_index(identifier),
     INDEX user_name_index(user_name),

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -155,7 +155,7 @@ class BatchJobSubmission(
   override protected def runInternal(): Unit = session.handleSessionException {
     val asyncOperation: Runnable = () => {
       try {
-        if (recoveryMetadata.exists(_.remoteClosed)) {
+        if (recoveryMetadata.exists(_.peerInstanceClosed)) {
           setState(OperationState.CANCELED)
         } else {
           // If it is in recovery mode, only re-submit batch job if previous state is PENDING and

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -156,23 +156,27 @@ class BatchJobSubmission(
     val asyncOperation: Runnable = () => {
       setStateIfNotCanceled(OperationState.RUNNING)
       try {
-        // If it is in recovery mode, only re-submit batch job if previous state is PENDING and
-        // fail to fetch the status including appId from resource manager. Otherwise, monitor the
-        // submitted batch application.
-        recoveryMetadata.map { metadata =>
-          if (metadata.state == OperationState.PENDING.toString) {
-            applicationStatus = currentApplicationState
-            applicationStatus.map(_.get(APP_ID_KEY)).map {
-              case Some(appId) => monitorBatchJob(appId)
-              case None => submitAndMonitorBatchJob()
+        if (recoveryMetadata.exists(_.remoteClosed)) {
+          setState(OperationState.CANCELED)
+        } else {
+          // If it is in recovery mode, only re-submit batch job if previous state is PENDING and
+          // fail to fetch the status including appId from resource manager. Otherwise, monitor the
+          // submitted batch application.
+          recoveryMetadata.map { metadata =>
+            if (metadata.state == OperationState.PENDING.toString) {
+              applicationStatus = currentApplicationState
+              applicationStatus.map(_.get(APP_ID_KEY)).map {
+                case Some(appId) => monitorBatchJob(appId)
+                case None => submitAndMonitorBatchJob()
+              }
+            } else {
+              monitorBatchJob(metadata.engineId)
             }
-          } else {
-            monitorBatchJob(metadata.engineId)
+          }.getOrElse {
+            submitAndMonitorBatchJob()
           }
-        }.getOrElse {
-          submitAndMonitorBatchJob()
+          setStateIfNotCanceled(OperationState.FINISHED)
         }
-        setStateIfNotCanceled(OperationState.FINISHED)
       } catch {
         onError()
       } finally {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -91,8 +91,7 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
             }
           }
         } catch {
-          case e: Throwable =>
-            error("Error checking batch session", e)
+          case e: Throwable => error("Error checking batch sessions", e)
         }
       }
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -84,7 +84,7 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
     val task = new Runnable {
       override def run(): Unit = {
         try {
-          sessionManager.getRemoteClosedBatchSessions(connectionUrl).foreach { batch =>
+          sessionManager.getPeerInstanceClosedBatchSessions(connectionUrl).foreach { batch =>
             Utils.tryLogNonFatalError {
               val sessionHandle = SessionHandle.fromUUID(batch.identifier)
               Option(sessionManager.getBatchSessionImpl(sessionHandle)).foreach(_.close())

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -316,7 +316,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
                 s"Marking batch[$batchId/${metadata.kyuubiInstance}] closed by ${fe.connectionUrl}")
               sessionManager.updateMetadata(Metadata(
                 identifier = batchId,
-                remoteClosed = true))
+                peerInstanceClosed = true))
               if (appMgrKillResp._1) {
                 new CloseBatchResponse(appMgrKillResp._1, appMgrKillResp._2)
               } else {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -303,6 +303,11 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
               val appMgrKillResp = sessionManager.applicationManager.killApplication(
                 metadata.clusterManager,
                 batchId)
+              info(
+                s"Marking batch[$batchId/${metadata.kyuubiInstance}] closed by ${fe.connectionUrl}")
+              sessionManager.updateMetadata(Metadata(
+                identifier = batchId,
+                remoteClosed = true))
               if (appMgrKillResp._1) {
                 new CloseBatchResponse(appMgrKillResp._1, appMgrKillResp._2)
               } else {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/InternalRestClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/InternalRestClient.scala
@@ -20,7 +20,7 @@ package org.apache.kyuubi.server.api.v1
 import java.util.Base64
 
 import org.apache.kyuubi.client.{BatchRestApi, KyuubiRestClient}
-import org.apache.kyuubi.client.api.v1.dto.{CloseBatchResponse, OperationLog}
+import org.apache.kyuubi.client.api.v1.dto.{Batch, CloseBatchResponse, OperationLog}
 import org.apache.kyuubi.client.auth.AuthHeaderGenerator
 import org.apache.kyuubi.server.http.authentication.AuthSchemes
 import org.apache.kyuubi.service.authentication.InternalSecurityAccessor
@@ -39,6 +39,12 @@ class InternalRestClient(kyuubiInstance: String, socketTimeout: Int, connectTime
     "Internal secure access across Kyuubi instances is not enabled")
 
   private val internalBatchRestApi = new BatchRestApi(initKyuubiRestClient())
+
+  def getBatch(user: String, batchId: String): Batch = {
+    withAuthUser(user) {
+      internalBatchRestApi.getBatchById(batchId)
+    }
+  }
 
   def getBatchLocalLog(user: String, batchId: String, from: Int, size: Int): OperationLog = {
     withAuthUser(user) {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -128,7 +128,7 @@ class MetadataManager extends CompositeService("MetadataManager") {
     _metadataStore.getMetadataList(filter, from, size, false)
   }
 
-  def getRemoteClosedBatchesMetadata(
+  def getPeerInstanceClosedBatchesMetadata(
       state: String,
       kyuubiInstance: String,
       from: Int,
@@ -137,7 +137,7 @@ class MetadataManager extends CompositeService("MetadataManager") {
       sessionType = SessionType.BATCH,
       state = state,
       kyuubiInstance = kyuubiInstance,
-      remoteClosed = true)
+      peerInstanceClosed = true)
     _metadataStore.getMetadataList(filter, from, size, true)
   }
 
@@ -287,7 +287,7 @@ object MetadataManager extends Logging {
       .map(info => (info._1, info._2.get))
 
     val batchState =
-      if (batchMetadata.remoteClosed &&
+      if (batchMetadata.peerInstanceClosed &&
         !OperationState.isTerminal(OperationState.withName(batchMetadata.state))) {
         OperationState.CANCELED.toString
       } else {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -27,7 +27,8 @@ import org.apache.kyuubi.client.api.v1.dto.Batch
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.METADATA_MAX_AGE
 import org.apache.kyuubi.engine.ApplicationOperation._
-import org.apache.kyuubi.server.metadata.api.Metadata
+import org.apache.kyuubi.operation.OperationState
+import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
 import org.apache.kyuubi.service.CompositeService
 import org.apache.kyuubi.session.SessionType
 import org.apache.kyuubi.util.{ClassUtils, ThreadUtils}
@@ -105,17 +106,14 @@ class MetadataManager extends CompositeService("MetadataManager") {
       endTime: Long,
       from: Int,
       size: Int): Seq[Batch] = {
-    _metadataStore.getMetadataList(
-      SessionType.BATCH,
-      batchType,
-      batchUser,
-      batchState,
-      null,
-      createTime,
-      endTime,
-      from,
-      size,
-      true).map(buildBatch)
+    val filter = MetadataFilter(
+      sessionType = SessionType.BATCH,
+      engineType = batchType,
+      username = batchUser,
+      state = batchState,
+      createTime = createTime,
+      endTime = endTime)
+    _metadataStore.getMetadataList(filter, from, size, true).map(buildBatch)
   }
 
   def getBatchesRecoveryMetadata(
@@ -123,17 +121,24 @@ class MetadataManager extends CompositeService("MetadataManager") {
       kyuubiInstance: String,
       from: Int,
       size: Int): Seq[Metadata] = {
-    _metadataStore.getMetadataList(
-      SessionType.BATCH,
-      null,
-      null,
-      state,
-      kyuubiInstance,
-      0,
-      0,
-      from,
-      size,
-      false)
+    val filter = MetadataFilter(
+      sessionType = SessionType.BATCH,
+      state = state,
+      kyuubiInstance = kyuubiInstance)
+    _metadataStore.getMetadataList(filter, from, size, false)
+  }
+
+  def getRemoteClosedBatchesMetadata(
+      state: String,
+      kyuubiInstance: String,
+      from: Int,
+      size: Int): Seq[Metadata] = {
+    val filter = MetadataFilter(
+      sessionType = SessionType.BATCH,
+      state = state,
+      kyuubiInstance = kyuubiInstance,
+      remoteClosed = true)
+    _metadataStore.getMetadataList(filter, from, size, true)
   }
 
   def updateMetadata(metadata: Metadata, retryOnError: Boolean = true): Unit = {
@@ -281,6 +286,14 @@ object MetadataManager extends Logging {
       .filter(_._2.isDefined)
       .map(info => (info._1, info._2.get))
 
+    val batchState =
+      if (batchMetadata.remoteClosed &&
+        !OperationState.isTerminal(OperationState.withName(batchMetadata.state))) {
+        OperationState.CANCELED.toString
+      } else {
+        batchMetadata.state
+      }
+
     new Batch(
       batchMetadata.identifier,
       batchMetadata.username,
@@ -288,7 +301,7 @@ object MetadataManager extends Logging {
       batchMetadata.requestName,
       batchAppInfo.asJava,
       batchMetadata.kyuubiInstance,
-      batchMetadata.state,
+      batchState,
       batchMetadata.createTime,
       batchMetadata.endTime)
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -33,6 +33,8 @@ import org.apache.kyuubi.session.SessionType
 import org.apache.kyuubi.util.{ClassUtils, ThreadUtils}
 
 class MetadataManager extends CompositeService("MetadataManager") {
+  import MetadataManager._
+
   private var _metadataStore: MetadataStore = _
 
   private val identifierRequestsRetryRefs =
@@ -146,28 +148,6 @@ class MetadataManager extends CompositeService("MetadataManager") {
 
   def cleanupMetadataById(batchId: String): Unit = {
     _metadataStore.cleanupMetadataByIdentifier(batchId)
-  }
-
-  private def buildBatch(batchMetadata: Metadata): Batch = {
-    val batchAppInfo = Map(
-      APP_ID_KEY -> Option(batchMetadata.engineId),
-      APP_NAME_KEY -> Option(batchMetadata.engineName),
-      APP_STATE_KEY -> Option(batchMetadata.engineState),
-      APP_URL_KEY -> Option(batchMetadata.engineUrl),
-      APP_ERROR_KEY -> batchMetadata.engineError)
-      .filter(_._2.isDefined)
-      .map(info => (info._1, info._2.get))
-
-    new Batch(
-      batchMetadata.identifier,
-      batchMetadata.username,
-      batchMetadata.engineType,
-      batchMetadata.requestName,
-      batchAppInfo.asJava,
-      batchMetadata.kyuubiInstance,
-      batchMetadata.state,
-      batchMetadata.createTime,
-      batchMetadata.endTime)
   }
 
   private def startMetadataCleaner(): Unit = {
@@ -289,5 +269,27 @@ object MetadataManager extends Logging {
         s"${KyuubiConf.METADATA_STORE_CLASS.key} cannot be empty.")
     }
     ClassUtils.createInstance(className, classOf[MetadataStore], conf)
+  }
+
+  def buildBatch(batchMetadata: Metadata): Batch = {
+    val batchAppInfo = Map(
+      APP_ID_KEY -> Option(batchMetadata.engineId),
+      APP_NAME_KEY -> Option(batchMetadata.engineName),
+      APP_STATE_KEY -> Option(batchMetadata.engineState),
+      APP_URL_KEY -> Option(batchMetadata.engineUrl),
+      APP_ERROR_KEY -> batchMetadata.engineError)
+      .filter(_._2.isDefined)
+      .map(info => (info._1, info._2.get))
+
+    new Batch(
+      batchMetadata.identifier,
+      batchMetadata.username,
+      batchMetadata.engineType,
+      batchMetadata.requestName,
+      batchAppInfo.asJava,
+      batchMetadata.kyuubiInstance,
+      batchMetadata.state,
+      batchMetadata.createTime,
+      batchMetadata.endTime)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataStore.scala
@@ -19,8 +19,7 @@ package org.apache.kyuubi.server.metadata
 
 import java.io.Closeable
 
-import org.apache.kyuubi.server.metadata.api.Metadata
-import org.apache.kyuubi.session.SessionType.SessionType
+import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
 
 trait MetadataStore extends Closeable {
 
@@ -39,26 +38,14 @@ trait MetadataStore extends Closeable {
 
   /**
    * Get the metadata list with filter conditions, offset and size.
-   * @param sessionType the session type.
-   * @param engineType the engine type.
-   * @param userName the user name.
-   * @param state the state.
-   * @param kyuubiInstance the kyuubi instance.
-   * @param createTime the metadata create time.
-   * @param endTime the end time.
-   * @param from the batch offset.
-   * @param size the batch size to get.
+   * @param filter the metadata filter conditions.
+   * @param from the metadata offset.
+   * @param size the size to get.
    * @param stateOnly only return the state related column values.
    * @return selected metadata list.
    */
   def getMetadataList(
-      sessionType: SessionType,
-      engineType: String,
-      userName: String,
-      state: String,
-      kyuubiInstance: String,
-      createTime: Long,
-      endTime: Long,
+      filter: MetadataFilter,
       from: Int,
       size: Int,
       stateOnly: Boolean): Seq[Metadata]

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/Metadata.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/Metadata.scala
@@ -47,6 +47,7 @@ import org.apache.kyuubi.session.SessionType.SessionType
  * @param engineState the engine state.
  * @param engineError the engine error diagnose.
  * @param endTime the end time.
+ * @param remoteClosed closed by remote kyuubi instance.
  */
 case class Metadata(
     identifier: String,
@@ -69,4 +70,5 @@ case class Metadata(
     engineUrl: String = null,
     engineState: String = null,
     engineError: Option[String] = None,
-    endTime: Long = 0L)
+    endTime: Long = 0L,
+    remoteClosed: Boolean = false)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/Metadata.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/Metadata.scala
@@ -47,7 +47,7 @@ import org.apache.kyuubi.session.SessionType.SessionType
  * @param engineState the engine state.
  * @param engineError the engine error diagnose.
  * @param endTime the end time.
- * @param remoteClosed closed by remote kyuubi instance.
+ * @param peerInstanceClosed closed by peer kyuubi instance.
  */
 case class Metadata(
     identifier: String,
@@ -71,4 +71,4 @@ case class Metadata(
     engineState: String = null,
     engineError: Option[String] = None,
     endTime: Long = 0L,
-    remoteClosed: Boolean = false)
+    peerInstanceClosed: Boolean = false)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/MetadataFilter.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/MetadataFilter.scala
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.server.metadata.api
+
+import org.apache.kyuubi.session.SessionType.SessionType
+
+/**
+ * The conditions to filter the metadata.
+ */
+case class MetadataFilter(
+    sessionType: SessionType = null,
+    engineType: String = null,
+    username: String = null,
+    state: String = null,
+    kyuubiInstance: String = null,
+    createTime: Long = 0L,
+    endTime: Long = 0L,
+    remoteClosed: Boolean = false)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/MetadataFilter.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/api/MetadataFilter.scala
@@ -30,4 +30,4 @@ case class MetadataFilter(
     kyuubiInstance: String = null,
     createTime: Long = 0L,
     endTime: Long = 0L,
-    remoteClosed: Boolean = false)
+    peerInstanceClosed: Boolean = false)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -209,9 +209,9 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
       whereConditions += " end_time <= ? "
       params += filter.endTime
     }
-    if (filter.remoteClosed) {
-      whereConditions += " remote_closed = ? "
-      params += filter.remoteClosed
+    if (filter.peerInstanceClosed) {
+      whereConditions += " peer_instance_closed = ? "
+      params += filter.peerInstanceClosed
     }
     if (whereConditions.nonEmpty) {
       queryBuilder.append(whereConditions.mkString(" WHERE ", " AND ", " "))
@@ -259,9 +259,9 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
       setClauses += " engine_error = ? "
       params += error
     }
-    if (metadata.remoteClosed) {
-      setClauses += " remote_closed = ? "
-      params += metadata.remoteClosed
+    if (metadata.peerInstanceClosed) {
+      setClauses += " peer_instance_closed = ? "
+      params += metadata.peerInstanceClosed
     }
     if (setClauses.nonEmpty) {
       queryBuilder.append(setClauses.mkString(" SET ", " , ", " "))
@@ -311,7 +311,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
         val engineState = resultSet.getString("engine_state")
         val engineError = Option(resultSet.getString("engine_error"))
         val endTime = resultSet.getLong("end_time")
-        val remoteClosed = resultSet.getBoolean("remote_closed")
+        val peerInstanceClosed = resultSet.getBoolean("peer_instance_closed")
 
         var resource: String = null
         var className: String = null
@@ -346,7 +346,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
           engineState = engineState,
           engineError = engineError,
           endTime = endTime,
-          remoteClosed = remoteClosed)
+          peerInstanceClosed = peerInstanceClosed)
         metadataList += metadata
       }
       metadataList
@@ -469,7 +469,7 @@ object JDBCMetadataStore {
     "engine_state",
     "engine_error",
     "end_time",
-    "remote_closed").mkString(",")
+    "peer_instance_closed").mkString(",")
   private val METADATA_ALL_COLUMNS = Seq(
     METADATA_STATE_ONLY_COLUMNS,
     "resource",

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -33,11 +33,10 @@ import org.apache.kyuubi.{KyuubiException, Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.operation.OperationState
 import org.apache.kyuubi.server.metadata.MetadataStore
-import org.apache.kyuubi.server.metadata.api.Metadata
+import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
 import org.apache.kyuubi.server.metadata.jdbc.DatabaseType._
 import org.apache.kyuubi.server.metadata.jdbc.JDBCMetadataStoreConf._
 import org.apache.kyuubi.session.SessionType
-import org.apache.kyuubi.session.SessionType.SessionType
 
 class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
   import JDBCMetadataStore._
@@ -169,13 +168,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
   }
 
   override def getMetadataList(
-      sessionType: SessionType,
-      engineType: String,
-      userName: String,
-      state: String,
-      kyuubiInstance: String,
-      createTime: Long,
-      endTime: Long,
+      filter: MetadataFilter,
       from: Int,
       size: Int,
       stateOnly: Boolean): Seq[Metadata] = {
@@ -187,34 +180,38 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
       queryBuilder.append(s"SELECT $METADATA_ALL_COLUMNS FROM $METADATA_TABLE")
     }
     val whereConditions = ListBuffer[String]()
-    Option(sessionType).foreach { _ =>
+    Option(filter.sessionType).foreach { sessionType =>
       whereConditions += " session_type = ?"
       params += sessionType.toString
     }
-    Option(engineType).filter(_.nonEmpty).foreach { _ =>
+    Option(filter.engineType).filter(_.nonEmpty).foreach { engineType =>
       whereConditions += " UPPER(engine_type) = ? "
       params += engineType.toUpperCase(Locale.ROOT)
     }
-    Option(userName).filter(_.nonEmpty).foreach { _ =>
+    Option(filter.username).filter(_.nonEmpty).foreach { username =>
       whereConditions += " user_name = ? "
-      params += userName
+      params += username
     }
-    Option(state).filter(_.nonEmpty).foreach { _ =>
+    Option(filter.state).filter(_.nonEmpty).foreach { state =>
       whereConditions += " state = ? "
       params += state.toUpperCase(Locale.ROOT)
     }
-    Option(kyuubiInstance).filter(_.nonEmpty).foreach { _ =>
+    Option(filter.kyuubiInstance).filter(_.nonEmpty).foreach { kyuubiInstance =>
       whereConditions += " kyuubi_instance = ? "
       params += kyuubiInstance
     }
-    if (createTime > 0) {
+    if (filter.createTime > 0) {
       whereConditions += " create_time >= ? "
-      params += createTime
+      params += filter.createTime
     }
-    if (endTime > 0) {
+    if (filter.endTime > 0) {
       whereConditions += " end_time > 0 "
       whereConditions += " end_time <= ? "
-      params += endTime
+      params += filter.endTime
+    }
+    if (filter.remoteClosed) {
+      whereConditions += " remote_closed = ? "
+      params += filter.remoteClosed
     }
     if (whereConditions.nonEmpty) {
       queryBuilder.append(whereConditions.mkString(" WHERE ", " AND ", " "))
@@ -261,6 +258,10 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
     metadata.engineError.foreach { error =>
       setClauses += " engine_error = ? "
       params += error
+    }
+    if (metadata.remoteClosed) {
+      setClauses += " remote_closed = ? "
+      params += metadata.remoteClosed
     }
     if (setClauses.nonEmpty) {
       queryBuilder.append(setClauses.mkString(" SET ", " , ", " "))
@@ -310,6 +311,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
         val engineState = resultSet.getString("engine_state")
         val engineError = Option(resultSet.getString("engine_error"))
         val endTime = resultSet.getLong("end_time")
+        val remoteClosed = resultSet.getBoolean("remote_closed")
 
         var resource: String = null
         var className: String = null
@@ -343,7 +345,8 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
           engineUrl = engineUrl,
           engineState = engineState,
           engineError = engineError,
-          endTime = endTime)
+          endTime = endTime,
+          remoteClosed = remoteClosed)
         metadataList += metadata
       }
       metadataList
@@ -403,6 +406,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
         case l: Long => statement.setLong(index + 1, l)
         case d: Double => statement.setDouble(index + 1, d)
         case f: Float => statement.setFloat(index + 1, f)
+        case b: Boolean => statement.setBoolean(index + 1, b)
         case _ => throw new KyuubiException(s"Unsupported param type ${param.getClass.getName}")
       }
     }
@@ -464,7 +468,8 @@ object JDBCMetadataStore {
     "engine_url",
     "engine_state",
     "engine_error",
-    "end_time").mkString(",")
+    "end_time",
+    "remote_closed").mkString(",")
   private val METADATA_ALL_COLUMNS = Seq(
     METADATA_STATE_ONLY_COLUMNS,
     "resource",

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
@@ -242,9 +242,9 @@ class KyuubiSessionManager private (name: String) extends SessionManager(name) {
     }
   }
 
-  def getRemoteClosedBatchSessions(kyuubiInstance: String): Seq[Metadata] = {
+  def getPeerInstanceClosedBatchSessions(kyuubiInstance: String): Seq[Metadata] = {
     Seq(OperationState.PENDING, OperationState.RUNNING).flatMap { stateToKill =>
-      metadataManager.getRemoteClosedBatchesMetadata(
+      metadataManager.getPeerInstanceClosedBatchesMetadata(
         stateToKill.toString,
         kyuubiInstance,
         0,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionManager.scala
@@ -242,6 +242,16 @@ class KyuubiSessionManager private (name: String) extends SessionManager(name) {
     }
   }
 
+  def getRemoteClosedBatchSessions(kyuubiInstance: String): Seq[Metadata] = {
+    Seq(OperationState.PENDING, OperationState.RUNNING).flatMap { stateToKill =>
+      metadataManager.getRemoteClosedBatchesMetadata(
+        stateToKill.toString,
+        kyuubiInstance,
+        0,
+        Int.MaxValue)
+    }
+  }
+
   override protected def isServer: Boolean = true
 
   private def initSessionLimiter(conf: KyuubiConf): Unit = {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreSuite.scala
@@ -186,7 +186,7 @@ class JDBCMetadataStoreSuite extends KyuubiFunSuite {
     batches = jdbcMetadataStore.getMetadataList(
       MetadataFilter(
         sessionType = SessionType.BATCH,
-        remoteClosed = true),
+        peerInstanceClosed = true),
       0,
       Int.MaxValue,
       true)
@@ -194,15 +194,15 @@ class JDBCMetadataStoreSuite extends KyuubiFunSuite {
 
     jdbcMetadataStore.updateMetadata(Metadata(
       identifier = batchStateOnlyMetadata.identifier,
-      remoteClosed = true))
+      peerInstanceClosed = true))
 
-    batchStateOnlyMetadata = batchStateOnlyMetadata.copy(remoteClosed = true)
-    batchMetadata = batchMetadata.copy(remoteClosed = true)
+    batchStateOnlyMetadata = batchStateOnlyMetadata.copy(peerInstanceClosed = true)
+    batchMetadata = batchMetadata.copy(peerInstanceClosed = true)
 
     batches = jdbcMetadataStore.getMetadataList(
       MetadataFilter(
         sessionType = SessionType.BATCH,
-        remoteClosed = true),
+        peerInstanceClosed = true),
       0,
       Int.MaxValue,
       true)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Now for the batch state, we rely on the metadata store, which is only updated by the local kyuubi instance.

But if the kyuubi instance is down or unreachable sometimes, the metadata state will not change and we can not get the correct state, it might cause the client side stuck if it is waiting the batch completion.

So, if the kyuubi instance is not reachable, we need backfill the batch state according to resource manager batch application state it the batch was in RUNNING state.

If the batch was stuck in PENDING state and the kyuubi instance can not get recovered in short-time, we need support to close the batch session and prevent the batch job re-submitted if it get recovered.

In this pr, I introduce a new field `remoteClosed` to present whether it has been marked as CLOSED state by remote kyuubi instance.

The `remoteClosed` should only be updated by remote kyuubi instance and set its value to true, so there is no race condition.

- When opening the batch session in recovery mode, if `remoteClosed` is true, set the state to CANCELED directly
- check the local batch sessions that is marked as remoteClosed periodically and close them.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
