### PR TITLE
[KYUUBI #3043][FOLLOWUP] Restore accidentally removed public APIs of kyuubi-hive-jdbc module

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcColumn.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/JdbcColumn.java
@@ -76,6 +76,26 @@ public class JdbcColumn {
     return ordinalPos;
   }
 
+  public Integer getNumPrecRadix() {
+    if (type.equalsIgnoreCase("tinyint")) {
+      return 10;
+    } else if (type.equalsIgnoreCase("smallint")) {
+      return 10;
+    } else if (type.equalsIgnoreCase("int")) {
+      return 10;
+    } else if (type.equalsIgnoreCase("bigint")) {
+      return 10;
+    } else if (type.equalsIgnoreCase("float")) {
+      return 10;
+    } else if (type.equalsIgnoreCase("double")) {
+      return 10;
+    } else if (type.equalsIgnoreCase("decimal")) {
+      return 10;
+    } else { // anything else including boolean and string is null
+      return null;
+    }
+  }
+
   static String columnClassName(TTypeId tType, JdbcColumnAttributes columnAttributes)
       throws SQLException {
     int columnType = convertTTypeIdToSqlType(tType);

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/cli/ColumnBasedSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/cli/ColumnBasedSet.java
@@ -34,7 +34,7 @@ import org.slf4j.LoggerFactory;
 public class ColumnBasedSet implements RowSet {
   public static final Logger LOG = LoggerFactory.getLogger(ColumnBasedSet.class);
 
-  private final long startOffset;
+  private long startOffset;
   private final List<ColumnBuffer> columns;
 
   public ColumnBasedSet(TRowSet tRowSet) throws TException {
@@ -65,6 +65,24 @@ public class ColumnBasedSet implements RowSet {
     startOffset = tRowSet.getStartRowOffset();
   }
 
+  private ColumnBasedSet(List<ColumnBuffer> columns, long startOffset) {
+    this.columns = columns;
+    this.startOffset = startOffset;
+  }
+
+  @Override
+  public ColumnBasedSet extractSubset(int maxRows) {
+    int numRows = Math.min(numRows(), maxRows);
+
+    List<ColumnBuffer> subset = new ArrayList<>();
+    for (ColumnBuffer column : columns) {
+      subset.add(column.extractSubset(numRows));
+    }
+    ColumnBasedSet result = new ColumnBasedSet(subset, startOffset);
+    startOffset += numRows;
+    return result;
+  }
+
   @Override
   public int numColumns() {
     return columns.size();
@@ -78,6 +96,11 @@ public class ColumnBasedSet implements RowSet {
   @Override
   public long getStartOffset() {
     return startOffset;
+  }
+
+  @Override
+  public void setStartOffset(long startOffset) {
+    this.startOffset = startOffset;
   }
 
   @Override

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/cli/RowBasedSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/cli/RowBasedSet.java
@@ -27,13 +27,27 @@ import org.apache.hive.service.rpc.thrift.TRowSet;
 /** RowBasedSet */
 public class RowBasedSet implements RowSet {
 
-  private final long startOffset;
+  private long startOffset;
 
   private final RemovableList<TRow> rows;
 
   public RowBasedSet(TRowSet tRowSet) {
     rows = new RemovableList<>(tRowSet.getRows());
     startOffset = tRowSet.getStartRowOffset();
+  }
+
+  private RowBasedSet(List<TRow> rows, long startOffset) {
+    this.rows = new RemovableList<>(rows);
+    this.startOffset = startOffset;
+  }
+
+  @Override
+  public RowBasedSet extractSubset(int maxRows) {
+    int numRows = Math.min(numRows(), maxRows);
+    RowBasedSet result = new RowBasedSet(rows.subList(0, numRows), startOffset);
+    rows.removeRange(0, numRows);
+    startOffset += numRows;
+    return result;
   }
 
   @Override
@@ -49,6 +63,15 @@ public class RowBasedSet implements RowSet {
   @Override
   public long getStartOffset() {
     return startOffset;
+  }
+
+  @Override
+  public void setStartOffset(long startOffset) {
+    this.startOffset = startOffset;
+  }
+
+  public int getSize() {
+    return rows.size();
   }
 
   @Override

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/cli/RowSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/cli/RowSet.java
@@ -19,9 +19,13 @@ package org.apache.kyuubi.jdbc.hive.cli;
 
 public interface RowSet extends Iterable<Object[]> {
 
+  RowSet extractSubset(int maxRows);
+
   int numColumns();
 
   int numRows();
 
   long getStartOffset();
+
+  void setStartOffset(long startOffset);
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The main purpose of #3043 is to remove un-referenced code and break nothing in `kyuubi-hive-jdbc` module, some data structures are shared by client and server, #3043 removed the server-specific APIs and code as well.

#3043 accidentally removed some client-side public APIs, this PR restores them.

This PR 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
