### PR TITLE
Support to interrupt the thrift request if remote engine is broken

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -38,6 +38,7 @@ import org.apache.kyuubi.session.SessionHandle
 import org.apache.kyuubi.util.{ThreadUtils, ThriftUtils}
 
 class KyuubiSyncThriftClient private (
+    sessionHandle: SessionHandle,
     protocol: TProtocol,
     maxAttempts: Int,
     engineAliveProbeProtocol: Option[TProtocol],
@@ -57,7 +58,7 @@ class KyuubiSyncThriftClient private (
   @volatile private var engineLastAlive: Long = _
 
   private lazy val asyncRequestExecutor =
-    ThreadUtils.newDaemonSingleThreadScheduledExecutor("async-request-pool-" + _remoteSessionHandle)
+    ThreadUtils.newDaemonSingleThreadScheduledExecutor("async-request-executor-" + sessionHandle)
 
   private def startEngineAliveProbe(): Unit = {
     engineAliveThreadPool = ThreadUtils.newDaemonSingleThreadScheduledExecutor(
@@ -440,6 +441,7 @@ private[kyuubi] object KyuubiSyncThriftClient extends Logging {
   }
 
   def createClient(
+      sessionHandle: SessionHandle,
       user: String,
       password: String,
       host: String,
@@ -471,6 +473,7 @@ private[kyuubi] object KyuubiSyncThriftClient extends Logging {
         None
       }
     new KyuubiSyncThriftClient(
+      sessionHandle,
       tProtocol,
       requestMaxAttempts,
       aliveProbeProtocol,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.client
 
-import java.util.concurrent.{ScheduledExecutorService, TimeUnit}
+import java.util.concurrent.{ExecutorService, ScheduledExecutorService, TimeUnit}
 import java.util.concurrent.locks.ReentrantLock
 
 import scala.collection.JavaConverters._
@@ -58,7 +58,7 @@ class KyuubiSyncThriftClient private (
   private var engineAliveThreadPool: ScheduledExecutorService = _
   @volatile private var engineLastAlive: Long = _
 
-  private var asyncRequestExecutor: ScheduledExecutorService = _
+  private var asyncRequestExecutor: ExecutorService = _
 
   @VisibleForTesting
   @volatile private[kyuubi] var asyncRequestInterrupted: Boolean = false
@@ -66,7 +66,7 @@ class KyuubiSyncThriftClient private (
   @VisibleForTesting
   private[kyuubi] def getEngineAliveProbeProtocol: Option[TProtocol] = engineAliveProbeProtocol
 
-  private def newAsyncRequestExecutor(): ScheduledExecutorService = {
+  private def newAsyncRequestExecutor(): ExecutorService = {
     ThreadUtils.newDaemonSingleThreadScheduledExecutor(
       "async-request-executor-" + _remoteSessionHandle)
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -63,6 +63,9 @@ class KyuubiSyncThriftClient private (
   @VisibleForTesting
   @volatile private[kyuubi] var asyncRequestInterrupted: Boolean = false
 
+  @VisibleForTesting
+  private[kyuubi] def getEngineAliveProbeProtocol: Option[TProtocol] = engineAliveProbeProtocol
+
   private def newAsyncRequestExecutor(): ScheduledExecutorService = {
     ThreadUtils.newDaemonSingleThreadScheduledExecutor(
       "async-request-executor-" + _remoteSessionHandle)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -291,7 +291,7 @@ class KyuubiSyncThriftClient private (
     req.setCatalogName(catalogName)
     req.setSchemaName(schemaName)
     req.setTableName(tableName)
-    val resp = withLockAcquired(GetPrimaryKeys(req))
+    val resp = withLockAcquiredAsyncRequest(GetPrimaryKeys(req))
     ThriftUtils.verifyTStatus(resp.getStatus)
     resp.getOperationHandle
   }
@@ -376,7 +376,7 @@ class KyuubiSyncThriftClient private (
     req.setSessionHandle(_remoteSessionHandle)
     req.setDelegationToken(encodedCredentials)
     try {
-      val resp = withLockAcquired(RenewDelegationToken(req))
+      val resp = withLockAcquiredAsyncRequest(RenewDelegationToken(req))
       if (resp.getStatus.getStatusCode == TStatusCode.SUCCESS_STATUS) {
         debug(s"$req succeed on engine side")
       } else {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -386,10 +386,6 @@ class KyuubiSyncThriftClient private (
       case e: Exception => warn(s"$req failed on engine side", e)
     }
   }
-
-  def isConnectionValid(): Boolean = {
-    !remoteEngineBroken && protocol.getTransport.isOpen
-  }
 }
 
 private[kyuubi] object KyuubiSyncThriftClient extends Logging {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -115,7 +115,7 @@ class KyuubiSessionImpl(
           Option(password).filter(_.nonEmpty).getOrElse("anonymous")
         }
       try {
-        _client = KyuubiSyncThriftClient.createClient(handle, user, passwd, host, port, sessionConf)
+        _client = KyuubiSyncThriftClient.createClient(user, passwd, host, port, sessionConf)
         _engineSessionHandle = _client.openSession(protocol, user, passwd, openEngineSessionConf)
       } catch {
         case e: Throwable =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -115,7 +115,7 @@ class KyuubiSessionImpl(
           Option(password).filter(_.nonEmpty).getOrElse("anonymous")
         }
       try {
-        _client = KyuubiSyncThriftClient.createClient(user, passwd, host, port, sessionConf)
+        _client = KyuubiSyncThriftClient.createClient(handle, user, passwd, host, port, sessionConf)
         _engineSessionHandle = _client.openSession(protocol, user, passwd, openEngineSessionConf)
       } catch {
         case e: Throwable =>

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -74,8 +74,10 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
       val executeStmtResp = client.ExecuteStatement(executeStmtReq)
       assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
       assert(executeStmtResp.getOperationHandle === null)
-      assert(executeStmtResp.getStatus.getErrorMessage contains
-        "Caused by: java.net.SocketException: Broken pipe (Write failed)")
+      assert(executeStmtResp.getStatus.getErrorMessage.contains(
+        "Caused by: java.net.SocketException: Broken pipe (Write failed)") ||
+        executeStmtResp.getStatus.getErrorMessage.contains(
+          "java.net.SocketException: Connection reset"))
     }
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -74,10 +74,8 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
       val executeStmtResp = client.ExecuteStatement(executeStmtReq)
       assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
       assert(executeStmtResp.getOperationHandle === null)
-      assert(executeStmtResp.getStatus.getErrorMessage.contains(
-        "Caused by: java.net.SocketException: Broken pipe (Write failed)") ||
-        executeStmtResp.getStatus.getErrorMessage.contains(
-          "java.net.SocketException: Connection reset"))
+      assert(executeStmtResp.getStatus.getErrorMessage contains
+        "Caused by: java.net.SocketException: Connection reset")
     }
   }
 
@@ -234,6 +232,8 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         val startTime = System.currentTimeMillis()
         val executeStmtResp = client.ExecuteStatement(executeStmtReq)
         assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+        assert(executeStmtResp.getStatus.getErrorMessage contains
+          "Caused by: java.net.SocketException: Connection reset")
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime > 3 * 1000 && elapsedTime < 20 * 1000)
       }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -181,17 +181,10 @@ class KyuubiOperationPerUserSuite extends WithKyuubiServer with SparkQueryTests 
         executeStmtReq.setSessionHandle(handle)
         executeStmtReq.setRunAsync(false)
         val startTime = System.currentTimeMillis()
-        try {
-          val executeStmtResp = client.ExecuteStatement(executeStmtReq)
-          assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
-          assert(executeStmtResp.getStatus.getErrorMessage.contains(
-            "java.net.SocketException: Connection reset"))
-        } catch {
-          case e: Throwable =>
-            assert(e.getMessage.contains("java.net.SocketException: Connection reset") ||
-              e.getMessage.contains("java.net.SocketException: Broken pipe"))
-        }
-
+        val executeStmtResp = client.ExecuteStatement(executeStmtReq)
+        assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+        assert(executeStmtResp.getStatus.getErrorMessage.contains(
+          "java.net.SocketException: Connection reset"))
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime < 20 * 1000)
       }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -181,10 +181,17 @@ class KyuubiOperationPerUserSuite extends WithKyuubiServer with SparkQueryTests 
         executeStmtReq.setSessionHandle(handle)
         executeStmtReq.setRunAsync(false)
         val startTime = System.currentTimeMillis()
-        val executeStmtResp = client.ExecuteStatement(executeStmtReq)
-        assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
-        assert(executeStmtResp.getStatus.getErrorMessage.contains(
-          "java.net.SocketException: Connection reset"))
+        try {
+          val executeStmtResp = client.ExecuteStatement(executeStmtReq)
+          assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+          assert(executeStmtResp.getStatus.getErrorMessage.contains(
+            "java.net.SocketException: Connection reset"))
+        } catch {
+          case e: Throwable =>
+            assert(e.getMessage.contains("java.net.SocketException: Connection reset") ||
+              e.getMessage.contains("java.net.SocketException: Broken pipe"))
+        }
+
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime < 20 * 1000)
       }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -184,6 +184,8 @@ class KyuubiOperationPerUserSuite extends WithKyuubiServer with SparkQueryTests 
         val executeStmtResp = client.ExecuteStatement(executeStmtReq)
         assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
         assert(executeStmtResp.getStatus.getErrorMessage.contains(
+          "java.net.SocketException: Connection reset") ||
+        executeStmtResp.getStatus.getErrorMessage.contains(
           "Caused by: java.net.SocketException: Broken pipe (Write failed)"))
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime < 20 * 1000)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -184,7 +184,7 @@ class KyuubiOperationPerUserSuite extends WithKyuubiServer with SparkQueryTests 
         val executeStmtResp = client.ExecuteStatement(executeStmtReq)
         assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
         assert(executeStmtResp.getStatus.getErrorMessage.contains(
-          "java.net.SocketException: Connection reset"))
+          "Caused by: java.net.SocketException: Broken pipe (Write failed)"))
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime < 20 * 1000)
       }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -183,6 +183,8 @@ class KyuubiOperationPerUserSuite extends WithKyuubiServer with SparkQueryTests 
         val startTime = System.currentTimeMillis()
         val executeStmtResp = client.ExecuteStatement(executeStmtReq)
         assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+        assert(executeStmtResp.getStatus.getErrorMessage.contains(
+          "java.net.SocketException: Connection reset"))
         val elapsedTime = System.currentTimeMillis() - startTime
         assert(elapsedTime < 20 * 1000)
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The engine request timeout was removed by #2948

We need rely on the aliveness probe to interrupt the thrift request if remote engine is broken.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
