### PR TITLE
Improve TPC-DS scan performance

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-tpcds/benchmarks/TPCDSTableGenerateBenchmark-results.txt
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/benchmarks/TPCDSTableGenerateBenchmark-results.txt
@@ -2,14 +2,14 @@ OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Mac OS X 12.4
 Apple M1 Pro
 TPCDS table generates 1000000 rows benchmark:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-catalog_returns benchmark                             13496          13836         398          0.1       13496.3       1.0X
-catalog_sales benchmark                               10084          10119          56          0.1       10084.0       1.3X
-customer benchmark                                     8900           8917          18          0.1        8900.0       1.5X
-customer_address benchmark                             5287           5295          10          0.2        5287.2       2.6X
-customer_demographics benchmark                         880            888           6          1.1         880.3      15.3X
-inventory benchmark                                     523            550          34          1.9         522.6      25.8X
-store_returns benchmark                               10853          10876          40          0.1       10852.9       1.2X
-store_sales benchmark                                  7764           7818          50          0.1        7764.0       1.7X
-web_returns benchmark                                 12840          12863          23          0.1       12839.7       1.1X
-web_sales benchmark                                   10810          10955         193          0.1       10809.6       1.2X
+catalog_returns benchmark                             13391          13544         251          0.1       13390.8       1.0X
+catalog_sales benchmark                               11690          11708          25          0.1       11690.1       1.1X
+customer benchmark                                     8527           8535           9          0.1        8526.9       1.6X
+customer_address benchmark                             5463           5474          11          0.2        5462.8       2.5X
+customer_demographics benchmark                         857            862           7          1.2         856.7      15.6X
+inventory benchmark                                     472            479           7          2.1         471.6      28.4X
+store_returns benchmark                               11655          11676          21          0.1       11655.4       1.1X
+store_sales benchmark                                  8898           9003         103          0.1        8898.5       1.5X
+web_returns benchmark                                 13377          13394          15          0.1       13377.3       1.0X
+web_sales benchmark                                   11948          11992          55          0.1       11947.7       1.1X
 

--- a/extensions/spark/kyuubi-spark-connector-tpcds/benchmarks/TPCDSTableGenerateBenchmark-results.txt
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/benchmarks/TPCDSTableGenerateBenchmark-results.txt
@@ -1,15 +1,15 @@
-Java HotSpot(TM) 64-Bit Server VM 1.8.0_311-b11 on Windows 10 10.0
-AMD64 Family 23 Model 96 Stepping 1, AuthenticAMD
+OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Mac OS X 12.4
+Apple M1 Pro
 TPCDS table generates 1000000 rows benchmark:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-catalog_returns benchmark                             13120          13143          33          0.1       13120.1       1.0X
-catalog_sales benchmark                               12008          12054          44          0.1       12008.4       1.1X
-customer benchmark                                     7499           7529          28          0.1        7499.2       1.7X
-customer_address benchmark                             4939           4958          16          0.2        4939.1       2.7X
-customer_demographics benchmark                         857            860           5          1.2         856.7      15.3X
-inventory benchmark                                     527            529           2          1.9         527.0      24.9X
-store_returns benchmark                               11643          11703          53          0.1       11643.0       1.1X
-store_sales benchmark                                  9418           9517          91          0.1        9418.2       1.4X
-web_returns benchmark                                 13560          13580          23          0.1       13559.7       1.0X
-web_sales benchmark                                   12635          12748         138          0.1       12634.9       1.0X
+catalog_returns benchmark                             13496          13836         398          0.1       13496.3       1.0X
+catalog_sales benchmark                               10084          10119          56          0.1       10084.0       1.3X
+customer benchmark                                     8900           8917          18          0.1        8900.0       1.5X
+customer_address benchmark                             5287           5295          10          0.2        5287.2       2.6X
+customer_demographics benchmark                         880            888           6          1.1         880.3      15.3X
+inventory benchmark                                     523            550          34          1.9         522.6      25.8X
+store_returns benchmark                               10853          10876          40          0.1       10852.9       1.2X
+store_sales benchmark                                  7764           7818          50          0.1        7764.0       1.7X
+web_returns benchmark                                 12840          12863          23          0.1       12839.7       1.1X
+web_sales benchmark                                   10810          10955         193          0.1       10809.6       1.2X
 

--- a/extensions/spark/kyuubi-spark-connector-tpcds/benchmarks/TPCDSTableGenerateBenchmark-results.txt
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/benchmarks/TPCDSTableGenerateBenchmark-results.txt
@@ -2,14 +2,14 @@ OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Mac OS X 12.4
 Apple M1 Pro
 TPCDS table generates 1000000 rows benchmark:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
 ----------------------------------------------------------------------------------------------------------------------------
