### PR TITLE
Fix typo for mysql metadata schema 

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
@@ -18,7 +18,7 @@
 package org.apache.kyuubi.service
 
 /**
- * A [[FrontendService]] in Kyuubi architecture is responsible for talking requests from clients
+ * A [[FrontendService]] in Kyuubi architecture is responsible for taking requests from clients
  */
 trait FrontendService {
 

--- a/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
+++ b/kyuubi-server/src/main/resources/sql/mysql/metadata-store-schema-mysql.sql
@@ -7,7 +7,7 @@ CREATE TABLE metadata(
     real_user varchar(1024) NOT NULL COMMENT 'the real user',
     user_name varchar(1024) NOT NULL COMMENT 'the user name, might be a proxy user',
     ip_address varchar(512) COMMENT 'the client ip address',
-    kyuubi_instance varchar(1024) NOT NULL COMMENT 'the kyuubi instance that creates this'
+    kyuubi_instance varchar(1024) NOT NULL COMMENT 'the kyuubi instance that creates this',
     state varchar(128) NOT NULL COMMENT 'the session state',
     resource varchar(1024) COMMENT 'the main resource',
     class_name varchar(1024) COMMENT 'the main class name',


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix typo for mysql metadata schema.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
