### PR TITLE
Remove unused thrift request max attempts and related ut

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -397,7 +397,6 @@ kyuubi.operation.scheduler.pool|&lt;undefined&gt;|The scheduler pool of job. Not
 kyuubi.operation.spark.listener.enabled|true|When set to true, Spark engine registers a SQLOperationListener before executing the statement, logs a few summary statistics when each stage completes.|boolean|1.6.0
 kyuubi.operation.status.polling.max.attempts|5|(deprecated) - Using kyuubi.operation.thrift.client.request.max.attempts instead|int|1.4.0
 kyuubi.operation.status.polling.timeout|PT5S|Timeout(ms) for long polling asynchronous running sql query's status|duration|1.0.0
-kyuubi.operation.thrift.client.request.max.attempts|5|Max attempts for operation thrift request call at server-side on raw transport failures, e.g. TTransportException|int|1.6.0
 
 
 ### Server

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -395,7 +395,6 @@ kyuubi.operation.query.timeout|&lt;undefined&gt;|Timeout for query executions at
 kyuubi.operation.result.max.rows|0|Max rows of Spark query results. Rows that exceeds the limit would be ignored. By setting this value to 0 to disable the max rows limit.|int|1.6.0
 kyuubi.operation.scheduler.pool|&lt;undefined&gt;|The scheduler pool of job. Note that, this config should be used after change Spark config spark.scheduler.mode=FAIR.|string|1.1.1
 kyuubi.operation.spark.listener.enabled|true|When set to true, Spark engine registers a SQLOperationListener before executing the statement, logs a few summary statistics when each stage completes.|boolean|1.6.0