-catalog_returns benchmark                             13391          13544         251          0.1       13390.8       1.0X
-catalog_sales benchmark                               11690          11708          25          0.1       11690.1       1.1X
-customer benchmark                                     8527           8535           9          0.1        8526.9       1.6X
-customer_address benchmark                             5463           5474          11          0.2        5462.8       2.5X
-customer_demographics benchmark                         857            862           7          1.2         856.7      15.6X
-inventory benchmark                                     472            479           7          2.1         471.6      28.4X
-store_returns benchmark                               11655          11676          21          0.1       11655.4       1.1X
-store_sales benchmark                                  8898           9003         103          0.1        8898.5       1.5X
-web_returns benchmark                                 13377          13394          15          0.1       13377.3       1.0X
-web_sales benchmark                                   11948          11992          55          0.1       11947.7       1.1X
+catalog_returns benchmark                             13644          13703          52          0.1       13643.6       1.0X
+catalog_sales benchmark                               10505          10553          43          0.1       10505.2       1.3X
+customer benchmark                                     8571           8658         124          0.1        8570.8       1.6X
+customer_address benchmark                             5230           5255          25          0.2        5229.7       2.6X
+customer_demographics benchmark                         838            844           6          1.2         837.7      16.3X
+inventory benchmark                                     475            489          13          2.1         475.3      28.7X
+store_returns benchmark                               10808          10935         163          0.1       10807.8       1.3X
+store_sales benchmark                                  7694           7723          43          0.1        7693.5       1.8X
+web_returns benchmark                                 12731          12737           6          0.1       12730.8       1.1X
+web_sales benchmark                                   10545          10584          41          0.1       10545.3       1.3X
 

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSBatchScan.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSBatchScan.scala
@@ -114,7 +114,7 @@ class TPCDSPartitionReader(
         }
         i += 1
       }
-      InternalRow(reusedRow)
+      InternalRow(reusedRow: _*)
     }
 
   private var currentRow: InternalRow = _

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSBatchScan.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSBatchScan.scala
@@ -96,9 +96,11 @@ class TPCDSPartitionReader(
     .constructResults(chuckInfo.getOnlyTableToGenerate, chuckInfo)
     .iterator.asScala
     .map { _.get(0).asScala } // the 1st row is specific table row
-    .map { row =>
-      row.zipWithIndex.map { case (v, i) =>
-        (v, schema(i).dataType) match {
+    .map { stringRow =>
+      var i = 0
+      val row = new Array[Any](stringRow.length)
+      while (i < stringRow.length) {
+        row(i) = (stringRow(i), schema(i).dataType) match {
           case (null, _) => null
           case (Options.DEFAULT_NULL_STRING, _) => null
           case (v, IntegerType) => v.toInt
@@ -110,9 +112,10 @@ class TPCDSPartitionReader(
           case (v, DecimalType()) => Decimal(v)
           case (v, dt) => throw new IllegalArgumentException(s"value: $v, type: $dt")
         }
+        i += 1
       }
+      InternalRow(row)
     }
-    .map { row => InternalRow.fromSeq(row) }
 
   private var currentRow: InternalRow = _
 

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSBatchScan.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSBatchScan.scala
@@ -92,15 +92,15 @@ class TPCDSPartitionReader(
 
   private lazy val dateFmt: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
 
+  private val reusedRow = new Array[Any](schema.length)
   private val iterator = Results
     .constructResults(chuckInfo.getOnlyTableToGenerate, chuckInfo)
     .iterator.asScala
     .map { _.get(0).asScala } // the 1st row is specific table row
     .map { stringRow =>
       var i = 0
-      val row = new Array[Any](stringRow.length)
       while (i < stringRow.length) {
-        row(i) = (stringRow(i), schema(i).dataType) match {
+        reusedRow(i) = (stringRow(i), schema(i).dataType) match {
           case (null, _) => null
           case (Options.DEFAULT_NULL_STRING, _) => null
           case (v, IntegerType) => v.toInt
@@ -114,7 +114,7 @@ class TPCDSPartitionReader(
         }
         i += 1
       }
-      InternalRow(row)
+      InternalRow(reusedRow)
     }
 
   private var currentRow: InternalRow = _


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Before
```
OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Mac OS X 12.4
Apple M1 Pro
TPCDS table generates 1000000 rows benchmark:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------
catalog_returns benchmark                             13956          13975          21          0.1       13955.7       1.0X
catalog_sales benchmark                               10229          10277          42          0.1       10229.2       1.4X
customer benchmark                                     9305           9464         249          0.1        9305.0       1.5X
customer_address benchmark                             5612           5737         162          0.2        5611.7       2.5X
customer_demographics benchmark                        1108           1182          66          0.9        1107.5      12.6X
inventory benchmark                                     665            695          27          1.5         664.7      21.0X
store_returns benchmark                               11260          11409         132          0.1       11260.1       1.2X
store_sales benchmark                                  7894           7909          15          0.1        7894.1       1.8X
web_returns benchmark                                 13042          13082          38          0.1       13042.1       1.1X
web_sales benchmark                                   11182          11201          23          0.1       11182.4       1.2X
```

After
```
OpenJDK 64-Bit Server VM 1.8.0_332-b09 on Mac OS X 12.4
Apple M1 Pro
TPCDS table generates 1000000 rows benchmark:  Best Time(ms)   Avg Time(ms)   Stdev(ms)    Rate(M/s)   Per Row(ns)   Relative
----------------------------------------------------------------------------------------------------------------------------
catalog_returns benchmark                             13644          13703          52          0.1       13643.6       1.0X
catalog_sales benchmark                               10505          10553          43          0.1       10505.2       1.3X
customer benchmark                                     8571           8658         124          0.1        8570.8       1.6X
customer_address benchmark                             5230           5255          25          0.2        5229.7       2.6X
customer_demographics benchmark                         838            844           6          1.2         837.7      16.3X
inventory benchmark                                     475            489          13          2.1         475.3      28.7X
store_returns benchmark                               10808          10935         163          0.1       10807.8       1.3X
store_sales benchmark                                  7694           7723          43          0.1        7693.5       1.8X
web_returns benchmark                                 12731          12737           6          0.1       12730.8       1.1X
web_sales benchmark                                   10545          10584          41          0.1       10545.3       1.3X
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
