### PR TITLE
Fix npe issue when formatting the kyuubi-ctl output

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Tabulator.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Tabulator.scala
@@ -34,7 +34,7 @@ private[kyuubi] object Tabulator {
   }
 
   private def formatTextTable(header: Array[String], rows: Array[Array[String]]): String = {
-    val normalizedRows = rows.map(row => row.map(Option(_).getOrElse("")))
+    val normalizedRows = rows.map(row => row.map(Option(_).getOrElse("null")))
     FlipTable.of(header, normalizedRows)
   }
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Tabulator.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Tabulator.scala
@@ -34,7 +34,7 @@ private[kyuubi] object Tabulator {
   }
 
   private def formatTextTable(header: Array[String], rows: Array[Array[String]]): String = {
-    val normalizedRows = rows.map(row => row.map(Option(_).getOrElse("null")))
+    val normalizedRows = rows.map(row => row.map(Option(_).getOrElse("N/A")))
     FlipTable.of(header, normalizedRows)
   }
 }

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/util/TabulatorSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/util/TabulatorSuite.scala
@@ -21,17 +21,17 @@ import org.apache.kyuubi.KyuubiFunSuite
 
 class TabulatorSuite extends KyuubiFunSuite {
   test("format rows have null") {
-    val rows: Array[Array[String]] = Array(Array("1", null), Array(null, "2"))
+    val rows: Array[Array[String]] = Array(Array("1", ""), Array(null, "2"))
     // scalastyle:off
     val expected =
       """
-        |╔════╤════╗
-        |║ c1 │ c2 ║
-        |╠════╪════╣
-        |║ 1  │    ║
-        |╟────┼────╢
-        |║    │ 2  ║
-        |╚════╧════╝
+        |╔══════╤════╗
+        |║ c1   │ c2 ║
+        |╠══════╪════╣
+        |║ 1    │    ║
+        |╟──────┼────╢
+        |║ null │ 2  ║
+        |╚══════╧════╝
         |""".stripMargin
     // scalastyle:on
     val result = Tabulator.format("test", Array("c1", "c2"), rows)

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/util/TabulatorSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/util/TabulatorSuite.scala
@@ -17,24 +17,24 @@
 
 package org.apache.kyuubi.ctl.util
 
-import com.jakewharton.fliptables.FlipTable
-import org.apache.commons.lang3.StringUtils
+import org.apache.kyuubi.KyuubiFunSuite
 
-private[kyuubi] object Tabulator {
-  def format(title: String, header: Array[String], rows: Array[Array[String]]): String = {
-    val textTable = formatTextTable(header, rows)
-    val footer = s"${rows.size} row(s)\n"
-    if (StringUtils.isBlank(title)) {
-      textTable + footer
-    } else {
-      val rowWidth = textTable.split("\n").head.size
-      val titleNewLine = "\n" + StringUtils.center(title, rowWidth) + "\n"
-      titleNewLine + textTable + footer
-    }
-  }
-
-  private def formatTextTable(header: Array[String], rows: Array[Array[String]]): String = {
-    val normalizedRows = rows.map(row => row.map(Option(_).getOrElse("")))
-    FlipTable.of(header, normalizedRows)
+class TabulatorSuite extends KyuubiFunSuite {
+  test("format rows have null") {
+    val rows: Array[Array[String]] = Array(Array("1", null), Array(null, "2"))
+    // scalastyle:off
+    val expected =
+      """
+        |╔════╤════╗
+        |║ c1 │ c2 ║
+        |╠════╪════╣
+        |║ 1  │    ║
+        |╟────┼────╢
+        |║    │ 2  ║
+        |╚════╧════╝
+        |""".stripMargin
+    // scalastyle:on
+    val result = Tabulator.format("test", Array("c1", "c2"), rows)
+    assert(result.contains(expected))
   }
 }

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/util/TabulatorSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/util/TabulatorSuite.scala
@@ -25,13 +25,13 @@ class TabulatorSuite extends KyuubiFunSuite {
     // scalastyle:off
     val expected =
       """
-        |╔══════╤════╗
-        |║ c1   │ c2 ║
-        |╠══════╪════╣
-        |║ 1    │    ║
-        |╟──────┼────╢
-        |║ null │ 2  ║
-        |╚══════╧════╝
+        |╔═════╤════╗
+        |║ c1  │ c2 ║
+        |╠═════╪════╣
+        |║ 1   │    ║
+        |╟─────┼────╢
+        |║ N/A │ 2  ║
+        |╚═════╧════╝
         |""".stripMargin
     // scalastyle:on
     val result = Tabulator.format("test", Array("c1", "c2"), rows)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix npe issue:

```
Exception in thread "main" java.lang.NullPointerException
	at com.jakewharton.fliptables.FlipTable.<init>(FlipTable.java:42)
	at com.jakewharton.fliptables.FlipTable.of(FlipTable.java:20)
	at org.apache.kyuubi.ctl.util.Tabulator$.formatTextTable(Tabulator.scala:37)
	at org.apache.kyuubi.ctl.util.Tabulator$.format(Tabulator.scala:25)
	at org.apache.kyuubi.ctl.util.Render$.renderBatchListInfo(Render.scala:39)
	at org.apache.kyuubi.ctl.cmd.list.ListBatchCommand.$anonfun$render$1(ListBatchCommand.scala:58)
	at org.apache.kyuubi.ctl.cmd.Command.info(Command.scala:86)
	at org.apache.kyuubi.ctl.cmd.list.ListBatchCommand.render(ListBatchCommand.scala:58)
	at org.apache.kyuubi.ctl.cmd.list.ListBatchCommand.render(ListBatchCommand.scala:26)
	at org.apache.kyuubi.ctl.cmd.Command.$anonfun$run$1(Command.scala:47)
	at org.apache.kyuubi.ctl.cmd.Command.$anonfun$run$1$adapted(Command.scala:47)
	at scala.Option.foreach(Option.scala:407)
	at org.apache.kyuubi.ctl.cmd.Command.run(Command.scala:47)
	at org.apache.kyuubi.ctl.ControlCli.doAction(ControlCli.scala:45)
	at org.apache.kyuubi.ctl.ControlCli$$anon$1.doAction(ControlCli.scala:78)
	at org.apache.kyuubi.ctl.ControlCli$.main(ControlCli.scala:86)
	at org.apache.kyuubi.ctl.ControlCli.main(ControlCli.scala)
```

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
