### PR TITLE
Fallback krb5 conf to OS if not configured

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -75,8 +75,6 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
           check-latest: false
-      - name: Check kinit
-        run: kinit --version
       - name: Build and test Kyuubi and Spark with maven w/o linters
         run: |
           TEST_MODULES="dev/kyuubi-codecov"

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -75,6 +75,8 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
           check-latest: false
+      - name: Check kinit
+        run: kinit --version
       - name: Build and test Kyuubi and Spark with maven w/o linters
         run: |
           TEST_MODULES="dev/kyuubi-codecov"

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KinitAuxiliaryService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KinitAuxiliaryService.scala
@@ -47,10 +47,9 @@ class KinitAuxiliaryService() extends AbstractService("KinitAuxiliaryService") {
       UserGroupInformation.loginUserFromKeytab(principal.get, keytab.get)
       val krb5Conf = Option(System.getProperty("java.security.krb5.conf"))
         .orElse(Option(System.getenv("KRB5_CONFIG")))
-        .getOrElse("/etc/krb5.conf")
       val commands = Seq("kinit", "-kt", keytab.get, principal.get)
       val kinitProc = new ProcessBuilder(commands: _*).inheritIO()
-      kinitProc.environment().put("KRB5_CONFIG", krb5Conf)
+      krb5Conf.foreach(kinitProc.environment().put("KRB5_CONFIG", _))
       kinitTask = new Runnable {
         override def run(): Unit = {
           val process = kinitProc.start()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
We should not assume that the default `krb5.conf` is located at `/etc/krb5.conf`, it OS-depended.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
