### PR TITLE
Change etcd docker image to recover arm64 CI

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithEtcdCluster.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/WithEtcdCluster.scala
@@ -38,7 +38,10 @@ trait WithEtcdCluster extends KyuubiFunSuite {
   }
 
   override def beforeAll(): Unit = {
-    etcdCluster = new Etcd.Builder().withNodes(1).build()
+    etcdCluster = new Etcd.Builder()
+      .withImage("gcr.io/etcd-development/etcd:v3.5.4")
+      .withNodes(1)
+      .build()
     etcdCluster.start()
     super.beforeAll()
   }

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
@@ -35,7 +35,7 @@ import org.apache.kyuubi.service.ServiceState
 trait DiscoveryClientTests extends KyuubiFunSuite {
   protected val conf: KyuubiConf
 
-  protected def getConnectString(): String
+  protected def getConnectString: String
 
   test("publish instance to embedded zookeeper server") {
     val namespace = "kyuubiserver"
@@ -90,7 +90,7 @@ trait DiscoveryClientTests extends KyuubiFunSuite {
       conf
         .unset(KyuubiConf.SERVER_KEYTAB)
         .unset(KyuubiConf.SERVER_PRINCIPAL)
-        .set(HA_ADDRESSES, getConnectString())
+        .set(HA_ADDRESSES, getConnectString)
         .set(HA_NAMESPACE, namespace)
         .set(KyuubiConf.FRONTEND_THRIFT_BINARY_BIND_PORT, 0)
         .set(HA_ZK_AUTH_TYPE, AuthTypes.NONE.toString)

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
@@ -31,12 +31,15 @@ import org.apache.kyuubi.ha.client.DiscoveryClientTests
 import org.apache.kyuubi.service.NoopTBinaryFrontendServer
 
 class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
+
+  val etcdVersion = "3.5.2"
+
   private var etcdCluster: EtcdCluster = _
   var engineServer: NoopTBinaryFrontendServer = _
 
-  private lazy val _connectString = etcdCluster.clientEndpoints().asScala.mkString(",")
+  private lazy val _connectString = etcdCluster.clientEndpoints.asScala.mkString(",")
 
-  override def getConnectString(): String = _connectString
+  override def getConnectString: String = _connectString
 
   val conf: KyuubiConf = {
     KyuubiConf()
@@ -44,7 +47,10 @@ class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
   }
 
   override def beforeAll(): Unit = {
-    etcdCluster = new Etcd.Builder().withNodes(2).build()
+    etcdCluster = new Etcd.Builder()
+      .withImage(s"pachyderm/etcd:v$etcdVersion")
+      .withNodes(2)
+      .build()
     etcdCluster.start()
     super.beforeAll()
   }

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
@@ -31,8 +31,6 @@ import org.apache.kyuubi.service.NoopTBinaryFrontendServer
 
 class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
 
-  val etcdVersion = "3.5.4"
-
   private var etcdCluster: EtcdCluster = _
   var engineServer: NoopTBinaryFrontendServer = _
 
@@ -47,7 +45,7 @@ class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
 
   override def beforeAll(): Unit = {
     etcdCluster = new Etcd.Builder()
-      .withImage(s"gcr.io/etcd-development/etcd:v$etcdVersion")
+      .withImage("gcr.io/etcd-development/etcd:v3.5.4")
       .withNodes(2)
       .build()
     etcdCluster.start()

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
@@ -21,8 +21,7 @@ import java.nio.charset.StandardCharsets
 
 import scala.collection.JavaConverters._
 
-import io.etcd.jetcd.launcher.Etcd
-import io.etcd.jetcd.launcher.EtcdCluster
+import io.etcd.jetcd.launcher.{Etcd, EtcdCluster}
 
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_CLIENT_CLASS
@@ -32,7 +31,7 @@ import org.apache.kyuubi.service.NoopTBinaryFrontendServer
 
 class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
 
-  val etcdVersion = "3.5.2"
+  val etcdVersion = "3.5.4"
 
   private var etcdCluster: EtcdCluster = _
   var engineServer: NoopTBinaryFrontendServer = _
@@ -48,7 +47,7 @@ class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
 
   override def beforeAll(): Unit = {
     etcdCluster = new Etcd.Builder()
-      .withImage(s"pachyderm/etcd:v$etcdVersion")
+      .withImage(s"gcr.io/etcd-development/etcd:v$etcdVersion")
       .withNodes(2)
       .build()
     etcdCluster.start()

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClientSuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClientSuite.scala
@@ -44,7 +44,7 @@ class ZookeeperDiscoveryClientSuite extends DiscoveryClientTests with Kerberized
   val zkServer = new EmbeddedZookeeper()
   override val conf: KyuubiConf = KyuubiConf()
 
-  override def getConnectString(): String = zkServer.getConnectString
+  override def getConnectString: String = zkServer.getConnectString
 
   override def beforeAll(): Unit = {
     conf.set(ZookeeperConf.ZK_CLIENT_PORT, 0)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefWithEtcdSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefWithEtcdSuite.scala
@@ -40,7 +40,10 @@ class EngineRefWithEtcdSuite extends EngineRefTests {
   override protected def getConnectString(): String = _connectString
 
   override def beforeAll(): Unit = {
-    etcdCluster = new Etcd.Builder().withNodes(1).build()
+    etcdCluster = new Etcd.Builder()
+      .withImage("gcr.io/etcd-development/etcd:v3.5.4")
+      .withNodes(1)
+      .build()
     etcdCluster.start()
     super.beforeAll()
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The current etcd docker image supports x86 only, so travis fail consistently.

https://hub.docker.com/layers/etcd/pachyderm/etcd/v3.5.2/images/sha256-48c43c7cb17b4a997490508d0ffcc7d3300f7fbbe07b899d6df37f9671dbcb63?context=explore

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

Test passed on arm64 platform
```
➜  incubator-kyuubi git:(PR_3148) build/mvn clean install -Dtest=none -DwildcardSuites=org.apache.kyuubi.ha.client.etcd.EtcdDiscoveryClientSuite -pl :kyuubi-ha_2.12 -am
```
```
[INFO] --- scalatest-maven-plugin:2.0.2:test (test) @ kyuubi-ha_2.12 ---
Discovery starting.
Discovery completed in 1 second, 902 milliseconds.
Run starting. Expected test count is: 4
EtcdDiscoveryClientSuite:
- publish instance to embedded zookeeper server
- KYUUBI-304: Stop engine service gracefully when related zk node is deleted
- parse host and port from instance string
- etcd test: set, get and delete
Run completed in 1 minute, 7 seconds.
Total number of tests run: 4
Suites: completed 2, aborted 0
Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
```

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
