### PR TITLE
[KYUUBI #3150] Expose metadata request metrics

### DIFF
--- a/docs/monitor/metrics.md
+++ b/docs/monitor/metrics.md
@@ -82,7 +82,7 @@ Metrics Prefix | Metrics Suffix | Type | Since | Description
 `kyuubi.operation.state` | `${operationType}`<br/>`.${state}` | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'>  The `${operationType}` with a particular `${state}` rate, e.g. `BatchJobSubmission.pending`, `BatchJobSubmission.finished`. Note that, the terminal states are cumulative, but the intermediate ones are not. </div>
 `kyuubi.metadata_request.total`                  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> metadata requests time and rate </div>
 `kyuubi.metadata_request.failed`                 | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> metadata requests failure time and rate </div>
-`kyuubi.metadata_request.retrying`               | | counter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> current retrying metadata requests count </div>
+`kyuubi.metadata_request.retrying`               | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> retrying metadata requests time and rate, it is not cumulative </div>
 
 Before v1.5.0, if you use these metrics:
 - `kyuubi.statement.total`

--- a/docs/monitor/metrics.md
+++ b/docs/monitor/metrics.md
@@ -77,9 +77,12 @@ Metrics Prefix | Metrics Suffix | Type | Since | Description
 `kyuubi.backend_service.fetch_results`           | | timer | 1.5.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `fetchResults` method execution time and rate </div>
 `kyuubi.backend_service.fetch_log_rows_rate`     | | meter | 1.5.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `fetchResults` method that fetch log rows rate </div>
 `kyuubi.backend_service.fetch_result_rows_rate`  | | meter | 1.5.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `fetchResults` method that fetch result rows rate </div>
-`kyuubi.backend_service.get_primary_keys`  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_primary_keys` method execution time and rate </div>
-`kyuubi.backend_service.get_cross_reference`  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_cross_reference` method execution time and rate </div>
+`kyuubi.backend_service.get_primary_keys`        | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_primary_keys` method execution time and rate </div>
+`kyuubi.backend_service.get_cross_reference`     | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_cross_reference` method execution time and rate </div>
 `kyuubi.operation.state` | `${operationType}`<br/>`.${state}` | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'>  The `${operationType}` with a particular `${state}` rate, e.g. `BatchJobSubmission.pending`, `BatchJobSubmission.finished`. Note that, the terminal states are cumulative, but the intermediate ones are not. </div>
+`kyuubi.metadata_request.total`                  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> metadata requests time and rate </div>
+`kyuubi.metadata_request.failed`                 | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> metadata requests failure time and rate </div>
+`kyuubi.metadata_request.retrying`               | | counter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> current retrying metadata requests count </div>
 
 Before v1.5.0, if you use these metrics:
 - `kyuubi.statement.total`

--- a/docs/monitor/metrics.md
+++ b/docs/monitor/metrics.md
@@ -80,9 +80,9 @@ Metrics Prefix | Metrics Suffix | Type | Since | Description
 `kyuubi.backend_service.get_primary_keys`        | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_primary_keys` method execution time and rate </div>
 `kyuubi.backend_service.get_cross_reference`     | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> kyuubi backend service `get_cross_reference` method execution time and rate </div>
 `kyuubi.operation.state` | `${operationType}`<br/>`.${state}` | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'>  The `${operationType}` with a particular `${state}` rate, e.g. `BatchJobSubmission.pending`, `BatchJobSubmission.finished`. Note that, the terminal states are cumulative, but the intermediate ones are not. </div>
-`kyuubi.metadata_request.total`                  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> metadata requests time and rate </div>
-`kyuubi.metadata_request.failed`                 | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> metadata requests failure time and rate </div>
-`kyuubi.metadata_request.retrying`               | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> retrying metadata requests time and rate, it is not cumulative </div>
+`kyuubi.metadata.request.total`                  | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> metadata requests time and rate </div>
+`kyuubi.metadata.request.failed`                 | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> metadata requests failure time and rate </div>
+`kyuubi.metadata.request.retrying`               | | meter | 1.6.0 |<div style='width: 150pt;word-wrap: break-word;white-space: normal'> retrying metadata requests time and rate, it is not cumulative </div>
 
 Before v1.5.0, if you use these metrics:
 - `kyuubi.statement.total`

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
@@ -76,6 +76,6 @@ object MetricsConstants {
 
   final private val METADATA_REQUEST = KYUUBI + "metadata_request."
   final val METADATA_REQUEST_TOTAL = METADATA_REQUEST + "total"
-  final val METADATA_REQUEST_RETRYING = METADATA_REQUEST + "retrying"
   final val METADATA_REQUEST_FAIL = METADATA_REQUEST + "failed"
+  final val METADATA_REQUEST_RETRYING = METADATA_REQUEST + "retrying"
 }

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
@@ -74,4 +74,8 @@ object MetricsConstants {
   final val BS_GET_RESULT_SET_METADATA = BACKEND_SERVICE + "get_result_set_metadata"
   final val BS_FETCH_RESULTS = BACKEND_SERVICE + "fetch_results"
 
+  final private val METADATA_REQUEST = KYUUBI + "metadata_request."
+  final val METADATA_REQUEST_TOTAL = METADATA_REQUEST + "total"
+  final val METADATA_REQUEST_RETRYING = METADATA_REQUEST + "retrying"
+  final val METADATA_REQUEST_FAIL = METADATA_REQUEST + "failed"
 }

--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConstants.scala
@@ -74,7 +74,7 @@ object MetricsConstants {
   final val BS_GET_RESULT_SET_METADATA = BACKEND_SERVICE + "get_result_set_metadata"
   final val BS_FETCH_RESULTS = BACKEND_SERVICE + "fetch_results"
 
-  final private val METADATA_REQUEST = KYUUBI + "metadata_request."
+  final private val METADATA_REQUEST = KYUUBI + "metadata.request."
   final val METADATA_REQUEST_TOTAL = METADATA_REQUEST + "total"
   final val METADATA_REQUEST_FAIL = METADATA_REQUEST + "failed"
   final val METADATA_REQUEST_RETRYING = METADATA_REQUEST + "retrying"

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -204,7 +204,7 @@ class MetadataManager extends AbstractService("MetadataManager") {
       })
     ref.addRetryingMetadataRequest(request)
     identifierRequestsRetryRefs.putIfAbsent(identifier, ref)
-    MetricsSystem.tracing(_.markMeter(MetricsConstants.METADATA_REQUEST_RETRYING))
+    MetricsSystem.tracing(_.incCount(MetricsConstants.METADATA_REQUEST_RETRYING))
   }
 
   def getMetadataRequestsRetryRef(identifier: String): MetadataRequestsRetryRef = {
@@ -245,9 +245,7 @@ class MetadataManager extends AbstractService("MetadataManager") {
                         case _ =>
                       }
                       ref.metadataRequests.remove(request)
-                      MetricsSystem.tracing(_.markMeter(
-                        MetricsConstants.METADATA_REQUEST_RETRYING,
-                        -1L))
+                      MetricsSystem.tracing(_.decCount(MetricsConstants.METADATA_REQUEST_RETRYING))
                       request = ref.metadataRequests.peek()
                     }
                   } catch {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -204,7 +204,7 @@ class MetadataManager extends AbstractService("MetadataManager") {
       })
     ref.addRetryingMetadataRequest(request)
     identifierRequestsRetryRefs.putIfAbsent(identifier, ref)
-    MetricsSystem.tracing(_.incCount(MetricsConstants.METADATA_REQUEST_RETRYING))
+    MetricsSystem.tracing(_.markMeter(MetricsConstants.METADATA_REQUEST_RETRYING))
   }
 
   def getMetadataRequestsRetryRef(identifier: String): MetadataRequestsRetryRef = {
@@ -245,7 +245,9 @@ class MetadataManager extends AbstractService("MetadataManager") {
                         case _ =>
                       }
                       ref.metadataRequests.remove(request)
-                      MetricsSystem.tracing(_.decCount(MetricsConstants.METADATA_REQUEST_RETRYING))
+                      MetricsSystem.tracing(_.markMeter(
+                        MetricsConstants.METADATA_REQUEST_RETRYING,
+                        -1L))
                       request = ref.metadataRequests.peek()
                     }
                   } catch {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -24,6 +24,7 @@ import org.apache.kyuubi.{KyuubiException, Logging}
 import org.apache.kyuubi.client.api.v1.dto.Batch
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.METADATA_MAX_AGE
+import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.OperationState
 import org.apache.kyuubi.server.metadata.api.{Metadata, MetadataFilter}
 import org.apache.kyuubi.service.AbstractService
@@ -76,9 +77,21 @@ class MetadataManager extends AbstractService("MetadataManager") {
     super.stop()
   }
 
+  private def withMetadataRequestMetrics[T](block: => T): T = {
+    try {
+      block
+    } catch {
+      case e: Throwable =>
+        MetricsSystem.tracing(_.markMeter(MetricsConstants.METADATA_REQUEST_FAIL))
+        throw e
+    } finally {
+      MetricsSystem.tracing(_.markMeter(MetricsConstants.METADATA_REQUEST_TOTAL))
+    }
+  }
+
   def insertMetadata(metadata: Metadata, retryOnError: Boolean = true): Unit = {
     try {
-      _metadataStore.insertMetadata(metadata)
+      withMetadataRequestMetrics(_metadataStore.insertMetadata(metadata))
     } catch {
       case e: Throwable if retryOnError =>
         error(s"Error inserting metadata for session ${metadata.identifier}", e)
@@ -91,7 +104,7 @@ class MetadataManager extends AbstractService("MetadataManager") {
   }
 
   def getBatchSessionMetadata(batchId: String): Metadata = {
-    Option(_metadataStore.getMetadata(batchId, true)).filter(
+    Option(withMetadataRequestMetrics(_metadataStore.getMetadata(batchId, true))).filter(
       _.sessionType == SessionType.BATCH).orNull
   }
 
@@ -110,7 +123,8 @@ class MetadataManager extends AbstractService("MetadataManager") {
       state = batchState,
       createTime = createTime,
       endTime = endTime)
-    _metadataStore.getMetadataList(filter, from, size, true).map(buildBatch)
+    withMetadataRequestMetrics(_metadataStore.getMetadataList(filter, from, size, true)).map(
+      buildBatch)
   }
 
   def getBatchesRecoveryMetadata(
@@ -122,7 +136,7 @@ class MetadataManager extends AbstractService("MetadataManager") {
       sessionType = SessionType.BATCH,
       state = state,
       kyuubiInstance = kyuubiInstance)
-    _metadataStore.getMetadataList(filter, from, size, false)
+    withMetadataRequestMetrics(_metadataStore.getMetadataList(filter, from, size, false))
   }
 
   def getPeerInstanceClosedBatchesMetadata(
@@ -135,12 +149,12 @@ class MetadataManager extends AbstractService("MetadataManager") {
       state = state,
       kyuubiInstance = kyuubiInstance,
       peerInstanceClosed = true)
-    _metadataStore.getMetadataList(filter, from, size, true)
+    withMetadataRequestMetrics(_metadataStore.getMetadataList(filter, from, size, true))
   }
 
   def updateMetadata(metadata: Metadata, retryOnError: Boolean = true): Unit = {
     try {
-      _metadataStore.updateMetadata(metadata)
+      withMetadataRequestMetrics(_metadataStore.updateMetadata(metadata))
     } catch {
       case e: Throwable if retryOnError =>
         error(s"Error updating metadata for session ${metadata.identifier}", e)
@@ -149,7 +163,7 @@ class MetadataManager extends AbstractService("MetadataManager") {
   }
 
   def cleanupMetadataById(batchId: String): Unit = {
-    _metadataStore.cleanupMetadataByIdentifier(batchId)
+    withMetadataRequestMetrics(_metadataStore.cleanupMetadataByIdentifier(batchId))
   }
 
   private def startMetadataCleaner(): Unit = {
@@ -160,7 +174,7 @@ class MetadataManager extends AbstractService("MetadataManager") {
       val interval = conf.get(KyuubiConf.METADATA_CLEANER_INTERVAL)
       val cleanerTask: Runnable = () => {
         try {
-          _metadataStore.cleanupMetadataByAge(stateMaxAge)
+          withMetadataRequestMetrics(_metadataStore.cleanupMetadataByAge(stateMaxAge))
         } catch {
           case e: Throwable => error("Error cleaning up the metadata by age", e)
         }
@@ -190,6 +204,7 @@ class MetadataManager extends AbstractService("MetadataManager") {
       })
     ref.addRetryingMetadataRequest(request)
     identifierRequestsRetryRefs.putIfAbsent(identifier, ref)
+    MetricsSystem.tracing(_.markMeter(MetricsConstants.METADATA_REQUEST_RETRYING))
   }
 
   def getMetadataRequestsRetryRef(identifier: String): MetadataRequestsRetryRef = {
@@ -230,6 +245,9 @@ class MetadataManager extends AbstractService("MetadataManager") {
                         case _ =>
                       }
                       ref.metadataRequests.remove(request)
+                      MetricsSystem.tracing(_.markMeter(
+                        MetricsConstants.METADATA_REQUEST_RETRYING,
+                        -1L))
                       request = ref.metadataRequests.peek()
                     }
                   } catch {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
@@ -104,7 +104,7 @@ class MetadataManagerSuite extends KyuubiFunSuite {
     val failedRequests =
       MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_FAIL).getOrElse(0L)
     val retryingRequests =
-      MetricsSystem.counterValue(MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L)
+      MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L)
 
     val metadata = Metadata(
       identifier = UUID.randomUUID().toString,
@@ -130,7 +130,7 @@ class MetadataManagerSuite extends KyuubiFunSuite {
     assert(
       MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_FAIL).getOrElse(
         0L) - failedRequests === 0)
-    assert(MetricsSystem.counterValue(
+    assert(MetricsSystem.meterValue(
       MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L) - retryingRequests === 0)
 
     val invalidMetadata = metadata.copy(kyuubiInstance = null)
@@ -141,7 +141,7 @@ class MetadataManagerSuite extends KyuubiFunSuite {
     assert(
       MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_FAIL).getOrElse(
         0L) - failedRequests === 1)
-    assert(MetricsSystem.counterValue(
+    assert(MetricsSystem.meterValue(
       MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L) - retryingRequests === 0)
 
     metadataManager.insertMetadata(invalidMetadata, true)
@@ -152,7 +152,7 @@ class MetadataManagerSuite extends KyuubiFunSuite {
     assert(
       MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_FAIL).getOrElse(
         0L) - failedRequests === 2)
-    assert(MetricsSystem.counterValue(
+    assert(MetricsSystem.meterValue(
       MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L) - retryingRequests === 1)
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
@@ -104,7 +104,7 @@ class MetadataManagerSuite extends KyuubiFunSuite {
     val failedRequests =
       MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_FAIL).getOrElse(0L)
     val retryingRequests =
-      MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L)
+      MetricsSystem.counterValue(MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L)
 
     val metadata = Metadata(
       identifier = UUID.randomUUID().toString,
@@ -130,7 +130,7 @@ class MetadataManagerSuite extends KyuubiFunSuite {
     assert(
       MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_FAIL).getOrElse(
         0L) - failedRequests === 0)
-    assert(MetricsSystem.meterValue(
+    assert(MetricsSystem.counterValue(
       MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L) - retryingRequests === 0)
 
     val invalidMetadata = metadata.copy(kyuubiInstance = null)
@@ -141,7 +141,7 @@ class MetadataManagerSuite extends KyuubiFunSuite {
     assert(
       MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_FAIL).getOrElse(
         0L) - failedRequests === 1)
-    assert(MetricsSystem.meterValue(
+    assert(MetricsSystem.counterValue(
       MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L) - retryingRequests === 0)
 
     metadataManager.insertMetadata(invalidMetadata, true)
@@ -152,7 +152,7 @@ class MetadataManagerSuite extends KyuubiFunSuite {
     assert(
       MetricsSystem.meterValue(MetricsConstants.METADATA_REQUEST_FAIL).getOrElse(
         0L) - failedRequests === 2)
-    assert(MetricsSystem.meterValue(
+    assert(MetricsSystem.counterValue(
       MetricsConstants.METADATA_REQUEST_RETRYING).getOrElse(0L) - retryingRequests === 1)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

close #3150

Expose the metadata store requests metrics:

```
kyuubi.metadata_request.total
kyuubi.metadata_request.failed
kyuubi.metadata_request.retrying
```
`total` and `failed` are cumulative, `retrying` is not.


If there are still some retrying metadata requests, we shall not restart the kyuubi server, otherwise, some metadata requests will lose.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
