### PR TITLE
[KYUUBI #2922] Clean up SparkConsoleProgressBar when SQL execution fails

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -144,7 +144,7 @@ class ExecuteStatement(
   }
 
   override def cleanup(targetState: OperationState): Unit = {
-    operationListener.foreach(spark.sparkContext.removeSparkListener(_))
+    operationListener.foreach(_.cleanup())
     super.cleanup(targetState)
   }
 


### PR DESCRIPTION
### _Why are the changes needed?_
Now `SparkConsoleProgressBar` is initialized after constructing `SQLOperationListener`. 
Sometimes the user's SQL syntax may fail.
At this time, because there is no `SparkListenerSQLExecutionEnd` event, `SparkConsoleProgressBar` is not cleaned up, resulting in a memory leak.

In this PR, make the following changes

- Added cleanup method

- Some objects use lazy to avoid constructing when SQL syntax is wrong

close #2922

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
