### PR TITLE
Fix the kyuubi restful href link format issue

### DIFF
--- a/kyuubi-server/src/main/resources/org/apache/kyuubi/ui/static/environment.html
+++ b/kyuubi-server/src/main/resources/org/apache/kyuubi/ui/static/environment.html
@@ -39,7 +39,7 @@
 		<a class="item" href="./operations.html" ><i class="tasks icon"></i>Operations</a>
 		<a class="item" href="./metrics.html" ><i class="bars icon"></i>Metrics</a>
 		<a class="item" href="./threaddump.html" ><i class="bars icon"></i>Thread Dump</a>
-		<a class="item" href="../swagger"><i class="h square icon"></i>REST API</a>
+		<a class="item" href="../swagger/"><i class="h square icon"></i>REST API</a>
 		<a class="item" href="https://kyuubi.apache.org/docs/latest"><i class="book icon"></i>Documentation</a>
 		<a class="item server version right padded"><i class="flag icon"></i>En</a>
 	</div>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -79,10 +79,10 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
     val authenticationFactory = new KyuubiHttpAuthenticationFactory(conf)
     server.addHandler(authenticationFactory.httpHandlerWrapperFactory.wrapHandler(contextHandler))
 
-    server.addStaticHandler("org/apache/kyuubi/ui/static", "/static")
-    server.addRedirectHandler("/", "/static")
-    server.addStaticHandler("org/apache/kyuubi/ui/swagger", "/swagger")
-    server.addRedirectHandler("/docs", "/swagger")
+    server.addStaticHandler("org/apache/kyuubi/ui/static", "/static/")
+    server.addRedirectHandler("/", "/static/")
+    server.addStaticHandler("org/apache/kyuubi/ui/swagger", "/swagger/")
+    server.addRedirectHandler("/docs", "/swagger/")
   }
 
   private def startBatchChecker(): Unit = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -81,8 +81,11 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
 
     server.addStaticHandler("org/apache/kyuubi/ui/static", "/static/")
     server.addRedirectHandler("/", "/static/")
+    server.addRedirectHandler("/static", "/static/")
     server.addStaticHandler("org/apache/kyuubi/ui/swagger", "/swagger/")
     server.addRedirectHandler("/docs", "/swagger/")
+    server.addRedirectHandler("/docs/", "/swagger/")
+    server.addRedirectHandler("/swagger", "/swagger/")
   }
 
   private def startBatchChecker(): Unit = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Now the href link format is not correct, we should add `/` at the tail for `/static` and `/swagger`.
FYI:
![image](https://user-images.githubusercontent.com/6757692/177765389-368bcb5c-7a4a-4d1d-b7e7-5827695cf6b8.png)


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
