### PR TITLE
[SUB-TASK][KPIP-4] If batch app status not found from cluster manager, fall back to metadata store

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -71,10 +71,23 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
     val batchAppStatus = batchOp.currentApplicationState.getOrElse(Map.empty)
 
     val name = Option(batchOp.batchName).getOrElse(batchAppStatus.get(APP_NAME_KEY).orNull)
-    val appId = batchAppStatus.get(APP_ID_KEY).orNull
-    val appUrl = batchAppStatus.get(APP_URL_KEY).orNull
-    val appState = batchAppStatus.get(APP_STATE_KEY).orNull
-    val appDiagnostic = batchAppStatus.get(APP_ERROR_KEY).orNull
+    var appId: String = null
+    var appUrl: String = null
+    var appState: String = null
+    var appDiagnostic: String = null
+
+    if (batchAppStatus.nonEmpty) {
+      appId = batchAppStatus.get(APP_ID_KEY).orNull
+      appUrl = batchAppStatus.get(APP_URL_KEY).orNull
+      appState = batchAppStatus.get(APP_STATE_KEY).orNull
+      appDiagnostic = batchAppStatus.get(APP_ERROR_KEY).orNull
+    } else {
+      val metadata = sessionManager.getBatchMetadata(batchOp.batchId)
+      appId = metadata.engineId
+      appUrl = metadata.engineUrl
+      appState = metadata.engineState
+      appDiagnostic = metadata.engineError.orNull
+    }
 
     new Batch(
       batchOp.batchId,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Because the kyuubi batch is not closed once the session completed(reserve the batch log for sometime).

If a batch has been finished for some time, it might can not be found from RM, which has max reserved application list limitation, for this case, we need fall back to metadata for batch info response.

Before:
<img width="1085" alt="image" src="https://user-images.githubusercontent.com/6757692/176682626-294da2bd-eb37-4b6f-95e9-052990fa2a85.png">

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
