### PR TITLE
[KYUUBI #3194][Scala-2.13] Refine deprecated config

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -345,6 +345,7 @@ object KyuubiConf {
       .version("1.4.0")
       .fallbackConf(FRONTEND_BIND_HOST)
 
+  @deprecated("using kyuubi.frontend.thrift.binary.bind.port instead", "1.4.0")
   val FRONTEND_BIND_PORT: ConfigEntry[Int] = buildConf("kyuubi.frontend.bind.port")
     .doc("(deprecated) Port of the machine on which to run the thrift frontend service " +
       "via binary protocol.")
@@ -417,6 +418,7 @@ object KyuubiConf {
       .version("1.4.0")
       .fallbackConf(FRONTEND_WORKER_KEEPALIVE_TIME)
 
+  @deprecated("using kyuubi.frontend.thrift.max.message.size instead", "1.4.0")
   val FRONTEND_MAX_MESSAGE_SIZE: ConfigEntry[Int] =
     buildConf("kyuubi.frontend.max.message.size")
       .doc("(deprecated) Maximum message size in bytes a Kyuubi server will accept.")
@@ -430,6 +432,7 @@ object KyuubiConf {
       .version("1.4.0")
       .fallbackConf(FRONTEND_MAX_MESSAGE_SIZE)
 
+  @deprecated("using kyuubi.frontend.thrift.login.timeout instead", "1.4.0")
   val FRONTEND_LOGIN_TIMEOUT: ConfigEntry[Long] =
     buildConf("kyuubi.frontend.login.timeout")
       .doc("(deprecated) Timeout for Thrift clients during login to the thrift frontend service.")
@@ -443,6 +446,7 @@ object KyuubiConf {
       .version("1.4.0")
       .fallbackConf(FRONTEND_LOGIN_TIMEOUT)
 
+  @deprecated("using kyuubi.frontend.thrift.backoff.slot.length instead", "1.4.0")
   val FRONTEND_LOGIN_BACKOFF_SLOT_LENGTH: ConfigEntry[Long] =
     buildConf("kyuubi.frontend.backoff.slot.length")
       .doc("(deprecated) Time to back off during login to the thrift frontend service.")
@@ -889,6 +893,7 @@ object KyuubiConf {
     .checkValue(_ > Duration.ofSeconds(3).toMillis, "Minimum 3 seconds")
     .createWithDefault(Duration.ofMinutes(5).toMillis)
 
+  @deprecated("using kyuubi.session.idle.timeout instead", "1.2.0")
   val SESSION_TIMEOUT: ConfigEntry[Long] = buildConf("kyuubi.session.timeout")
     .doc("(deprecated)session timeout, it will be closed when it's not accessed for this duration")
     .version("1.0.0")
@@ -1201,6 +1206,7 @@ object KyuubiConf {
       .stringConf
       .createWithDefault("server_operation_logs")
 
+  @deprecated("using kyuubi.engine.share.level instead", "1.2.0")
   val LEGACY_ENGINE_SHARE_LEVEL: ConfigEntry[String] =
     buildConf("kyuubi.session.engine.share.level")
       .doc(s"(deprecated) - Using kyuubi.engine.share.level instead")
@@ -1215,6 +1221,7 @@ object KyuubiConf {
   private val validZookeeperSubPath: Pattern = ("(?!^[\\u002e]{1,2}$)" +
     "(^[\\u0020-\\u002e\\u0030-\\u007e\\u00a0-\\ud7ff\\uf900-\\uffef]{1,}$)").r.pattern
 
+  @deprecated("using kyuubi.engine.share.level.subdomain instead", "1.4.0")
   val ENGINE_SHARE_LEVEL_SUB_DOMAIN: ConfigEntry[Option[String]] =
     buildConf("kyuubi.engine.share.level.sub.domain")
       .doc("(deprecated) - Using kyuubi.engine.share.level.subdomain instead")
@@ -1234,6 +1241,7 @@ object KyuubiConf {
       .version("1.4.0")
       .fallbackConf(ENGINE_SHARE_LEVEL_SUB_DOMAIN)
 
+  @deprecated("using kyuubi.frontend.connection.url.use.hostname instead, 1.5.0")
   val ENGINE_CONNECTION_URL_USE_HOSTNAME: ConfigEntry[Boolean] =
     buildConf("kyuubi.engine.connection.url.use.hostname")
       .doc("(deprecated) " +
@@ -1919,7 +1927,7 @@ object KyuubiConf {
       DeprecatedConfig(
         "kyuubi.ha.zookeeper.acl.enabled",
         "1.3.2",
-        "Use kyuubi.ha.zookeeper.auth.type instead"))
+        "Use kyuubi.ha.zookeeper.auth.type and kyuubi.ha.zookeeper.engine.auth.type instead"))
     Map(configs.map { cfg => cfg.key -> cfg }: _*)
   }
 }

--- a/kyuubi-common/src/test/resources/log4j2-test.xml
+++ b/kyuubi-common/src/test/resources/log4j2-test.xml
@@ -23,7 +23,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
             <Filters>
-                <ThresholdFilter level="FATAL"/>
+                <ThresholdFilter level="WARN"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>

--- a/kyuubi-common/src/test/resources/log4j2-test.xml
+++ b/kyuubi-common/src/test/resources/log4j2-test.xml
@@ -23,7 +23,7 @@
         <Console name="stdout" target="SYSTEM_OUT">
             <PatternLayout pattern="%d{HH:mm:ss.SSS} %p %c: %m%n"/>
             <Filters>
-                <ThresholdFilter level="WARN"/>
+                <ThresholdFilter level="FATAL"/>
                 <RegexFilter regex=".*Thrift error occurred during processing of message.*" onMatch="DENY" onMismatch="NEUTRAL"/>
             </Filters>
         </Console>

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
@@ -29,12 +29,14 @@ object HighAvailabilityConf {
 
   private def buildConf(key: String): ConfigBuilder = KyuubiConf.buildConf(key)
 
+  @deprecated("using kyuubi.ha.addresses instead", "1.6.0")
   val HA_ZK_QUORUM: ConfigEntry[String] = buildConf("kyuubi.ha.zookeeper.quorum")
     .doc("(deprecated) The connection string for the zookeeper ensemble")
     .version("1.0.0")
     .stringConf
     .createWithDefault("")
 
+  @deprecated("using kyuubi.ha.namespace instead", "1.6.0")
   val HA_ZK_NAMESPACE: ConfigEntry[String] = buildConf("kyuubi.ha.zookeeper.namespace")
     .doc("(deprecated) The root directory for the service to deploy its instance uri")
     .version("1.0.0")
@@ -62,6 +64,9 @@ object HighAvailabilityConf {
       .checkValue(_.nonEmpty, "must not be empty")
       .createWithDefault("org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient")
 
+  @deprecated(
+    "using kyuubi.ha.zookeeper.auth.type and kyuubi.ha.zookeeper.engine.auth.type instead",
+    "1.3.2")
   val HA_ZK_ACL_ENABLED: ConfigEntry[Boolean] =
     buildConf("kyuubi.ha.zookeeper.acl.enabled")
       .doc("Set to true if the zookeeper ensemble is kerberized")

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/HighAvailabilityConf.scala
@@ -29,14 +29,12 @@ object HighAvailabilityConf {
 
   private def buildConf(key: String): ConfigBuilder = KyuubiConf.buildConf(key)
 
-  @deprecated(s"using ${HA_ADDRESSES.key} instead", "1.6.0")
   val HA_ZK_QUORUM: ConfigEntry[String] = buildConf("kyuubi.ha.zookeeper.quorum")
     .doc("(deprecated) The connection string for the zookeeper ensemble")
     .version("1.0.0")
     .stringConf
     .createWithDefault("")
 
-  @deprecated(s"using ${HA_NAMESPACE.key} instead", "1.6.0")
   val HA_ZK_NAMESPACE: ConfigEntry[String] = buildConf("kyuubi.ha.zookeeper.namespace")
     .doc("(deprecated) The root directory for the service to deploy its instance uri")
     .version("1.0.0")
@@ -64,7 +62,6 @@ object HighAvailabilityConf {
       .checkValue(_.nonEmpty, "must not be empty")
       .createWithDefault("org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient")
 
-  @deprecated(s"using ${HA_ZK_AUTH_TYPE.key} and ${HA_ZK_ENGINE_AUTH_TYPE.key} instead", "1.3.2")
   val HA_ZK_ACL_ENABLED: ConfigEntry[Boolean] =
     buildConf("kyuubi.ha.zookeeper.acl.enabled")
       .doc("Set to true if the zookeeper ensemble is kerberized")

--- a/kyuubi-zookeeper/src/main/scala/org/apache/kyuubi/zookeeper/ZookeeperConf.scala
+++ b/kyuubi-zookeeper/src/main/scala/org/apache/kyuubi/zookeeper/ZookeeperConf.scala
@@ -23,12 +23,14 @@ object ZookeeperConf {
 
   private def buildConf(key: String): ConfigBuilder = KyuubiConf.buildConf(key)
 
+  @deprecated("using kyuubi.zookeeper.embedded.client.port instead", since = "1.2.0")
   val EMBEDDED_ZK_PORT: ConfigEntry[Int] = buildConf("kyuubi.zookeeper.embedded.port")
     .doc("The port of the embedded zookeeper server")
     .version("1.0.0")
     .intConf
     .createWithDefault(2181)
 
+  @deprecated("using kyuubi.zookeeper.embedded.data.dir instead", since = "1.2.0")
   val EMBEDDED_ZK_TEMP_DIR: ConfigEntry[String] = buildConf("kyuubi.zookeeper.embedded.directory")
     .doc("The temporary directory for the embedded zookeeper server")
     .version("1.0.0")

--- a/kyuubi-zookeeper/src/main/scala/org/apache/kyuubi/zookeeper/ZookeeperConf.scala
+++ b/kyuubi-zookeeper/src/main/scala/org/apache/kyuubi/zookeeper/ZookeeperConf.scala
@@ -23,14 +23,12 @@ object ZookeeperConf {
 
   private def buildConf(key: String): ConfigBuilder = KyuubiConf.buildConf(key)
 
-  @deprecated(s"using ${ZK_CLIENT_PORT.key} instead", since = "1.2.0")
   val EMBEDDED_ZK_PORT: ConfigEntry[Int] = buildConf("kyuubi.zookeeper.embedded.port")
     .doc("The port of the embedded zookeeper server")
     .version("1.0.0")
     .intConf
     .createWithDefault(2181)
 
-  @deprecated(s"using ${ZK_DATA_DIR.key} instead", since = "1.2.0")
   val EMBEDDED_ZK_TEMP_DIR: ConfigEntry[String] = buildConf("kyuubi.zookeeper.embedded.directory")
     .doc("The temporary directory for the embedded zookeeper server")
     .version("1.0.0")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

1. add a warning message when the user sets the deprecated configuration
```
10:49:58.558 WARN org.apache.kyuubi.config.KyuubiConf: The Kyuubi config 'kyuubi.frontend.bind.port' has been deprecated in Kyuubi v1.4.0 and may be removed in the future. Use kyuubi.frontend.thrift.binary.bind.port instead
```

2. make the annotation `@deprecated` arguments only contain constants to fix the error when compiling for scala-2.13

```
[ERROR] /home/chenfu/workspace/incubator-kyuubi/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala:353: annotation argument needs to be a constant; found: "using ".+(KyuubiConf.this.FRONTEND_THRIFT_BINARY_BIND_PORT.key).+(" instead")
```

### _How was this patch tested?_

Pass CI.
