### PR TITLE
Clean up JDBC shaded client pom and license

### DIFF
--- a/kyuubi-hive-jdbc-shaded/pom.xml
+++ b/kyuubi-hive-jdbc-shaded/pom.xml
@@ -26,9 +26,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <!--
-       A scala-free module in runtime scope.
-       -->
     <artifactId>kyuubi-hive-jdbc-shaded</artifactId>
     <name>Kyuubi Project Hive JDBC Shaded Client</name>
     <packaging>jar</packaging>
@@ -43,65 +40,12 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.hive</groupId>
-            <artifactId>hive-service-rpc</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-framework</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.curator</groupId>
-            <artifactId>curator-client</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>${httpclient.version}</version>
-            <optional>true</optional>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpcore</artifactId>
-            <version>${httpcore.version}</version>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.zookeeper</groupId>
-            <artifactId>zookeeper</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>jcl-over-slf4j</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
+        <!-- TODO: mark as optional once provide JAAS-based Kerberos authentication   -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-api</artifactId>
@@ -117,23 +61,17 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
-                    <minimizeJar>true</minimizeJar>
+                    <minimizeJar>false</minimizeJar>
                     <createSourcesJar>true</createSourcesJar>
                     <shadeSourcesContent>true</shadeSourcesContent>
                     <shadedArtifactAttached>false</shadedArtifactAttached>
                     <artifactSet>
                         <excludes>
                             <exclude>org.apache.hadoop:*</exclude>
-                            <exclude>org.slf4j:*</exclude>
+                            <exclude>com.google.code.findbugs:jsr305</exclude>
                         </excludes>
                     </artifactSet>
                     <filters>
-                        <filter>
-                            <artifact>org.apache.kyuubi:kyuubi-hive-jdbc</artifact>
-                            <includes>
-                                <include>**</include>
-                            </includes>
-                        </filter>
                         <filter>
                             <artifact>*:*</artifact>
                             <excludes>
@@ -147,9 +85,6 @@
                                 <exclude>LICENSE.txt</exclude>
                                 <exclude>NOTICE.txt</exclude>
                                 <exclude>mozilla/**</exclude>
-                                <exclude>hive-log4j2.properties</exclude>
-                                <exclude>parquet-logging.properties</exclude>
-                                <exclude>**/module-info.class</exclude>
                             </excludes>
                         </filter>
                     </filters>
@@ -159,8 +94,8 @@
                             <shadedPattern>${kyuubi.shade.packageName}.com.facebook</shadedPattern>
                         </relocation>
                         <relocation>
-                            <pattern>com.google.common</pattern>
-                            <shadedPattern>${kyuubi.shade.packageName}.com.google.common</shadedPattern>
+                            <pattern>com.google</pattern>
+                            <shadedPattern>${kyuubi.shade.packageName}.com.google</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>org.apache.commons.codec</pattern>
@@ -173,10 +108,6 @@
                         <relocation>
                             <pattern>org.apache.curator</pattern>
                             <shadedPattern>${kyuubi.shade.packageName}.org.apache.curator</shadedPattern>
-                        </relocation>
-                        <relocation>
-                            <pattern>org.apache.hadoop.hive</pattern>
-                            <shadedPattern>${kyuubi.shade.packageName}.org.apache.hadoop.hive</shadedPattern>
                         </relocation>
                         <relocation>
                             <pattern>org.apache.hive</pattern>

--- a/kyuubi-hive-jdbc-shaded/src/main/resources/META-INF/LICENSE
+++ b/kyuubi-hive-jdbc-shaded/src/main/resources/META-INF/LICENSE
@@ -207,20 +207,10 @@ This project bundles some components that are licensed under the
 
 Apache License Version 2.0
 --------------------------
-org.apache.hive:hive-storage-api
 org.apache.hive:hive-service-rpc
-org.apache.hive.shims:hive-shims-common
-org.apache.hive.shims:hive-shims-0.23
-org.apache.hive:hive-common
-org.apache.hive:hive-metastore
-org.apache.hive:hive-standalone-metastore
-org.apache.hive:hive-llap-client
-org.apache.hive:hive-serde
-org.apache.hive:hive-service
 com.google.guava:failureaccess
 com.google.guava:guava
 commons-codec:commons-codec
-commons-lang:commons-lang
 org.apache.commons:commons-lang3
 org.apache.curator:curator-framework
 org.apache.curator:curator-client
@@ -229,3 +219,8 @@ org.apache.httpcomponents:httpcore
 org.apache.thrift:fb303
 org.apache.thrift:libthrift
 org.apache.zookeeper:zookeeper
+
+MIT License
+-----------
+org.slf4j:slf4j-api
+org.slf4j:jcl-over-slf4j

--- a/kyuubi-hive-jdbc-shaded/src/main/resources/META-INF/NOTICE
+++ b/kyuubi-hive-jdbc-shaded/src/main/resources/META-INF/NOTICE
@@ -40,38 +40,8 @@ Copyright 2011-2017 The Apache Software Foundation
 Curator Framework
 Copyright 2011-2017 The Apache Software Foundation
 
-Hive Common
-Copyright 2022 The Apache Software Foundation
-
-Hive JDBC
-Copyright 2022 The Apache Software Foundation
-
-Hive Metastore
-Copyright 2022 The Apache Software Foundation
-
-Hive Standalone Metastore
-Copyright 2022 The Apache Software Foundation
-
-Hive Llap Client
-Copyright 2022 The Apache Software Foundation
-
-Hive Serde
-Copyright 2022 The Apache Software Foundation
-
-Hive Service
-Copyright 2022 The Apache Software Foundation
-
 Hive Service RPC
 Copyright 2022 The Apache Software Foundation
-
-Hive Shims 0.23
-Copyright 2022 The Apache Software Foundation
-
-Hive Shims Common
-Copyright 2022 The Apache Software Foundation
-
-Hive Storage API
-Copyright 2020 The Apache Software Foundation
 
 Apache HttpClient
 Copyright 1999-2020 The Apache Software Foundation

--- a/kyuubi-hive-jdbc/README.md
+++ b/kyuubi-hive-jdbc/README.md
@@ -5,4 +5,5 @@ Aiming to make a better supported client for Kyuubi and Spark
 
 - Add catalog to getTables meta function for DataLakes (DONE, broken in v1.3.0-incubating, fixed in v1.3.1-incubating)
 - Deploy to maven central (DONE, available since v1.3.0-incubating)
-- Create Shaded jar (DONE, available since v1.4.0-incubating)
+- Create shaded jar (DONE, available since v1.4.0-incubating)
+- Remove Hive dependencies (DONE, available since v1.6.0-incubating)

--- a/kyuubi-hive-jdbc/pom.xml
+++ b/kyuubi-hive-jdbc/pom.xml
@@ -68,25 +68,19 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-framework</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-client</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
@@ -97,12 +91,6 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>*</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Clean up JDBC shaded client pom and license because we removed some dependencies.

This PR also disables `minimizeJar` in JDBC shaded client, because it may cause unexpected "class not found" issues.

The current JDBC shaded client jar size is 11MB.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
