### PR TITLE
[KYUUBI #3045] Support to do admin rest request with kyuubi-adminctl

### DIFF
--- a/bin/kyuubi-adminctl
+++ b/bin/kyuubi-adminctl
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+## Kyuubi Admin Control Client Entrance
+CLASS="org.apache.kyuubi.ctl.AdminControlCli"
+
+export KYUUBI_HOME="$(cd "$(dirname "$0")"/..; pwd)"
+
+. "${KYUUBI_HOME}/bin/load-kyuubi-env.sh" -s
+
+if [[ -z ${JAVA_HOME} ]]; then
+  echo "Error: JAVA_HOME IS NOT SET! CANNOT PROCEED."
+  exit 1
+fi
+
+RUNNER="${JAVA_HOME}/bin/java"
+
+## Find the Kyuubi Jar
+if [[ -z "$KYUUBI_JAR_DIR" ]]; then
+  KYUUBI_JAR_DIR="$KYUUBI_HOME/jars"
+  if [[ ! -d ${KYUUBI_JAR_DIR} ]]; then
+  echo -e "\nCandidate Kyuubi lib $KYUUBI_JAR_DIR doesn't exist, searching development environment..."
+    KYUUBI_JAR_DIR="$KYUUBI_HOME/kyuubi-assembly/target/scala-${KYUUBI_SCALA_VERSION}/jars"
+  fi
+fi
+
+if [[ -z ${YARN_CONF_DIR} ]]; then
+  KYUUBI_CLASSPATH="${KYUUBI_JAR_DIR}/*:${KYUUBI_CONF_DIR}:${HADOOP_CONF_DIR}"
+else
+  KYUUBI_CLASSPATH="${KYUUBI_JAR_DIR}/*:${KYUUBI_CONF_DIR}:${HADOOP_CONF_DIR}:${YARN_CONF_DIR}"
+fi
+
+exec ${RUNNER} ${KYUUBI_CTL_JAVA_OPTS} -cp ${KYUUBI_CLASSPATH} $CLASS "$@"

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/AdminControlCli.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/AdminControlCli.scala
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.ctl.util.CommandLineUtils
+
+class AdminControlCli extends ControlCli {
+  override protected def parseArguments(args: Array[String]): AdminControlCliArguments = {
+    new AdminControlCliArguments(args)
+  }
+}
+
+object AdminControlCli extends CommandLineUtils with Logging {
+  override def main(args: Array[String]): Unit = {
+    val adminCtl = new AdminControlCli() { self =>
+      override protected def parseArguments(args: Array[String]): AdminControlCliArguments = {
+        new AdminControlCliArguments(args) {
+          override def info(msg: => Any): Unit = self.info(msg)
+          override def warn(msg: => Any): Unit = self.warn(msg)
+          override def error(msg: => Any): Unit = self.error(msg)
+
+          override private[kyuubi] lazy val effectSetup = new KyuubiOEffectSetup {
+            override def displayToOut(msg: String): Unit = self.info(msg)
+            override def displayToErr(msg: String): Unit = self.error(msg)
+            override def reportWarning(msg: String): Unit = self.warn(msg)
+            override def reportError(msg: String): Unit = self.error(msg)
+          }
+        }
+      }
+
+      override def info(msg: => Any): Unit = printMessage(msg)
+      override def warn(msg: => Any): Unit = printMessage(s"Warning: $msg")
+      override def error(msg: => Any): Unit = printMessage(s"Error: $msg")
+
+      override def doAction(args: Array[String]): Unit = {
+        try {
+          super.doAction(args)
+          exitFn(0)
+        } catch {
+          case e: ControlCliException => exitFn(e.exitCode)
+        }
+      }
+    }
+
+    adminCtl.doAction(args)
+  }
+}

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/AdminControlCliArguments.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/AdminControlCliArguments.scala
@@ -41,6 +41,14 @@ class AdminControlCliArguments(args: Seq[String], env: Map[String, String] = sys
   }
 
   override def toString: String = {
-    super.toString
+    cliConfig.resource match {
+      case ControlObject.CONFIG =>
+        s"""Parsed arguments:
+           |  action                  ${cliConfig.action}
+           |  resource                ${cliConfig.resource}
+           |  configType              ${cliConfig.adminConfigOpts.configType}
+        """.stripMargin
+      case _ => ""
+    }
   }
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/AdminControlCliArguments.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/AdminControlCliArguments.scala
@@ -33,9 +33,9 @@ class AdminControlCliArguments(args: Seq[String], env: Map[String, String] = sys
   override protected def getCommand(cliConfig: CliConfig): Command[_] = {
     cliConfig.action match {
       case ControlAction.REFRESH => cliConfig.resource match {
-        case ControlObject.CONFIG => new RefreshConfigCommand(cliConfig)
-        case _ => throw new KyuubiException(s"Invalid resource: ${cliConfig.resource}")
-      }
+          case ControlObject.CONFIG => new RefreshConfigCommand(cliConfig)
+          case _ => throw new KyuubiException(s"Invalid resource: ${cliConfig.resource}")
+        }
       case _ => throw new KyuubiException(s"Invalid operation: ${cliConfig.action}")
     }
   }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/AdminControlCliArguments.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/AdminControlCliArguments.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl
+
+class AdminControlCliArguments(args: Seq[String], env: Map[String, String] = sys.env)
+  extends ControlCliArguments(args, env) {}

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/CliConfig.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/CliConfig.scala
@@ -21,29 +21,27 @@ import org.apache.kyuubi.ctl.ControlObject.ControlObject
 
 private[ctl] object ControlAction extends Enumeration {
   type ControlAction = Value
-  val CREATE, GET, DELETE, LIST, LOG, SUBMIT = Value
+  val CREATE, GET, DELETE, LIST, LOG, SUBMIT, REFRESH = Value
 }
 
 private[ctl] object ControlObject extends Enumeration {
   type ControlObject = Value
-  val SERVER, ENGINE, BATCH = Value
+  val SERVER, ENGINE, BATCH, CONFIG = Value
 }
 
 case class CliConfig(
     action: ControlAction = null,
     resource: ControlObject = ControlObject.SERVER,
     commonOpts: CommonOpts = CommonOpts(),
+    zkOpts: ZookeeperOpts = ZookeeperOpts(),
     createOpts: CreateOpts = CreateOpts(),
     logOpts: LogOpts = LogOpts(),
     batchOpts: BatchOpts = BatchOpts(),
     engineOpts: EngineOpts = EngineOpts(),
+    adminConfigOpts: AdminConfigOpts = AdminConfigOpts(),
     conf: Map[String, String] = Map.empty)
 
 case class CommonOpts(
-    zkQuorum: String = null,
-    namespace: String = null,
-    host: String = null,
-    port: String = null,
     version: String = null,
     verbose: Boolean = false,
     hostUrl: String = null,
@@ -51,6 +49,12 @@ case class CommonOpts(
     username: String = null,
     password: String = null,
     spnegoHost: String = null)
+
+case class ZookeeperOpts(
+    zkQuorum: String = null,
+    namespace: String = null,
+    host: String = null,
+    port: String = null)
 
 case class CreateOpts(filename: String = null)
 
@@ -73,3 +77,5 @@ case class EngineOpts(
     engineType: String = null,
     engineSubdomain: String = null,
     engineShareLevel: String = null)
+
+case class AdminConfigOpts(configType: String = null)

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ControlCliArguments.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ControlCliArguments.scala
@@ -42,7 +42,7 @@ class ControlCliArguments(args: Seq[String], env: Map[String, String] = sys.env)
 
   override def parser(): OParser[Unit, CliConfig] = {
     val builder = OParser.builder[CliConfig]
-    CommandLine.getOptionParser(builder)
+    CommandLine.getCtlOptionParser(builder)
   }
 
   private[kyuubi] lazy val effectSetup = new KyuubiOEffectSetup
@@ -118,10 +118,10 @@ class ControlCliArguments(args: Seq[String], env: Map[String, String] = sys.env)
         s"""Parsed arguments:
            |  action                  ${cliConfig.action}
            |  resource                ${cliConfig.resource}
-           |  zkQuorum                ${cliConfig.commonOpts.zkQuorum}
-           |  namespace               ${cliConfig.commonOpts.namespace}
-           |  host                    ${cliConfig.commonOpts.host}
-           |  port                    ${cliConfig.commonOpts.port}
+           |  zkQuorum                ${cliConfig.zkOpts.zkQuorum}
+           |  namespace               ${cliConfig.zkOpts.namespace}
+           |  host                    ${cliConfig.zkOpts.host}
+           |  port                    ${cliConfig.zkOpts.port}
            |  version                 ${cliConfig.commonOpts.version}
            |  verbose                 ${cliConfig.commonOpts.verbose}
         """.stripMargin
@@ -129,11 +129,11 @@ class ControlCliArguments(args: Seq[String], env: Map[String, String] = sys.env)
         s"""Parsed arguments:
            |  action                  ${cliConfig.action}
            |  resource                ${cliConfig.resource}
-           |  zkQuorum                ${cliConfig.commonOpts.zkQuorum}
-           |  namespace               ${cliConfig.commonOpts.namespace}
+           |  zkQuorum                ${cliConfig.zkOpts.zkQuorum}
+           |  namespace               ${cliConfig.zkOpts.namespace}
            |  user                    ${cliConfig.engineOpts.user}
-           |  host                    ${cliConfig.commonOpts.host}
-           |  port                    ${cliConfig.commonOpts.port}
+           |  host                    ${cliConfig.zkOpts.host}
+           |  port                    ${cliConfig.zkOpts.port}
            |  version                 ${cliConfig.commonOpts.version}
            |  verbose                 ${cliConfig.commonOpts.verbose}
         """.stripMargin

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ControlCliArguments.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/ControlCliArguments.scala
@@ -62,7 +62,7 @@ class ControlCliArguments(args: Seq[String], env: Map[String, String] = sys.env)
     }
   }
 
