### PR TITLE
[KYUUBI #3046][Metrics] Add meter metrics for recording the rate of the operation state for each kyuubi operation

### DIFF
--- a/docs/monitor/metrics.md
+++ b/docs/monitor/metrics.md
@@ -79,7 +79,7 @@ Metrics Prefix | Metrics Suffix | Type | Since | Description
 `kyuubi.backend_service.fetch_result_rows_rate`  | | meter | 1.5.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `fetchResults` method that fetch result rows rate </div>
 `kyuubi.backend_service.get_primary_keys`  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_primary_keys` method execution time and rate </div>
 `kyuubi.backend_service.get_cross_reference`  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_cross_reference` method execution time and rate </div>
-`kyuubi.operation.state`   | `${operationType}`<br/>`.${state}`     | counter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'>  current count for the `${operationType}` with a particular `${state}`, e.g. `BatchJobSubmission.pending`</div>
+`kyuubi.operation.state` | `${operationType}`<br/>`.${state}` | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'>  The `${operationType}` with a particular `${state}` rate, e.g. `BatchJobSubmission.pending`, `BatchJobSubmission.finished`. Note that, the terminal states are cumulative, but the intermediate ones are not. </div>
 
 Before v1.5.0, if you use these metrics:
 - `kyuubi.statement.total`

--- a/docs/monitor/metrics.md
+++ b/docs/monitor/metrics.md
@@ -79,6 +79,7 @@ Metrics Prefix | Metrics Suffix | Type | Since | Description
 `kyuubi.backend_service.fetch_result_rows_rate`  | | meter | 1.5.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `fetchResults` method that fetch result rows rate </div>
 `kyuubi.backend_service.get_primary_keys`  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_primary_keys` method execution time and rate </div>
 `kyuubi.backend_service.get_cross_reference`  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_cross_reference` method execution time and rate </div>
+`kyuubi.operation.state`   | `${operationType}`<br/>`.${state}`     | counter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'>  current count for the `${operationType}` with a particular `${state}`, e.g. `BatchJobSubmission.pending`</div>
 
 Before v1.5.0, if you use these metrics:
 - `kyuubi.statement.total`
@@ -89,12 +90,3 @@ Since v1.5.0, you can use the following metrics to replace:
 - `kyuubi.operation.total.ExecuteStatement`
 - `kyuubi.operation.opened.ExecuteStatement`
 - `kyuubi.operation.failed.ExecuteStatement.${errorType}`
-
-Since v1.6.0, you can use the following metrics to get the current state counter for a specified operation type:
-- `kyuubi.operation.state.${opType}.initialized`
-- `kyuubi.operation.state.${opType}.pending`
-- `kyuubi.operation.state.${opType}.running`
-- `kyuubi.operation.state.${opType}.finished`
-- `kyuubi.operation.state.${opType}.error`
-- `kyuubi.operation.state.${opType}.canceled`
-- `kyuubi.operation.state.${opType}.closed`

--- a/docs/monitor/metrics.md
+++ b/docs/monitor/metrics.md
@@ -89,3 +89,12 @@ Since v1.5.0, you can use the following metrics to replace:
 - `kyuubi.operation.total.ExecuteStatement`
 - `kyuubi.operation.opened.ExecuteStatement`
 - `kyuubi.operation.failed.ExecuteStatement.${errorType}`
+
+Since v1.6.0, you can use the following metrics to get the current state counter for a specified operation type:
+- `kyuubi.operation.state.${opType}.initialized`
+- `kyuubi.operation.state.${opType}.pending`
+- `kyuubi.operation.state.${opType}.running`
+- `kyuubi.operation.state.${opType}.finished`
+- `kyuubi.operation.state.${opType}.error`
+- `kyuubi.operation.state.${opType}.canceled`
+- `kyuubi.operation.state.${opType}.closed`

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsSystem.scala
@@ -117,4 +117,8 @@ object MetricsSystem {
   def counterValue(name: String): Option[Long] = {
     maybeSystem.map(_.registry.counter(name).getCount)
   }
+
+  def meterValue(name: String): Option[Long] = {
+    maybeSystem.map(_.registry.meter(name).getCount)
+  }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
@@ -65,6 +65,9 @@ class JpsApplicationOperation extends ApplicationOperation {
       val (id, _) = idAndCmd.splitAt(idAndCmd.indexOf(" "))
       try {
         s"kill -15 $id".lineStream
+        if (getEngine(tag).nonEmpty) {
+          killApplicationByTag(tag)
+        }
         (true, s"Succeeded to terminate: $idAndCmd")
       } catch {
         case e: Exception =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
@@ -68,11 +68,7 @@ class JpsApplicationOperation extends ApplicationOperation {
         (true, s"Succeeded to terminate: $idAndCmd")
       } catch {
         case e: Exception =>
-          if (getEngine(tag).nonEmpty) {
-            killApplicationByTag(tag)
-          } else {
-            (false, s"Failed to terminate: $idAndCmd, due to ${e.getMessage}")
-          }
+          (false, s"Failed to terminate: $idAndCmd, due to ${e.getMessage}")
       }
     } else {
       (false, NOT_FOUND)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/JpsApplicationOperation.scala
@@ -65,13 +65,14 @@ class JpsApplicationOperation extends ApplicationOperation {
       val (id, _) = idAndCmd.splitAt(idAndCmd.indexOf(" "))
       try {
         s"kill -15 $id".lineStream
-        if (getEngine(tag).nonEmpty) {
-          killApplicationByTag(tag)
-        }
         (true, s"Succeeded to terminate: $idAndCmd")
       } catch {
         case e: Exception =>
-          (false, s"Failed to terminate: $idAndCmd, due to ${e.getMessage}")
+          if (getEngine(tag).nonEmpty) {
+            killApplicationByTag(tag)
+          } else {
+            (false, s"Failed to terminate: $idAndCmd, due to ${e.getMessage}")
+          }
       }
     } else {
       (false, NOT_FOUND)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -306,9 +306,7 @@ class BatchJobSubmission(
         case e: IOException => error(e.getMessage, e)
       }
 
-      MetricsSystem.tracing(_.decCount(
-        MetricRegistry.name(OPERATION_OPEN, statement.toLowerCase(Locale.getDefault))))
-
+      MetricsSystem.tracing(_.decCount(MetricRegistry.name(OPERATION_OPEN, opType)))
       // fast fail
       if (isTerminalState(state)) {
         killMessage = (false, s"batch $batchId is already terminal so can not kill it.")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -66,8 +66,6 @@ class BatchJobSubmission(
   extends KyuubiOperation(session) {
   import BatchJobSubmission._
 
-  override def statement: String = "BATCH_JOB_SUBMISSION"
-
   override def shouldRunAsync: Boolean = true
 
   private val _operationLog = OperationLog.createOperationLog(session, getHandle)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -38,7 +38,7 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
   MetricsSystem.tracing { ms =>
     ms.incCount(MetricRegistry.name(OPERATION_OPEN, opType))
     ms.incCount(MetricRegistry.name(OPERATION_TOTAL, opType))
-    ms.incCount(MetricRegistry.name(OPERATION_STATE, opType, state.toString.toLowerCase))
+    ms.markMeter(MetricRegistry.name(OPERATION_STATE, opType, state.toString.toLowerCase))
     ms.incCount(MetricRegistry.name(OPERATION_TOTAL))
     ms.markMeter(MetricRegistry.name(OPERATION_STATE, state.toString.toLowerCase))
   }
@@ -158,8 +158,8 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
 
   override def setState(newState: OperationState): Unit = {
     MetricsSystem.tracing { ms =>
-      ms.decCount(MetricRegistry.name(OPERATION_STATE, opType, state.toString.toLowerCase))
-      ms.incCount(MetricRegistry.name(OPERATION_STATE, opType, newState.toString.toLowerCase))
+      ms.markMeter(MetricRegistry.name(OPERATION_STATE, opType, state.toString.toLowerCase), -1)
+      ms.markMeter(MetricRegistry.name(OPERATION_STATE, opType, newState.toString.toLowerCase))
       ms.markMeter(MetricRegistry.name(OPERATION_STATE, newState.toString.toLowerCase))
     }
     super.setState(newState)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -38,6 +38,7 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
   MetricsSystem.tracing { ms =>
     ms.incCount(MetricRegistry.name(OPERATION_OPEN, opType))
     ms.incCount(MetricRegistry.name(OPERATION_TOTAL, opType))
+    ms.incCount(MetricRegistry.name(OPERATION_STATE, opType, state.toString.toLowerCase))
     ms.incCount(MetricRegistry.name(OPERATION_TOTAL))
     ms.markMeter(MetricRegistry.name(OPERATION_STATE, state.toString.toLowerCase))
   }
@@ -156,8 +157,11 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
   override def shouldRunAsync: Boolean = false
 
   override def setState(newState: OperationState): Unit = {
+    MetricsSystem.tracing { ms =>
+      ms.decCount(MetricRegistry.name(OPERATION_STATE, opType, state.toString.toLowerCase))
+      ms.incCount(MetricRegistry.name(OPERATION_STATE, opType, newState.toString.toLowerCase))
+      ms.markMeter(MetricRegistry.name(OPERATION_STATE, newState.toString.toLowerCase))
+    }
     super.setState(newState)
-    MetricsSystem.tracing(
-      _.markMeter(MetricRegistry.name(OPERATION_STATE, newState.toString.toLowerCase)))
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -623,19 +623,16 @@ class BatchesResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       getBatchJobSubmissionStateCounter(OperationState.PENDING) +
       getBatchJobSubmissionStateCounter(OperationState.RUNNING) === 1)
 
-    // to prevent flaky test with jps application manager
-    eventually(timeout(20.seconds)) {
-      val deleteResp = webTarget.path(s"api/v1/batches/${batch.getId}")
-        .request(MediaType.APPLICATION_JSON_TYPE)
-        .delete()
-      assert(200 == deleteResp.getStatus)
+    val deleteResp = webTarget.path(s"api/v1/batches/${batch.getId}")
+      .request(MediaType.APPLICATION_JSON_TYPE)
+      .delete()
+    assert(200 == deleteResp.getStatus)
 
-      assert(getBatchJobSubmissionStateCounter(OperationState.INITIALIZED) === 0)
-      assert(getBatchJobSubmissionStateCounter(OperationState.PENDING) === 0)
-      assert(getBatchJobSubmissionStateCounter(OperationState.RUNNING) === 0)
-      assert(
-        getBatchJobSubmissionStateCounter(OperationState.CANCELED) - originalCanceledCounter === 1)
-    }
+    assert(getBatchJobSubmissionStateCounter(OperationState.INITIALIZED) === 0)
+    assert(getBatchJobSubmissionStateCounter(OperationState.PENDING) === 0)
+    assert(getBatchJobSubmissionStateCounter(OperationState.RUNNING) === 0)
+    assert(
+      getBatchJobSubmissionStateCounter(OperationState.CANCELED) - originalCanceledCounter === 1)
   }
 
   private def getBatchJobSubmissionStateCounter(state: OperationState): Long = {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -638,6 +638,6 @@ class BatchesResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
   private def getBatchJobSubmissionStateCounter(state: OperationState): Long = {
     val opType = classOf[BatchJobSubmission].getSimpleName
     val counterName = s"${MetricsConstants.OPERATION_STATE}.$opType.${state.toString.toLowerCase}"
-    MetricsSystem.counterValue(counterName).getOrElse(0L)
+    MetricsSystem.meterValue(counterName).getOrElse(0L)
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -623,16 +623,19 @@ class BatchesResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       getBatchJobSubmissionStateCounter(OperationState.PENDING) +
       getBatchJobSubmissionStateCounter(OperationState.RUNNING) === 1)
 
-    val deleteResp = webTarget.path(s"api/v1/batches/${batch.getId}")
-      .request(MediaType.APPLICATION_JSON_TYPE)
-      .delete()
-    assert(200 == deleteResp.getStatus)
+    // to prevent flaky test with jps application manager
+    eventually(timeout(20.seconds)) {
+      val deleteResp = webTarget.path(s"api/v1/batches/${batch.getId}")
+        .request(MediaType.APPLICATION_JSON_TYPE)
+        .delete()
+      assert(200 == deleteResp.getStatus)
 
-    assert(getBatchJobSubmissionStateCounter(OperationState.INITIALIZED) === 0)
-    assert(getBatchJobSubmissionStateCounter(OperationState.PENDING) === 0)
-    assert(getBatchJobSubmissionStateCounter(OperationState.RUNNING) === 0)
-    assert(
-      getBatchJobSubmissionStateCounter(OperationState.CANCELED) - originalCanceledCounter === 1)
+      assert(getBatchJobSubmissionStateCounter(OperationState.INITIALIZED) === 0)
+      assert(getBatchJobSubmissionStateCounter(OperationState.PENDING) === 0)
+      assert(getBatchJobSubmissionStateCounter(OperationState.RUNNING) === 0)
+      assert(
+        getBatchJobSubmissionStateCounter(OperationState.CANCELED) - originalCanceledCounter === 1)
+    }
   }
 
   private def getBatchJobSubmissionStateCounter(state: OperationState): Long = {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Close #3046
Expose the metrics likes:

```
kyuubi.operation.state.BatchJobSubmission.pending
kyuubi.operation.state.BatchJobSubmission.running
kyuubi.operation.state.BatchJobSubmission.finished
kyuubi.operation.state.BatchJobSubmission.error
kyuubi.operation.state.BatchJobSubmission.canceled
```
So that the kyuubi service admin can know that how many BatchJobSubmission operations are pending, running and so on.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
