### PR TITLE
[BUILD] Use jdk_switcher to setup JAVA_HOME

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,9 +26,7 @@ branches:
   only:
     - master
 
-language: scala
-scala:
-  - 2.12.15
+language: java
 jdk:
   - openjdk8
 
@@ -56,10 +54,10 @@ cache:
     - $HOME/.m2
 
 install:
+  - jdk_switcher use openjdk8
   - ./build/mvn --version
 
 before_script:
-  - export JAVA_HOME="$(realpath -Pm "$(which javac)/../../")"
   - export MVN_ARGS="-Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
   - ./build/mvn clean install -DskipTests $MVN_ARGS
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Travis is broken now.

```
Setting environment variables from .travis.yml
$ export SPARK_LOCAL_IP=localhost
cache.1
Setting up build cache
$ export CASHER_DIR=${TRAVIS_HOME}/.casher
0.12s$ Installing caching utilities
0.00s33.20sattempting to download cache archive
fetching master/cache-arm64-graviton2-linux-focal-046985d2f0b3191d2c6bcfb79939b9fc8dc49dbf18bf961a8807339370ad57bf--jdk-openjdk8--scala-2.12.15.tgz
found cache
0.00s38.80sadding /home/travis/.m2 to cache
$ java -Xmx32m -version
openjdk version "11.0.8" 2020-07-14
OpenJDK Runtime Environment (build 11.0.8+10-post-Ubuntu-0ubuntu120.04)
OpenJDK 64-Bit Server VM (build 11.0.8+10-post-Ubuntu-0ubuntu120.04, mixed mode)
$ javac -J-Xmx32m -version
javac 11.0.8
Using Scala 2.12.15
15.93s$ ./build/mvn --version
The JAVA_HOME environment variable is not defined correctly
This environment variable is needed to run this program
NB: JAVA_HOME should point to a JDK not a JRE
exec: curl --progress-bar -L https://archive.apache.org/dist//maven/maven-3/3.8.4/binaries/apache-maven-3.8.4-bin.tar.gz
######################################################################### 100.0%
Using `mvn` from path: /home/travis/build/apache/incubator-kyuubi/build/apache-maven-3.8.4/bin/mvn
The JAVA_HOME environment variable is not defined correctly,
this environment variable is needed to run this program.
The command "./build/mvn --version" failed and exited with 1 during .
```

This PR proposes to use jdk_switcher to setup `JAVA_HOME`.

https://docs.travis-ci.com/user/languages/java/#switching-jdks-java-8-and-below-within-one-job

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