-  private def getCommand(cliConfig: CliConfig): Command[_] = {
+  protected def getCommand(cliConfig: CliConfig): Command[_] = {
     cliConfig.action match {
       case ControlAction.CREATE => cliConfig.resource match {
           case ControlObject.BATCH => new CreateBatchCommand(cliConfig)

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/AdminCtlCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/AdminCtlCommand.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl.cmd
+
+import org.apache.kyuubi.ctl.AdminControlCli.printMessage
+import org.apache.kyuubi.ctl.CliConfig
+
+abstract class AdminCtlCommand[T](cliConfig: CliConfig) extends Command[T](cliConfig) {
+
+  override def info(msg: => Any): Unit = printMessage(msg)
+
+  override def warn(msg: => Any): Unit = printMessage(s"Warning: $msg")
+
+  override def error(msg: => Any): Unit = printMessage(s"Error: $msg")
+}

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/AdminCtlCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/AdminCtlCommand.scala
@@ -17,11 +17,11 @@
 
 package org.apache.kyuubi.ctl.cmd
 
-import org.apache.kyuubi.ctl.AdminControlCli.printMessage
+import org.apache.kyuubi.ctl.AdminControlCli
 import org.apache.kyuubi.ctl.CliConfig
 
 abstract class AdminCtlCommand[T](cliConfig: CliConfig) extends Command[T](cliConfig) {
-  override def info(msg: => Any): Unit = printMessage(msg)
-  override def warn(msg: => Any): Unit = printMessage(s"Warning: $msg")
-  override def error(msg: => Any): Unit = printMessage(s"Error: $msg")
+  override def info(msg: => Any): Unit = AdminControlCli.printMessage(msg)
+  override def warn(msg: => Any): Unit = AdminControlCli.printMessage(s"Warning: $msg")
+  override def error(msg: => Any): Unit = AdminControlCli.printMessage(s"Error: $msg")
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/AdminCtlCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/AdminCtlCommand.scala
@@ -21,10 +21,7 @@ import org.apache.kyuubi.ctl.AdminControlCli.printMessage
 import org.apache.kyuubi.ctl.CliConfig
 
 abstract class AdminCtlCommand[T](cliConfig: CliConfig) extends Command[T](cliConfig) {
-
   override def info(msg: => Any): Unit = printMessage(msg)
-
   override def warn(msg: => Any): Unit = printMessage(s"Warning: $msg")
-
   override def error(msg: => Any): Unit = printMessage(s"Error: $msg")
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.ctl.cmd
 import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiException, Logging}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.ctl.CliConfig
-import org.apache.kyuubi.ctl.ControlCli.printMessage
+import org.apache.kyuubi.ctl.ControlCli
 import org.apache.kyuubi.ha.HighAvailabilityConf._
 
 abstract class Command[T](cliConfig: CliConfig) extends Logging {
@@ -83,10 +83,7 @@ abstract class Command[T](cliConfig: CliConfig) extends Logging {
     arguments
   }
 
-  override def info(msg: => Any): Unit = printMessage(msg)
-
-  override def warn(msg: => Any): Unit = printMessage(s"Warning: $msg")
-
-  override def error(msg: => Any): Unit = printMessage(s"Error: $msg")
-
+  override def info(msg: => Any): Unit = ControlCli.printMessage(msg)
+  override def warn(msg: => Any): Unit = ControlCli.printMessage(s"Warning: $msg")
+  override def error(msg: => Any): Unit = ControlCli.printMessage(s"Error: $msg")
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
@@ -50,27 +50,27 @@ abstract class Command[T](cliConfig: CliConfig) extends Logging {
   def fail(msg: String): Unit = throw new KyuubiException(msg)
 
   protected def mergeArgsIntoKyuubiConf(): Unit = {
-    conf.set(HA_ADDRESSES.key, normalizedCliConfig.commonOpts.zkQuorum)
-    conf.set(HA_NAMESPACE.key, normalizedCliConfig.commonOpts.namespace)
+    conf.set(HA_ADDRESSES.key, normalizedCliConfig.zkOpts.zkQuorum)
+    conf.set(HA_NAMESPACE.key, normalizedCliConfig.zkOpts.namespace)
   }
 
   private def useDefaultPropertyValueIfMissing(): CliConfig = {
     var arguments: CliConfig = cliConfig.copy()
-    if (cliConfig.commonOpts.zkQuorum == null) {
+    if (cliConfig.zkOpts.zkQuorum == null) {
       conf.getOption(HA_ADDRESSES.key).foreach { v =>
         if (verbose) {
           super.info(s"Zookeeper quorum is not specified, use value from default conf:$v")
         }
-        arguments = arguments.copy(commonOpts = arguments.commonOpts.copy(zkQuorum = v))
+        arguments = arguments.copy(zkOpts = arguments.zkOpts.copy(zkQuorum = v))
       }
     }
 
-    if (arguments.commonOpts.namespace == null) {
-      arguments = arguments.copy(commonOpts =
-        arguments.commonOpts.copy(namespace = conf.get(HA_NAMESPACE)))
+    if (arguments.zkOpts.namespace == null) {
+      arguments = arguments.copy(zkOpts =
+        arguments.zkOpts.copy(namespace = conf.get(HA_NAMESPACE)))
       if (verbose) {
         super.info(s"Zookeeper namespace is not specified, use value from default conf:" +
-          s"${arguments.commonOpts.namespace}")
+          s"${arguments.zkOpts.namespace}")
       }
     }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/create/CreateServerCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/create/CreateServerCommand.scala
@@ -36,7 +36,7 @@ class CreateServerCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeI
 
     val defaultNamespace = conf.getOption(HA_NAMESPACE.key)
       .getOrElse(HA_NAMESPACE.defaultValStr)
-    if (defaultNamespace.equals(normalizedCliConfig.commonOpts.namespace)) {
+    if (defaultNamespace.equals(normalizedCliConfig.zkOpts.namespace)) {
       fail(
         s"""
            |Only support expose Kyuubi server instance to another domain, a different namespace
@@ -52,7 +52,7 @@ class CreateServerCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeI
   def doRun(): Seq[ServiceNodeInfo] = {
     val kyuubiConf = conf
 
-    kyuubiConf.setIfMissing(HA_ADDRESSES, normalizedCliConfig.commonOpts.zkQuorum)
+    kyuubiConf.setIfMissing(HA_ADDRESSES, normalizedCliConfig.zkOpts.zkQuorum)
     withDiscoveryClient(kyuubiConf) { discoveryClient =>
       val fromNamespace =
         DiscoveryPaths.makePath(null, kyuubiConf.get(HA_NAMESPACE))
@@ -68,7 +68,7 @@ class CreateServerCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeI
               s" from $fromNamespace to $toNamespace")
             val newNodePath = zc.createAndGetServiceNode(
               kyuubiConf,
-              normalizedCliConfig.commonOpts.namespace,
+              normalizedCliConfig.zkOpts.namespace,
               sn.instance,
               sn.version,
               true)
@@ -78,10 +78,10 @@ class CreateServerCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeI
           }
         }
 
-        if (kyuubiConf.get(HA_ADDRESSES) == normalizedCliConfig.commonOpts.zkQuorum) {
+        if (kyuubiConf.get(HA_ADDRESSES) == normalizedCliConfig.zkOpts.zkQuorum) {
           doCreate(discoveryClient)
         } else {
-          kyuubiConf.set(HA_ADDRESSES, normalizedCliConfig.commonOpts.zkQuorum)
+          kyuubiConf.set(HA_ADDRESSES, normalizedCliConfig.zkOpts.zkQuorum)
           withDiscoveryClient(kyuubiConf)(doCreate)
         }
       }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/delete/DeleteCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/delete/DeleteCommand.scala
@@ -39,7 +39,7 @@ class DeleteCommand(cliConfig: CliConfig) extends Command[Seq[ServiceNodeInfo]](
     withDiscoveryClient(conf) { discoveryClient =>
       val znodeRoot = CtlUtils.getZkNamespace(conf, normalizedCliConfig)
       val hostPortOpt =
-        Some((normalizedCliConfig.commonOpts.host, normalizedCliConfig.commonOpts.port.toInt))
+        Some((normalizedCliConfig.zkOpts.host, normalizedCliConfig.zkOpts.port.toInt))
       val nodesToDelete = CtlUtils.getServiceNodes(discoveryClient, znodeRoot, hostPortOpt)
 
       val deletedNodes = ListBuffer[ServiceNodeInfo]()

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/refresh/RefreshConfigCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/refresh/RefreshConfigCommand.scala
@@ -21,10 +21,10 @@ import org.apache.kyuubi.KyuubiException
 import org.apache.kyuubi.client.AdminRestApi
 import org.apache.kyuubi.ctl.CliConfig
 import org.apache.kyuubi.ctl.RestClientFactory.withKyuubiRestClient
-import org.apache.kyuubi.ctl.cmd.Command
+import org.apache.kyuubi.ctl.cmd.AdminCtlCommand
 import org.apache.kyuubi.ctl.util.Validator
 
-class RefreshConfigCommand(cliConfig: CliConfig) extends Command[String](cliConfig) {
+class RefreshConfigCommand(cliConfig: CliConfig) extends AdminCtlCommand[String](cliConfig) {
   def validate(): Unit = {
     Validator.validateAdminConfigType(cliConfig)
   }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/refresh/RefreshConfigCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/refresh/RefreshConfigCommand.scala
@@ -22,7 +22,7 @@ import org.apache.kyuubi.client.AdminRestApi
 import org.apache.kyuubi.ctl.CliConfig
 import org.apache.kyuubi.ctl.RestClientFactory.withKyuubiRestClient
 import org.apache.kyuubi.ctl.cmd.AdminCtlCommand
-import org.apache.kyuubi.ctl.util.Validator
+import org.apache.kyuubi.ctl.util.{Tabulator, Validator}
 
 class RefreshConfigCommand(cliConfig: CliConfig) extends AdminCtlCommand[String](cliConfig) {
   def validate(): Unit = {
@@ -40,6 +40,6 @@ class RefreshConfigCommand(cliConfig: CliConfig) extends AdminCtlCommand[String]
   }
 
   def render(resp: String): Unit = {
-    info(resp)
+    info(Tabulator.format("", Array("Response"), Array(Array(resp))))
   }
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/CtlUtils.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/CtlUtils.scala
@@ -34,7 +34,7 @@ object CtlUtils {
   private[ctl] def getZkNamespace(conf: KyuubiConf, cliConfig: CliConfig): String = {
     cliConfig.resource match {
       case ControlObject.SERVER =>
-        DiscoveryPaths.makePath(null, cliConfig.commonOpts.namespace)
+        DiscoveryPaths.makePath(null, cliConfig.zkOpts.namespace)
       case ControlObject.ENGINE =>
         val engineType = Some(cliConfig.engineOpts.engineType)
           .filter(_ != null).filter(_.nonEmpty)
@@ -48,7 +48,7 @@ object CtlUtils {
         // The path of the engine defined in zookeeper comes from
         // org.apache.kyuubi.engine.EngineRef#engineSpace
         DiscoveryPaths.makePath(
-          s"${cliConfig.commonOpts.namespace}_" +
+          s"${cliConfig.zkOpts.namespace}_" +
             s"${cliConfig.commonOpts.version}_" +
             s"${engineShareLevel}_${engineType}",
           cliConfig.engineOpts.user,
@@ -81,7 +81,7 @@ object CtlUtils {
       val znodeRoot = getZkNamespace(conf, cliConfig)
       val hostPortOpt =
         if (filterHostPort) {
-          Some((cliConfig.commonOpts.host, cliConfig.commonOpts.port.toInt))
+          Some((cliConfig.zkOpts.host, cliConfig.zkOpts.port.toInt))
         } else None
       nodes = getServiceNodes(discoveryClient, znodeRoot, hostPortOpt)
     }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Validator.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Validator.scala
@@ -72,5 +72,11 @@ private[ctl] object Validator {
     }
   }
 
+  def validateAdminConfigType(cliConfig: CliConfig): Unit = {
+    if (cliConfig.adminConfigOpts.configType == null) {
+      fail("The config type is not specified.")
+    }
+  }
+
   private def fail(msg: String): Unit = throw new KyuubiException(msg)
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Validator.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Validator.scala
@@ -27,37 +27,37 @@ import org.apache.kyuubi.ctl.CliConfig
 private[ctl] object Validator {
 
   def validateZkArguments(cliConfig: CliConfig): Unit = {
-    if (cliConfig.commonOpts.zkQuorum == null) {
+    if (cliConfig.zkOpts.zkQuorum == null) {
       fail("Zookeeper quorum is not specified and no default value to load")
     }
-    if (cliConfig.commonOpts.namespace == null) {
+    if (cliConfig.zkOpts.namespace == null) {
       fail("Zookeeper namespace is not specified and no default value to load")
     }
   }
 
   def validateHostAndPort(cliConfig: CliConfig): Unit = {
-    if (cliConfig.commonOpts.host == null) {
+    if (cliConfig.zkOpts.host == null) {
       fail("Must specify host for service")
     }
-    if (cliConfig.commonOpts.port == null) {
+    if (cliConfig.zkOpts.port == null) {
       fail("Must specify port for service")
     }
 
     try {
-      InetAddress.getByName(cliConfig.commonOpts.host)
+      InetAddress.getByName(cliConfig.zkOpts.host)
     } catch {
       case _: Exception =>
-        fail(s"Unknown host: ${cliConfig.commonOpts.host}")
+        fail(s"Unknown host: ${cliConfig.zkOpts.host}")
     }
 
     try {
-      if (cliConfig.commonOpts.port.toInt <= 0) {
+      if (cliConfig.zkOpts.port.toInt <= 0) {
         fail(s"Specified port should be a positive number")
       }
     } catch {
       case _: NumberFormatException =>
         fail(s"Specified port is not a valid integer number: " +
-          s"${cliConfig.commonOpts.port}")
+          s"${cliConfig.zkOpts.port}")
     }
   }
 

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/AdminControlCliArgumentsSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/AdminControlCliArgumentsSuite.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.ctl
+
+import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiFunSuite}
+
+class AdminControlCliArgumentsSuite extends KyuubiFunSuite with TestPrematureExit {
+
+  /** Check whether the script exits and the given search string is printed. */
+  private def testHelpExit(args: Array[String], searchString: String): Unit = {
+    val logAppender = new LogAppender("test premature exit")
+    withLogAppender(logAppender) {
+      val thread = new Thread {
+        override def run(): Unit =
+          try {
+            new AdminControlCliArguments(args) {
+              override private[kyuubi] lazy val effectSetup = new KyuubiOEffectSetup {
+                // nothing to do, to handle out stream.
+                override def terminate(exitState: Either[String, Unit]): Unit = ()
+              }
+            }
+          } catch {
+            case e: Exception =>
+              error(e)
+          }
+      }
+      thread.start()
+      thread.join()
+      assert(logAppender.loggingEvents.exists(
+        _.getMessage.getFormattedMessage.contains(searchString)))
+    }
+  }
+
+  test("test refresh config") {
+    var args = Array(
+      "refresh",
+      "server",
+      "hadoopConf")
+    testPrematureExitForAdminControlCliArgs(args, "Unknown argument 'server'")
+
+    args = Array(
+      "refresh",
+      "config",
+      "hadoopConf")
+    val opArgs = new AdminControlCliArguments(args)
+    assert(opArgs.cliConfig.action === ControlAction.REFRESH)
+    assert(opArgs.cliConfig.resource === ControlObject.CONFIG)
+    assert(opArgs.cliConfig.adminConfigOpts.configType === "hadoopConf")
+
+    args = Array(
+      "refresh",
+      "config",
+      "--hostUrl",
+      "https://kyuubi.test.com",
+      "otherConf")
+    testPrematureExitForAdminControlCli(args, "Invalid config type:otherConf")
+  }
+
+  test("test --help") {
+    // scalastyle:off
+    val helpString =
+      s"""kyuubi $KYUUBI_VERSION
+         |Usage: kyuubi-adminctl [refresh] [options]
+         |
+         |  -v, --version <value>    Using the compiled KYUUBI_VERSION default, change it if the active service is running in another.
+         |  -b, --verbose            Print additional debug output.
+         |  --hostUrl <value>        Host url for rest api.
+         |  --authSchema <value>     Auth schema for rest api, valid values are basic, spnego.
+         |  --username <value>       Username for basic authentication.
+         |  --password <value>       Password for basic authentication.
+         |  --spnegoHost <value>     Spnego host for spnego authentication.
+         |  --conf <value>           Kyuubi config property pair, formatted key=value.
+         |
+         |Command: refresh [config] <args>...
+         |	Refresh the resource.
+         |Command: refresh config [<configType>]
+         |	Refresh the config with specified type.
+         |  <configType>             The valid config type can be one of the following: hadoopConf.
+         |
+         |  -h, --help               Show help message and exit.""".stripMargin
+    // scalastyle:on
+    testHelpExit(Array("--help"), helpString)
+  }
+}

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ControlCliArgumentsSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ControlCliArgumentsSuite.scala
@@ -357,11 +357,6 @@ class ControlCliArgumentsSuite extends KyuubiFunSuite with TestPrematureExit {
       s"""kyuubi $KYUUBI_VERSION
          |Usage: kyuubi-ctl [create|get|delete|list|log|submit] [options]
          |
-         |  -zk, --zk-quorum <value>
-         |                           $zkHelpString
-         |  -n, --namespace <value>  The namespace, using kyuubi-defaults/conf if absent.
-         |  -s, --host <value>       Hostname or IP address of a service.
-         |  -p, --port <value>       Listening port of a service.
          |  -v, --version <value>    $versionHelpString
          |  -b, --verbose            Print additional debug output.
          |  --hostUrl <value>        Host url for rest api.
@@ -370,6 +365,11 @@ class ControlCliArgumentsSuite extends KyuubiFunSuite with TestPrematureExit {
          |  --password <value>       Password for basic authentication.
          |  --spnegoHost <value>     Spnego host for spnego authentication.
          |  --conf <value>           Kyuubi config property pair, formatted key=value.
+         |  -zk, --zk-quorum <value>
+         |                           $zkHelpString
+         |  -n, --namespace <value>  The namespace, using kyuubi-defaults/conf if absent.
+         |  -s, --host <value>       Hostname or IP address of a service.
+         |  -p, --port <value>       Listening port of a service.
          |
          |Command: create [batch|server] [options]
          |${"\t"}Create a resource.

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ControlCliArgumentsSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ControlCliArgumentsSuite.scala
@@ -78,10 +78,10 @@ class ControlCliArgumentsSuite extends KyuubiFunSuite with TestPrematureExit {
         val opArgs = new ControlCliArguments(args)
         assert(opArgs.cliConfig.action.toString.equalsIgnoreCase(op))
         assert(opArgs.cliConfig.resource.toString.equalsIgnoreCase(service))
-        assert(opArgs.cliConfig.commonOpts.zkQuorum == zkQuorum)
-        assert(opArgs.cliConfig.commonOpts.namespace == namespace)
-        assert(opArgs.cliConfig.commonOpts.host == host)
-        assert(opArgs.cliConfig.commonOpts.port == port)
+        assert(opArgs.cliConfig.zkOpts.zkQuorum == zkQuorum)
+        assert(opArgs.cliConfig.zkOpts.namespace == namespace)
+        assert(opArgs.cliConfig.zkOpts.host == host)
+        assert(opArgs.cliConfig.zkOpts.port == port)
         assert(opArgs.cliConfig.commonOpts.version == KYUUBI_VERSION)
         if (service == "engine") {
           assert(opArgs.cliConfig.engineOpts.user == user)
@@ -109,10 +109,10 @@ class ControlCliArgumentsSuite extends KyuubiFunSuite with TestPrematureExit {
       val opArgs = new ControlCliArguments(args)
       assert(opArgs.cliConfig.action.toString.equalsIgnoreCase(op))
       assert(opArgs.cliConfig.resource.toString.equalsIgnoreCase(service))
-      assert(opArgs.cliConfig.commonOpts.zkQuorum == zkQuorum)
-      assert(opArgs.cliConfig.commonOpts.namespace == newNamespace)
-      assert(opArgs.cliConfig.commonOpts.host == host)
-      assert(opArgs.cliConfig.commonOpts.port == port)
+      assert(opArgs.cliConfig.zkOpts.zkQuorum == zkQuorum)
+      assert(opArgs.cliConfig.zkOpts.namespace == newNamespace)
+      assert(opArgs.cliConfig.zkOpts.host == host)
+      assert(opArgs.cliConfig.zkOpts.port == port)
       assert(opArgs.cliConfig.commonOpts.version == KYUUBI_VERSION)
     }
   }
@@ -295,7 +295,7 @@ class ControlCliArgumentsSuite extends KyuubiFunSuite with TestPrematureExit {
       "--zk-quorum",
       zkQuorum)
     val opArgs = new ControlCliArguments(args)
-    assert(opArgs.cliConfig.commonOpts.namespace == namespace)
+    assert(opArgs.cliConfig.zkOpts.namespace == namespace)
     assert(opArgs.cliConfig.commonOpts.version == KYUUBI_VERSION)
   }
 
@@ -324,10 +324,10 @@ class ControlCliArgumentsSuite extends KyuubiFunSuite with TestPrematureExit {
         val opArgs = new ControlCliArguments(args)
         assert(opArgs.cliConfig.action.toString.equalsIgnoreCase(op))
         assert(opArgs.cliConfig.resource.toString.equalsIgnoreCase(service))
-        assert(opArgs.cliConfig.commonOpts.zkQuorum == zkQuorum)
-        assert(opArgs.cliConfig.commonOpts.namespace == namespace)
-        assert(opArgs.cliConfig.commonOpts.host == host)
-        assert(opArgs.cliConfig.commonOpts.port == port)
+        assert(opArgs.cliConfig.zkOpts.zkQuorum == zkQuorum)
+        assert(opArgs.cliConfig.zkOpts.namespace == namespace)
+        assert(opArgs.cliConfig.zkOpts.host == host)
+        assert(opArgs.cliConfig.zkOpts.port == port)
         assert(opArgs.cliConfig.commonOpts.version == KYUUBI_VERSION)
         if (service == "engine") {
           assert(opArgs.cliConfig.engineOpts.user == user)

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/TestPrematureExit.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/TestPrematureExit.scala
@@ -103,41 +103,8 @@ trait TestPrematureExit {
   /** Returns true if the script exits and the given search string is printed. */
   private[kyuubi] def testPrematureExitForAdminControlCli(
       input: Array[String],
-      searchString: String,
-      mainObject: CommandLineUtils = AdminControlCli): String = {
-    val printStream = new BufferPrintStream()
-    mainObject.printStream = printStream
-
-    @volatile var exitedCleanly = false
-    val original = mainObject.exitFn
-    mainObject.exitFn = (_) => exitedCleanly = true
-    try {
-      @volatile var exception: Exception = null
-      val thread = new Thread {
-        override def run() =
-          try {
-            mainObject.main(input)
-          } catch {
-            // Capture the exception to check whether the exception contains searchString or not
-            case e: Exception => exception = e
-          }
-      }
-      thread.start()
-      thread.join()
-      var joined = ""
-      if (exitedCleanly) {
-        joined = printStream.lineBuffer.mkString("\n")
-        assert(joined.contains(searchString))
-      } else {
-        assert(exception != null)
-        if (!exception.getMessage.contains(searchString)) {
-          throw exception
-        }
-      }
-      joined
-    } finally {
-      mainObject.exitFn = original
-    }
+      searchString: String): String = {
+    testPrematureExitForControlCli(input, searchString, AdminControlCli)
   }
 
   def testPrematureExitForAdminControlCliArgs(args: Array[String], searchString: String): Unit = {

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
@@ -18,22 +18,22 @@
 package org.apache.kyuubi.client;
 
 public class AdminRestApi {
-    private KyuubiRestClient client;
+  private KyuubiRestClient client;
 
-    private static final String API_BASE_PATH = "admin";
+  private static final String API_BASE_PATH = "admin";
 
-    private AdminRestApi() {}
+  private AdminRestApi() {}
 
-    public AdminRestApi(KyuubiRestClient client) {
-        this.client = client;
-    }
+  public AdminRestApi(KyuubiRestClient client) {
+    this.client = client;
+  }
 
-    public String refreshHadoopConf() {
-        String path = String.format("%s/%s", API_BASE_PATH, "refresh/hadoop_conf");
-        return this.getClient().post(path, null, client.getAuthHeader());
-    }
+  public String refreshHadoopConf() {
+    String path = String.format("%s/%s", API_BASE_PATH, "refresh/hadoop_conf");
+    return this.getClient().post(path, null, client.getAuthHeader());
+  }
 
-    private IRestClient getClient() {
-        return this.client.getHttpClient();
-    }
+  private IRestClient getClient() {
+    return this.client.getHttpClient();
+  }
 }

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/AdminRestApi.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.client;
+
+public class AdminRestApi {
+    private KyuubiRestClient client;
+
+    private static final String API_BASE_PATH = "admin";
+
+    private AdminRestApi() {}
+
+    public AdminRestApi(KyuubiRestClient client) {
+        this.client = client;
+    }
+
+    public String refreshHadoopConf() {
+        String path = String.format("%s/%s", API_BASE_PATH, "refresh/hadoop_conf");
+        return this.getClient().post(path, null, client.getAuthHeader());
+    }
+
+    private IRestClient getClient() {
+        return this.client.getHttpClient();
+    }
+}

--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RestClient.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/RestClient.java
@@ -80,8 +80,10 @@ public class RestClient implements IRestClient {
 
   @Override
   public String post(String path, String body, String authHeader) {
-    RequestBuilder postRequestBuilder =
-        RequestBuilder.post().setEntity(new StringEntity(body, StandardCharsets.UTF_8));
+    RequestBuilder postRequestBuilder = RequestBuilder.post();
+    if (body != null) {
+      postRequestBuilder.setEntity(new StringEntity(body, StandardCharsets.UTF_8));
+    }
     return doRequest(buildURI(path), authHeader, postRequestBuilder);
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/AdminResource.scala
@@ -52,6 +52,6 @@ private[v1] class AdminResource extends ApiRequestContext with Logging {
     }
     info(s"Reloading the Kyuubi server hadoop conf")
     KyuubiServer.reloadHadoopConf()
-    Response.ok().build()
+    Response.ok(s"Refresh the hadoop conf for ${fe.connectionUrl} successfully.").build()
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminCtlSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminCtlSuite.scala
@@ -37,7 +37,8 @@ class AdminCtlSuite extends RestClientTestHelper with TestPrematureExit {
 
   test("refresh config - hadoop conf") {
     val args = Array("refresh", "config", "hadoopConf")
-    testPrematureExitForAdminControlCli(args,
+    testPrematureExitForAdminControlCli(
+      args,
       s"Refresh the hadoop conf for ${fe.connectionUrl} successfully.")
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminCtlSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminCtlSuite.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.server.rest.client
+
+import org.apache.kyuubi.RestClientTestHelper
+import org.apache.kyuubi.ctl.{CtlConf, TestPrematureExit}
+
+class AdminCtlSuite extends RestClientTestHelper with TestPrematureExit {
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    System.setProperty(CtlConf.CTL_REST_CLIENT_BASE_URL.key, baseUri.toString)
+    System.setProperty(CtlConf.CTL_REST_CLIENT_SPNEGO_HOST.key, "localhost")
+    System.setProperty(CtlConf.CTL_REST_CLIENT_AUTH_SCHEMA.key, "spnego")
+  }
+
+  override def afterAll(): Unit = {
+    System.clearProperty(CtlConf.CTL_REST_CLIENT_BASE_URL.key)
+    System.clearProperty(CtlConf.CTL_REST_CLIENT_SPNEGO_HOST.key)
+    System.clearProperty(CtlConf.CTL_REST_CLIENT_AUTH_SCHEMA.key)
+    super.afterAll()
+  }
+
+  test("refresh config - hadoop conf") {
+    val args = Array("refresh", "config", "hadoopConf")
+    testPrematureExitForAdminControlCli(args,
+      s"Refresh the hadoop conf for ${fe.connectionUrl} successfully.")
+  }
+}

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminRestApiSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/AdminRestApiSuite.scala
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.server.rest.client
+
+import org.apache.kyuubi.RestClientTestHelper
+import org.apache.kyuubi.client.{AdminRestApi, KyuubiRestClient}
+
+class AdminRestApiSuite extends RestClientTestHelper {
+  test("refresh kyuubi server hadoop conf") {
+    val spnegoKyuubiRestClient: KyuubiRestClient =
+      KyuubiRestClient.builder(baseUri.toString)
+        .authHeaderMethod(KyuubiRestClient.AuthHeaderMethod.SPNEGO)
+        .spnegoHost("localhost")
+        .build()
+    val adminRestApi = new AdminRestApi(spnegoKyuubiRestClient)
+    val result = adminRestApi.refreshHadoopConf()
+    assert(result === s"Refresh the hadoop conf for ${fe.connectionUrl} successfully.")
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Close #3045 

Introduce kyuubi-adminctl for admin control.

```
Usage: kyuubi-adminctl [refresh] [options]

  -v, --version <value>    Using the compiled KYUUBI_VERSION default, change it if the active service is running in another.
  -b, --verbose            Print additional debug output.
  --hostUrl <value>        Host url for rest api.
  --authSchema <value>     Auth schema for rest api, valid values are basic, spnego.
  --username <value>       Username for basic authentication.
  --password <value>       Password for basic authentication.
  --spnegoHost <value>     Spnego host for spnego authentication.
  --conf <value>           Kyuubi config property pair, formatted key=value.

Command: refresh [config] <args>...
        Refresh the resource.
Command: refresh config [<configType>]
        Refresh the config with specified type.
  <configType>             The valid config type can be one of the following: hadoopConf.

  -h, --help               Show help message and exit.
```

Now support `kyuubi-adminctl refresh config hadoopConf` to reload hadoop conf.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
