### PR TITLE
[KYUUBI #2949] Flaky test: execute statement - analysis exception

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -323,13 +323,16 @@ trait SparkQueryTests extends HiveJDBCTestHelper {
 
   test("execute statement - analysis exception") {
     val sql = "select date_sub(date'2011-11-11', '1.2')"
+    val errors = Set(
+      "The second argument of 'date_sub' function needs to be an integer.",
+      // unquoted since Spark-3.4, see https://github.com/apache/spark/pull/36693
+      "The second argument of date_sub function needs to be an integer.")
 
     withJdbcStatement() { statement =>
       val e = intercept[SQLException] {
         statement.executeQuery(sql)
       }
-      assert(e.getMessage
-        .contains("The second argument of 'date_sub' function needs to be an integer."))
+      assert(errors.exists(msg => e.getMessage.contains(msg)))
     }
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/mysql/MySQLSparkQuerySuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/mysql/MySQLSparkQuerySuite.scala
@@ -249,13 +249,16 @@ class MySQLSparkQuerySuite extends WithKyuubiServer with MySQLJDBCTestHelper {
 
   test("execute statement - analysis exception") {
     val sql = "select date_sub(date'2011-11-11', '1.2')"
+    val errors = Set(
+      "The second argument of 'date_sub' function needs to be an integer.",
+      // unquoted since Spark-3.4, see https://github.com/apache/spark/pull/36693
+      "The second argument of date_sub function needs to be an integer.")
 
     withJdbcStatement() { statement =>
       val e = intercept[SQLException] {
         statement.executeQuery(sql)
       }
-      assert(e.getMessage
-        .contains("The second argument of 'date_sub' function needs to be an integer."))
+      assert(errors.exists(msg => e.getMessage.contains(msg)))
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

to close #2949 

Unquoted the function name  in the error `SECOND_FUNCTION_ARGUMENT_NOT_INTEGER` since Spark-3.4.0, for more details, see https://github.com/apache/spark/pull/36693

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
