### PR TITLE
Fix flaky test: BatchesResourceSuite - batch sessions recovery

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/BatchesResourceSuite.scala
@@ -437,10 +437,12 @@ class BatchesResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper wi
     assert(session2.createTime === batchMetadata2.createTime)
 
     eventually(timeout(5.seconds)) {
-      assert(session1.batchJobSubmissionOp.getStatus.state === OperationState.RUNNING)
+      val batchState1 = session1.batchJobSubmissionOp.getStatus.state
+      assert(batchState1 === OperationState.RUNNING || batchState1 === OperationState.FINISHED)
       assert(session1.batchJobSubmissionOp.builder.processLaunched)
 
-      assert(session2.batchJobSubmissionOp.getStatus.state === OperationState.RUNNING)
+      val batchState2 = session2.batchJobSubmissionOp.getStatus.state
+      assert(batchState2 === OperationState.RUNNING || batchState2 === OperationState.FINISHED)
       assert(!session2.batchJobSubmissionOp.builder.processLaunched)
     }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix flaky test:

```
- batch sessions recovery *** FAILED ***
  The code passed to eventually never returned normally. Attempted 331 times over 5.008745328 seconds. Last failure message: FINISHED did not equal RUNNING. (BatchesResourceSuite.scala:439)
```
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
