### PR TITLE
Introduce JDBC parameters to control connection timeout

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -124,12 +124,12 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   }
 
   public KyuubiConnection(String uri, Properties info) throws SQLException {
+    isBeeLineMode = Boolean.parseBoolean(info.getProperty(BEELINE_MODE_PROPERTY));
     try {
       connParams = Utils.parseURL(uri, info);
     } catch (ZooKeeperHiveClientException e) {
       throw new KyuubiSQLException(e);
     }
-    isBeeLineMode = Boolean.parseBoolean(info.getProperty(BEELINE_MODE_PROPERTY));
     jdbcUriString = connParams.getJdbcUriString();
     // JDBC URL: jdbc:hive2://<host>:<port>/dbName;sess_var_list?hive_conf_list#hive_var_list
     // each list: <key1>=<val1>;<key2>=<val2> and so on
@@ -139,6 +139,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     host = Utils.getCanonicalHostName(connParams.getHost());
     port = connParams.getPort();
     sessConfMap = connParams.getSessionVars();
+
     setupTimeout();
 
     if (sessConfMap.containsKey(FETCH_SIZE)) {
@@ -154,17 +155,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     }
 
     // add supported protocols
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V1);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V2);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V3);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V4);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V5);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V6);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V7);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V8);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V9);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V10);
-    supportedProtocols.add(TProtocolVersion.HIVE_CLI_SERVICE_PROTOCOL_V11);
+    Collections.addAll(supportedProtocols, TProtocolVersion.values());
 
     int maxRetries = 1;
     try {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -859,12 +859,12 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
 
   private void setupTimeout() {
     if (sessConfMap.containsKey(CONNECT_TIMEOUT)) {
-      String loginTimeoutStr = sessConfMap.get(CONNECT_TIMEOUT);
+      String connectTimeoutStr = sessConfMap.get(CONNECT_TIMEOUT);
       try {
-        long connectTimeoutMs = Long.parseLong(loginTimeoutStr);
+        long connectTimeoutMs = Long.parseLong(connectTimeoutStr);
         connectTimeout = (int) Math.max(0, Math.min(connectTimeoutMs, Integer.MAX_VALUE));
       } catch (NumberFormatException e) {
-        LOG.info("Failed to parse connectTimeout of value " + loginTimeoutStr);
+        LOG.info("Failed to parse connectTimeout of value " + connectTimeoutStr);
       }
     }
     if (sessConfMap.containsKey(SOCKET_TIMEOUT)) {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -126,6 +126,9 @@ public class Utils {
     // Cookie prefix
     static final String HTTP_COOKIE_PREFIX = "http.cookie.";
 
+    static final String CONNECT_TIMEOUT = "connectTimeout";
+    static final String SOCKET_TIMEOUT = "socketTimeout";
+
     // We support ways to specify application name modeled after some existing DBs, since
     // there's no standard approach.
     // MSSQL: applicationName

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/ThriftUtils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/ThriftUtils.java
@@ -29,19 +29,26 @@ import org.apache.thrift.transport.TTransportException;
  * given configuration as well as helps with authenticating requests.
  */
 public class ThriftUtils {
-  public static TTransport getSocketTransport(String host, int port, int loginTimeout) {
-    return new TSocket(host, port, loginTimeout);
+  public static TTransport getSocketTransport(
+      String host, int port, int connectTimeout, int socketTimeout) {
+    return new TSocket(host, port, socketTimeout, connectTimeout);
   }
 
-  public static TTransport getSSLSocket(String host, int port, int loginTimeout)
-      throws TTransportException {
+  public static TTransport getSSLSocket(
+      String host, int port, int connectTimeout, int socketTimeout) throws TTransportException {
     // The underlying SSLSocket object is bound to host:port with the given SO_TIMEOUT
-    TSocket tSSLSocket = TSSLTransportFactory.getClientSocket(host, port, loginTimeout);
+    TSocket tSSLSocket = TSSLTransportFactory.getClientSocket(host, port, socketTimeout);
+    tSSLSocket.setConnectTimeout(connectTimeout);
     return getSSLSocketWithHttps(tSSLSocket);
   }
 
   public static TTransport getSSLSocket(
-      String host, int port, int loginTimeout, String trustStorePath, String trustStorePassWord)
+      String host,
+      int port,
+      int connectTimeout,
+      int socketTimeout,
+      String trustStorePath,
+      String trustStorePassWord)
       throws TTransportException {
     TSSLTransportFactory.TSSLTransportParameters params =
         new TSSLTransportFactory.TSSLTransportParameters();
@@ -49,7 +56,8 @@ public class ThriftUtils {
     params.requireClientAuth(true);
     // The underlying SSLSocket object is bound to host:port with the given SO_TIMEOUT and
     // SSLContext created with the given params
-    TSocket tSSLSocket = TSSLTransportFactory.getClientSocket(host, port, loginTimeout, params);
+    TSocket tSSLSocket = TSSLTransportFactory.getClientSocket(host, port, socketTimeout, params);
+    tSSLSocket.setConnectTimeout(connectTimeout);
     return getSSLSocketWithHttps(tSSLSocket);
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

There are two concepts `connect timeout` and `so timeout` in the socket, currently, the Kyuubi Hive JDBC driver uses `DriverManager#loginTimeout` as both of them, it does not make sense, and will cause unexpected "read timeout" exceptions if `DriverManager#loginTimeout` was set a small value, e.g. Spring Boot set it to 30s in default.

This PR proposes to introduce two dedicated JDBC parameters to control them.

See also https://github.com/apache/hive/pull/3379

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
