### PR TITLE
[KYUUBI #2968] Support equal sign in JDBC URL var_key=var_value

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -50,7 +50,7 @@ public class Utils {
 
   private static final String URI_HIVE_PREFIX = "hive2:";
 
-  /** Escape base64 hive var */
+  /** Escape equal sign, pick up %3D from https://www.urldecoder.org/dec/beeline */
   private static final String ENCODE_EQUAL_SIGN = "%3D";
   private static final String EQUAL_SIGN = "=";
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -50,6 +50,10 @@ public class Utils {
 
   private static final String URI_HIVE_PREFIX = "hive2:";
 
+  /** Escape base64 hive var */
+  private static final String ENCODE_EQUAL_SIGN = "%3D";
+  private static final String EQUAL_SIGN = "=";
+
   // This value is set to true by the setServiceUnavailableRetryStrategy() when the server returns
   // 401
   static final String HIVE_SERVER2_RETRY_KEY = "hive.server2.retryserver";
@@ -259,6 +263,15 @@ public class Utils {
     throw new HiveSQLException(status);
   }
 
+  // Decode equal sing ( "=" )
+  private static String decodeEqualSign(String s) {
+    if (null == s ) {
+      return null;
+    }
+
+    return s.replaceAll(ENCODE_EQUAL_SIGN, EQUAL_SIGN);
+  }
+
   public static JdbcConnectionParams parseURL(String uri)
       throws JdbcUriParseException, SQLException, ZooKeeperHiveClientException {
     return parseURL(uri, new Properties());
@@ -342,8 +355,9 @@ public class Utils {
         if (sessVars != null) {
           Matcher sessMatcher = pattern.matcher(sessVars);
           while (sessMatcher.find()) {
-            if (connParams.getSessionVars().put(sessMatcher.group(1), sessMatcher.group(2))
-                != null) {
+            String key = decodeEqualSign(sessMatcher.group(1));
+            String value = decodeEqualSign(sessMatcher.group(2));
+            if (connParams.getSessionVars().put(key, value) != null) {
               throw new JdbcUriParseException(
                   "Bad URL format: Multiple values for property " + sessMatcher.group(1));
             }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -50,6 +50,7 @@ public class Utils {
 
   private static final String URI_HIVE_PREFIX = "hive2:";
 
+  public static final String KEY_VALUE_PATTERN = "([^;]*)=([^;]*)[;]?";
 
   /** Escape equal sign, pick up %3D from https://www.urldecoder.org/dec/beeline */
   private static final String ENCODE_EQUAL_SIGN = "%3D";
@@ -265,7 +266,7 @@ public class Utils {
   }
 
   // Decode equal sing ( "=" )
-  private static String decodeEqualSign(String s) {
+  public static String decodeEqualSign(String s) {
     if (null == s ) {
       return null;
     }
@@ -338,7 +339,7 @@ public class Utils {
     URI jdbcURI = URI.create(uri.substring(URI_JDBC_PREFIX.length()));
 
     // key=value pattern
-    Pattern pattern = Pattern.compile("([^;]*)=([^;]*)[;]?");
+    Pattern pattern = Pattern.compile(KEY_VALUE_PATTERN);
 
     // dbname and session settings
     String sessVars = jdbcURI.getPath();

--- a/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/TestJdbcDriver.java
+++ b/kyuubi-hive-jdbc/src/test/java/org/apache/kyuubi/jdbc/hive/TestJdbcDriver.java
@@ -26,6 +26,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -95,5 +98,41 @@ public class TestJdbcDriver {
         bw.close();
       }
     }
+  }
+
+  @Test
+  public void testEscapeEqualSign() throws Exception {
+    Pattern pattern = Pattern.compile(Utils.KEY_VALUE_PATTERN);
+    String sessVars = "fs.azure.account.key.pfsdpstorage.dfs.core.windows.net=BASE64123A%3D%3D";
+    Matcher sessMatcher = pattern.matcher(sessVars);
+    String key = Utils.decodeEqualSign(sessMatcher.group(1));
+    String value = Utils.decodeEqualSign(sessMatcher.group(2));
+
+    assertEquals(key, "fs.azure.account.key.pfsdpstorage.dfs.core.windows.net");
+    assertEquals(value, "BASE64123A==");
+  }
+
+  @Test
+  public void testEscapeEqualSignNormalCase() throws Exception {
+    Pattern pattern = Pattern.compile(Utils.KEY_VALUE_PATTERN);
+    String sessVars = "a=1";
+    Matcher sessMatcher = pattern.matcher(sessVars);
+    String key = Utils.decodeEqualSign(sessMatcher.group(1));
+    String value = Utils.decodeEqualSign(sessMatcher.group(2));
+
+    assertEquals(key, "a");
+    assertEquals(value, "1");
+  }
+
+  @Test
+  public void testEscapeEqualSignNegativeCase() throws Exception {
+    Pattern pattern = Pattern.compile(Utils.KEY_VALUE_PATTERN);
+    String sessVars = "";
+    Matcher sessMatcher = pattern.matcher(sessVars);
+    String key = Utils.decodeEqualSign(sessMatcher.group(1));
+    String value = Utils.decodeEqualSign(sessMatcher.group(2));
+
+    Assert.assertNull(key);
+    Assert.assertNull(value);
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  To support BASE64 key in JDBC URL. For example:

fs.azure.account.key.pfsdpstorage.dfs.core.windows.net=BASE64....%3D%3D;

-->


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