-kyuubi.operation.status.polling.max.attempts|5|(deprecated) - Using kyuubi.operation.thrift.client.request.max.attempts instead|int|1.4.0
 kyuubi.operation.status.polling.timeout|PT5S|Timeout(ms) for long polling asynchronous running sql query's status|duration|1.0.0
 
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1154,14 +1154,6 @@ object KyuubiConf {
       .timeConf
       .createWithDefault(Duration.ofSeconds(5).toMillis)
 
-  @deprecated(s"using kyuubi.operation.thrift.client.request.max.attempts instead", "1.6.0")
-  val OPERATION_STATUS_POLLING_MAX_ATTEMPTS: ConfigEntry[Int] =
-    buildConf("kyuubi.operation.status.polling.max.attempts")
-      .doc(s"(deprecated) - Using kyuubi.operation.thrift.client.request.max.attempts instead")
-      .version("1.4.0")
-      .intConf
-      .createWithDefault(5)
-
   val OPERATION_FORCE_CANCEL: ConfigEntry[Boolean] =
     buildConf("kyuubi.operation.interrupt.on.cancel")
       .doc("When true, all running tasks will be interrupted if one cancels a query. " +

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1162,15 +1162,6 @@ object KyuubiConf {
       .intConf
       .createWithDefault(5)
 
-  val OPERATION_THRIFT_CLIENT_REQUEST_MAX_ATTEMPTS: ConfigEntry[Int] =
-    buildConf("kyuubi.operation.thrift.client.request.max.attempts")
-      .doc("Max attempts for operation thrift request call at server-side on raw transport" +
-        " failures, e.g. TTransportException")
-      .version("1.6.0")
-      .intConf
-      .checkValue(_ > 0, "must be positive number")
-      .createWithDefault(5)
-
   val OPERATION_FORCE_CANCEL: ConfigEntry[Boolean] =
     buildConf("kyuubi.operation.interrupt.on.cancel")
       .doc("When true, all running tasks will be interrupted if one cancels a query. " +

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -41,7 +41,6 @@ import org.apache.kyuubi.util.{ThreadUtils, ThriftUtils}
 
 class KyuubiSyncThriftClient private (
     protocol: TProtocol,
-    maxAttempts: Int,
     engineAliveProbeProtocol: Option[TProtocol],
     engineAliveProbeInterval: Long,
     engineAliveTimeout: Long)
@@ -458,7 +457,6 @@ private[kyuubi] object KyuubiSyncThriftClient extends Logging {
       conf: KyuubiConf): KyuubiSyncThriftClient = {
     val passwd = Option(password).filter(_.nonEmpty).getOrElse("anonymous")
     val loginTimeout = conf.get(ENGINE_LOGIN_TIMEOUT).toInt
-    val requestMaxAttempts = conf.get(KyuubiConf.OPERATION_THRIFT_CLIENT_REQUEST_MAX_ATTEMPTS)
     val aliveProbeEnabled = conf.get(KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED)
     val aliveProbeInterval = conf.get(KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL).toInt
     val aliveTimeout = conf.get(KyuubiConf.ENGINE_ALIVE_TIMEOUT)
@@ -473,7 +471,6 @@ private[kyuubi] object KyuubiSyncThriftClient extends Logging {
       }
     new KyuubiSyncThriftClient(
       tProtocol,
-      requestMaxAttempts,
       aliveProbeProtocol,
       aliveProbeInterval,
       aliveTimeout)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -20,16 +20,18 @@ package org.apache.kyuubi.operation
 import java.sql.SQLException
 import java.util
 import java.util.Properties
+
 import scala.collection.JavaConverters._
+
 import org.apache.hive.service.rpc.thrift._
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
 import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.SESSION_CONF_ADVISOR
 import org.apache.kyuubi.jdbc.KyuubiHiveDriver
 import org.apache.kyuubi.jdbc.hive.KyuubiConnection
 import org.apache.kyuubi.plugin.SessionConfAdvisor
-import org.apache.kyuubi.session.{KyuubiSessionImpl, KyuubiSessionManager, SessionHandle}
 
 /**
  * UT with Connection level engine shared cost much time, only run basic jdbc tests.
@@ -206,49 +208,6 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
       val kyuubiConnection = new KyuubiConnection(jdbcUrlWithConf, prop)
       intercept[SQLException](kyuubiConnection.waitLaunchEngineToComplete())
       assert(kyuubiConnection.isClosed)
-    }
-  }
-
-  test("KYUUBI #2102 #2953 - support to interrupt the thrift request if remote engine is broken") {
-    withSessionConf(Map(
-      KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED.key -> "true",
-      KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL.key -> "1000",
-      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "1000"))(Map.empty)(
-      Map.empty) {
-      withSessionHandle { (client, handle) =>
-        val preReq = new TExecuteStatementReq()
-        preReq.setStatement("select engine_name()")
-        preReq.setSessionHandle(handle)
-        preReq.setRunAsync(false)
-        client.ExecuteStatement(preReq)
-
-        val sessionHandle = SessionHandle(handle)
-        val session = server.backendService.sessionManager.asInstanceOf[KyuubiSessionManager]
-          .getSession(sessionHandle).asInstanceOf[KyuubiSessionImpl]
-        session.client.getEngineAliveProbeProtocol.foreach(_.getTransport.close())
-
-        val exitReq = new TExecuteStatementReq()
-        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 1000L)," +
-          "java_method('java.lang.System', 'exit', 1)")
-        exitReq.setSessionHandle(handle)
-        exitReq.setRunAsync(true)
-        client.ExecuteStatement(exitReq)
-
-        val executeStmtReq = new TExecuteStatementReq()
-        executeStmtReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 30000l)")
-        executeStmtReq.setSessionHandle(handle)
-        executeStmtReq.setRunAsync(false)
-        val startTime = System.currentTimeMillis()
-        val executeStmtResp = client.ExecuteStatement(executeStmtReq)
-        assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
-        assert(executeStmtResp.getStatus.getErrorMessage.contains(
-          "java.net.SocketException: Connection reset") ||
-          executeStmtResp.getStatus.getErrorMessage.contains(
-            "Caused by: java.net.SocketException: Broken pipe (Write failed)"))
-        val elapsedTime = System.currentTimeMillis() - startTime
-        assert(elapsedTime < 20 * 1000)
-        assert(session.client.asyncRequestInterrupted)
-      }
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -215,8 +215,7 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
     withSessionConf(Map(
       KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED.key -> "true",
       KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL.key -> "1000",
-      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "3000",
-      KyuubiConf.OPERATION_THRIFT_CLIENT_REQUEST_MAX_ATTEMPTS.key -> "10000"))(Map.empty)(
+      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "3000"))(Map.empty)(
       Map.empty) {
       withSessionHandle { (client, handle) =>
         val preReq = new TExecuteStatementReq()

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerConnectionSuite.scala
@@ -20,18 +20,16 @@ package org.apache.kyuubi.operation
 import java.sql.SQLException
 import java.util
 import java.util.Properties
-
 import scala.collection.JavaConverters._
-
 import org.apache.hive.service.rpc.thrift._
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
-
 import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.SESSION_CONF_ADVISOR
 import org.apache.kyuubi.jdbc.KyuubiHiveDriver
 import org.apache.kyuubi.jdbc.hive.KyuubiConnection
 import org.apache.kyuubi.plugin.SessionConfAdvisor
+import org.apache.kyuubi.session.{KyuubiSessionImpl, KyuubiSessionManager, SessionHandle}
 
 /**
  * UT with Connection level engine shared cost much time, only run basic jdbc tests.
@@ -211,11 +209,11 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
     }
   }
 
-  test("KYUUBI #2102 - support engine alive probe to fast fail on engine broken") {
+  test("KYUUBI #2102 #2953 - support to interrupt the thrift request if remote engine is broken") {
     withSessionConf(Map(
       KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED.key -> "true",
       KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL.key -> "1000",
-      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "3000"))(Map.empty)(
+      KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "1000"))(Map.empty)(
       Map.empty) {
       withSessionHandle { (client, handle) =>
         val preReq = new TExecuteStatementReq()
@@ -224,17 +222,32 @@ class KyuubiOperationPerConnectionSuite extends WithKyuubiServer with HiveJDBCTe
         preReq.setRunAsync(false)
         client.ExecuteStatement(preReq)
 
+        val sessionHandle = SessionHandle(handle)
+        val session = server.backendService.sessionManager.asInstanceOf[KyuubiSessionManager]
+          .getSession(sessionHandle).asInstanceOf[KyuubiSessionImpl]
+        session.client.getEngineAliveProbeProtocol.foreach(_.getTransport.close())
+
+        val exitReq = new TExecuteStatementReq()
+        exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 1000L)," +
+          "java_method('java.lang.System', 'exit', 1)")
+        exitReq.setSessionHandle(handle)
+        exitReq.setRunAsync(true)
+        client.ExecuteStatement(exitReq)
+
         val executeStmtReq = new TExecuteStatementReq()
-        executeStmtReq.setStatement("select java_method('java.lang.System', 'exit', 1)")
+        executeStmtReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 30000l)")
         executeStmtReq.setSessionHandle(handle)
         executeStmtReq.setRunAsync(false)
         val startTime = System.currentTimeMillis()
         val executeStmtResp = client.ExecuteStatement(executeStmtReq)
         assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
-        assert(executeStmtResp.getStatus.getErrorMessage contains
-          "Caused by: java.net.SocketException: Connection reset")
+        assert(executeStmtResp.getStatus.getErrorMessage.contains(
+          "java.net.SocketException: Connection reset") ||
+          executeStmtResp.getStatus.getErrorMessage.contains(
+            "Caused by: java.net.SocketException: Broken pipe (Write failed)"))
         val elapsedTime = System.currentTimeMillis() - startTime
-        assert(elapsedTime > 3 * 1000 && elapsedTime < 20 * 1000)
+        assert(elapsedTime < 20 * 1000)
+        assert(session.client.asyncRequestInterrupted)
       }
     }
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -161,8 +161,7 @@ class KyuubiOperationPerUserSuite extends WithKyuubiServer with SparkQueryTests 
       withSessionConf(Map(
         KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED.key -> "true",
         KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL.key -> "1000",
-        KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "3000",
-        KyuubiConf.OPERATION_THRIFT_CLIENT_REQUEST_MAX_ATTEMPTS.key -> "10000"))(Map.empty)(
+        KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "3000"))(Map.empty)(
         Map.empty) {
         withSessionHandle { (client, handle) =>
           val preReq = new TExecuteStatementReq()

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -17,12 +17,10 @@
 
 package org.apache.kyuubi.operation
 
-import org.apache.hive.service.rpc.thrift.{TExecuteStatementReq, TStatusCode}
 import org.scalatest.time.SpanSugar._
 
 import org.apache.kyuubi.{Utils, WithKyuubiServer}
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.session.{KyuubiSessionImpl, KyuubiSessionManager, SessionHandle}
 
 class KyuubiOperationPerUserSuite extends WithKyuubiServer with SparkQueryTests {
 
@@ -152,51 +150,6 @@ class KyuubiOperationPerUserSuite extends WithKyuubiServer with SparkQueryTests 
         val resultUnLimit = statement.executeQuery("select * from va")
         assert(resultUnLimit.next())
         assert(resultUnLimit.next())
-      }
-    }
-  }
-
-  test("support to interrupt the thrift request if remote engine is broken") {
-    if (!httpMode) {
-      withSessionConf(Map(
-        KyuubiConf.ENGINE_ALIVE_PROBE_ENABLED.key -> "true",
-        KyuubiConf.ENGINE_ALIVE_PROBE_INTERVAL.key -> "1000",
-        KyuubiConf.ENGINE_ALIVE_TIMEOUT.key -> "3000"))(Map.empty)(
-        Map.empty) {
-        withSessionHandle { (client, handle) =>
-          val preReq = new TExecuteStatementReq()
-          preReq.setStatement("select engine_name()")
-          preReq.setSessionHandle(handle)
-          preReq.setRunAsync(false)
-          client.ExecuteStatement(preReq)
-
-          val sessionHandle = SessionHandle(handle)
-          val session = server.backendService.sessionManager.asInstanceOf[KyuubiSessionManager]
-            .getSession(sessionHandle).asInstanceOf[KyuubiSessionImpl]
-          session.client.getEngineAliveProbeProtocol.foreach(_.getTransport.close())
-
-          val exitReq = new TExecuteStatementReq()
-          exitReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 1000L)," +
-            "java_method('java.lang.System', 'exit', 1)")
-          exitReq.setSessionHandle(handle)
-          exitReq.setRunAsync(true)
-          client.ExecuteStatement(exitReq)
-
-          val executeStmtReq = new TExecuteStatementReq()
-          executeStmtReq.setStatement("SELECT java_method('java.lang.Thread', 'sleep', 30000l)")
-          executeStmtReq.setSessionHandle(handle)
-          executeStmtReq.setRunAsync(false)
-          val startTime = System.currentTimeMillis()
-          val executeStmtResp = client.ExecuteStatement(executeStmtReq)
-          assert(executeStmtResp.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
-          assert(executeStmtResp.getStatus.getErrorMessage.contains(
-            "java.net.SocketException: Connection reset") ||
-            executeStmtResp.getStatus.getErrorMessage.contains(
-              "Caused by: java.net.SocketException: Broken pipe (Write failed)"))
-          val elapsedTime = System.currentTimeMillis() - startTime
-          assert(elapsedTime < 20 * 1000)
-          assert(session.client.asyncRequestInterrupted)
-        }
       }
     }
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
After #2948 and #2953, the OPERATION_THRIFT_CLIENT_REQUEST_MAX_ATTEMPTS is not used.

In this pr, I remove the attempts config entry and related ut that based on the request attempts.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
