### PR TITLE
[KYUUBI #3131] Improve operation state change logging

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -103,16 +103,18 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
 
   protected def setState(newState: OperationState): Unit = {
     OperationState.validateTransition(state, newState)
-    var timeCost = ""
     newState match {
-      case RUNNING => startTime = System.currentTimeMillis()
+      case RUNNING =>
+        info(s"Processing ${session.user}'s query[$statementId]: " +
+          s"${state.name} -> ${newState.name}, statement:\n$redactedStatement")
+        startTime = System.currentTimeMillis()
       case ERROR | FINISHED | CANCELED | TIMEOUT =>
         completedTime = System.currentTimeMillis()
-        timeCost = s"\ntime taken: ${(completedTime - startTime) / 1000.0} seconds"
+        val timeCost = s"\ntime taken: ${(completedTime - startTime) / 1000.0} seconds"
+        info(s"Processing ${session.user}'s query[$statementId]: " +
+          s"${state.name} -> ${newState.name}$timeCost")
       case _ =>
     }
-    info(s"Processing ${session.user}'s query[$statementId]: ${state.name} -> ${newState.name}," +
-      s" statement:\n$redactedStatement$timeCost")
     state = newState
     lastAccessTime = System.currentTimeMillis()
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -108,11 +108,11 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
       case RUNNING => startTime = System.currentTimeMillis()
       case ERROR | FINISHED | CANCELED | TIMEOUT =>
         completedTime = System.currentTimeMillis()
-        timeCost = s", time taken: ${(completedTime - startTime) / 1000.0} seconds"
+        timeCost = s"\ntime taken: ${(completedTime - startTime) / 1000.0} seconds"
       case _ =>
     }
     info(s"Processing ${session.user}'s query[$statementId]: ${state.name} -> ${newState.name}," +
-      s" statement: $redactedStatement$timeCost")
+      s" statement:\n$redactedStatement$timeCost")
     state = newState
     lastAccessTime = System.currentTimeMillis()
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -110,7 +110,7 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
         startTime = System.currentTimeMillis()
       case ERROR | FINISHED | CANCELED | TIMEOUT =>
         completedTime = System.currentTimeMillis()
-        val timeCost = s"\ntime taken: ${(completedTime - startTime) / 1000.0} seconds"
+        val timeCost = s", time taken: ${(completedTime - startTime) / 1000.0} seconds"
         info(s"Processing ${session.user}'s query[$statementId]: " +
           s"${state.name} -> ${newState.name}$timeCost")
       case _ =>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
closes https://github.com/apache/incubator-kyuubi/issues/3131

- use \n to replace , in operation state change logging
- only log statement if the state is running

### _How was this patch tested?_
before:
```
2022-07-25 14:03:31.391 INFO org.apache.kyuubi.operation.ExecuteStatement: Processing anonymous's query[183ee841-16b5-4444-a53f-3e8966e6af69]: INITIALIZED_STATE -> PENDING_STATE, statement: select 1
2022-07-25 14:03:31.410 INFO org.apache.kyuubi.operation.ExecuteStatement: Processing anonymous's query[183ee841-16b5-4444-a53f-3e8966e6af69]: PENDING_STATE -> RUNNING_STATE, statement: select 1
2022-07-25 14:03:31.433 INFO org.apache.kyuubi.operation.ExecuteStatement: Processing anonymous's query[183ee841-16b5-4444-a53f-3e8966e6af69]: RUNNING_STATE -> FINISHED_STATE, statement: select 1, time taken: 0.42 seconds
2022-07-25 14:03:31.446 INFO org.apache.kyuubi.operation.ExecuteStatement: Processing anonymous's query[183ee841-16b5-4444-a53f-3e8966e6af69]: FINISHED_STATE -> CLOSED_STATE, statement: select 1
```

after:
```
2022-07-25 18:47:34.870 INFO org.apache.kyuubi.operation.ExecuteStatement: Processing anonymous's query[c6a51097-5c38-4552-8c15-4b9466916d33]: PENDING_STATE -> RUNNING_STATE, statement:
select 1
2022-07-25 18:47:35.389 INFO org.apache.kyuubi.operation.ExecuteStatement: Processing anonymous's query[c6a51097-5c38-4552-8c15-4b9466916d33]: RUNNING_STATE -> FINISHED_STATE, time taken: 0.515 seconds
```
