### PR TITLE
Remove deprecated KyuubiDriver in services manifest

### DIFF
--- a/kyuubi-hive-jdbc/src/main/resources/META-INF/services/java.sql.Driver
+++ b/kyuubi-hive-jdbc/src/main/resources/META-INF/services/java.sql.Driver
@@ -13,5 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-org.apache.kyuubi.jdbc.KyuubiDriver
 org.apache.kyuubi.jdbc.KyuubiHiveDriver


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`KyuubiDriver` has been marked deprecated and replaced by `KyuubiHiveDriver` in 1.4.0, see detail in #1147.

This PR removes the deprecated KyuubiDriver in services manifest so it would not be discovered by the service loader, users still can use this deprecated driver before removing the class itself.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
