### PR TITLE
[KYUUBI #3186] Support applying Row-level Filter and Data Masking policies for DatasourceV2 in Authz module

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -34,18 +34,6 @@ import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 object PrivilegesBuilder {
 
-  private def quoteIfNeeded(part: String): String = {
-    if (part.matches("[a-zA-Z0-9_]+") && !part.matches("\\d+")) {
-      part
-    } else {
-      s"`${part.replace("`", "``")}`"
-    }
-  }
-
-  private def quote(parts: Seq[String]): String = {
-    parts.map(quoteIfNeeded).mkString(".")
-  }
-
   private def databasePrivileges(db: String): PrivilegeObject = {
     PrivilegeObject(DATABASE, PrivilegeObjectActionType.OTHER, db, db)
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -46,16 +46,12 @@ class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[Logical
         }
       case datasourceV2Relation if hasResolvedDatasourceV2Table(datasourceV2Relation) =>
         val table = getDatasourceV2Table(datasourceV2Relation)
-        if (table == null) {
-          datasourceV2Relation
-        } else {
-          val catalogDbTable = table.name.split("\\.")
-          if (catalogDbTable.length != 3) {
-            return datasourceV2Relation
-          }
-          val tableIdentifier = TableIdentifier(catalogDbTable(2), Option(catalogDbTable(1)))
-          applyFilterAndMasking(datasourceV2Relation, tableIdentifier, spark)
+        val catalogDbTable = table.name.split("\\.")
+        if (catalogDbTable.length != 3) {
+          return datasourceV2Relation
         }
+        val tableIdentifier = TableIdentifier(catalogDbTable(2), Option(catalogDbTable(1)))
+        applyFilterAndMasking(datasourceV2Relation, tableIdentifier, spark)
       case other => apply(other)
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -45,13 +45,14 @@ class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[Logical
           applyFilterAndMasking(logicalRelation, table.get.identifier, spark)
         }
       case datasourceV2Relation if hasResolvedDatasourceV2Table(datasourceV2Relation) =>
-        val table = getDatasourceV2Table(datasourceV2Relation)
-        val catalogDbTable = table.name.split("\\.")
-        if (catalogDbTable.length != 3) {
+        val identifier = getDatasourceV2Identifier(datasourceV2Relation)
+        if (identifier.isEmpty) {
           return datasourceV2Relation
+        } else {
+          val tableIdentifier = TableIdentifier(identifier.get.name,
+            Option(identifier.get.namespace.mkString(".")))
+          applyFilterAndMasking(datasourceV2Relation, tableIdentifier, spark)
         }
-        val tableIdentifier = TableIdentifier(catalogDbTable(2), Option(catalogDbTable(1)))
-        applyFilterAndMasking(datasourceV2Relation, tableIdentifier, spark)
       case other => apply(other)
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -62,9 +62,8 @@ class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[Logical
 
   private def applyFilterAndMasking(
       plan: LogicalPlan,
-      table: CatalogTable,
+      identifier: TableIdentifier,
       spark: SparkSession): LogicalPlan = {
-    val identifier = table.identifier
     val ugi = getAuthzUgi(spark.sparkContext)
     val opType = OperationType(plan.nodeName)
     val parse = spark.sessionState.sqlParser.parseExpression _

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -47,7 +47,7 @@ class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[Logical
       case datasourceV2Relation if hasResolvedDatasourceV2Table(datasourceV2Relation) =>
         val identifier = getDatasourceV2Identifier(datasourceV2Relation)
         if (identifier.isEmpty) {
-          return datasourceV2Relation
+          datasourceV2Relation
         } else {
           val tableIdentifier = TableIdentifier(identifier.get.name,
             Option(identifier.get.namespace.mkString(".")))

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -45,13 +45,11 @@ class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[Logical
           applyFilterAndMasking(logicalRelation, table.get.identifier, spark)
         }
       case datasourceV2Relation if hasResolvedDatasourceV2Table(datasourceV2Relation) =>
-        val identifier = getDatasourceV2Identifier(datasourceV2Relation)
-        if (identifier.isEmpty) {
+        val tableIdentifier = getDatasourceV2Identifier(datasourceV2Relation)
+        if (tableIdentifier.isEmpty) {
           datasourceV2Relation
         } else {
-          val tableIdentifier =
-            TableIdentifier(identifier.get.name, Option(identifier.get.namespace.mkString(".")))
-          applyFilterAndMasking(datasourceV2Relation, tableIdentifier, spark)
+          applyFilterAndMasking(datasourceV2Relation, tableIdentifier.get, spark)
         }
       case other => apply(other)
     }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -46,10 +46,10 @@ class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[Logical
         }
       case datasourceV2Relation if hasResolvedDatasourceV2Table(datasourceV2Relation) =>
         val table = getDatasourceV2Table(datasourceV2Relation)
-        if (table.isEmpty) {
+        if (table == null) {
           datasourceV2Relation
         } else {
-          val catalogDbTable = table.get.name.split("\\.")
+          val catalogDbTable = table.name.split("\\.")
           if (catalogDbTable.length != 3) {
             return datasourceV2Relation
           }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -49,8 +49,8 @@ class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[Logical
         if (identifier.isEmpty) {
           datasourceV2Relation
         } else {
-          val tableIdentifier = TableIdentifier(identifier.get.name,
-            Option(identifier.get.namespace.mkString(".")))
+          val tableIdentifier =
+            TableIdentifier(identifier.get.name, Option(identifier.get.namespace.mkString(".")))
           applyFilterAndMasking(datasourceV2Relation, tableIdentifier, spark)
         }
       case other => apply(other)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -30,7 +30,7 @@ import org.apache.kyuubi.plugin.spark.authz.util.RowFilterAndDataMaskingMarker
 class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[LogicalPlan] {
 
   override def apply(plan: LogicalPlan): LogicalPlan = {
-    // Apply FilterAndMasking and wrap HiveTableRelation/LogicalRelation with
+    // Apply FilterAndMasking and wrap HiveTableRelation/LogicalRelation/DataSourceV2Relation with
     // RowFilterAndDataMaskingMarker if it is not wrapped yet.
     plan mapChildren {
       case p: RowFilterAndDataMaskingMarker => p

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -24,7 +24,7 @@ import org.apache.spark.SPARK_VERSION
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
-import org.apache.spark.sql.connector.catalog.Table
+import org.apache.spark.sql.connector.catalog.{Identifier, Table}
 
 private[authz] object AuthZUtils {
 
@@ -89,8 +89,8 @@ private[authz] object AuthZUtils {
     plan.nodeName == "DataSourceV2Relation" && plan.resolved
   }
 
-  def getDatasourceV2Table(plan: LogicalPlan): Table = {
-    getFieldVal[Table](plan, "table")
+  def getDatasourceV2Identifier(plan: LogicalPlan): Option[Identifier] = {
+    getFieldVal[Option[Identifier]](plan, "identifier")
   }
 
   /**

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -24,6 +24,7 @@ import org.apache.spark.SPARK_VERSION
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.connector.catalog.Table
 
 private[authz] object AuthZUtils {
 
@@ -82,6 +83,14 @@ private[authz] object AuthZUtils {
 
   def getDatasourceTable(plan: LogicalPlan): Option[CatalogTable] = {
     getFieldVal[Option[CatalogTable]](plan, "catalogTable")
+  }
+
+  def hasResolvedDatasourceV2Table(plan: LogicalPlan): Boolean = {
+    plan.nodeName == "DataSourceV2Relation" && plan.resolved
+  }
+
+  def getDatasourceV2Table(plan: LogicalPlan): Option[Table] = {
+    getFieldVal[Option[Table]](plan, "table")
   }
 
   /**

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -89,8 +89,8 @@ private[authz] object AuthZUtils {
     plan.nodeName == "DataSourceV2Relation" && plan.resolved
   }
 
-  def getDatasourceV2Table(plan: LogicalPlan): Option[Table] = {
-    getFieldVal[Option[Table]](plan, "table")
+  def getDatasourceV2Table(plan: LogicalPlan): Table = {
+    getFieldVal[Table](plan, "table")
   }
 
   /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

`RuleApplyRowFilterAndDataMasking` in AuthZ currently applys row-level filters correctly on both `HiveTableRelation` fro Hive tables and `LogicalRelation`, but is not affcecting the execution plan for Iceberg tables.

As Iceberg table is accssesed via `DataSourceV2Relation`, `RuleApplyRowFilterAndDataMasking` is adopted to apply row filtering on `TableIdentifier` for different relation (including HiveTableRelation and LogicalRelation) and fetch correct table identifier from `DataSourceV2Relation`.


Considering an iceberg table `gftest.sampleice`, with an row-level filter as `id='1'`.

SQL：
`EXPLAIN EXTENDED select *from gftest.sampleice limit 5;`

Execution Plan before this PR：
```
== Parsed Logical Plan ==
'GlobalLimit 5
+- 'LocalLimit 5
   +- 'Project [*]
      +- 'UnresolvedRelation [gftest, sampleice], [], false

== Analyzed Logical Plan ==
id: bigint, data: string
GlobalLimit 5
+- LocalLimit 5
   +- Project [id#13332L, data#13333]
      +- SubqueryAlias spark_catalog.gftest.sampleice
         +- RelationV2[id#13332L, data#13333] spark_catalog.gftest.sampleice

== Optimized Logical Plan ==
GlobalLimit 5
+- LocalLimit 5
   +- RelationV2[id#13332L, data#13333] spark_catalog.gftest.sampleice

== Physical Plan ==
CollectLimit 5
+- *(1) ColumnarToRow
   +- BatchScan[id#13332L, data#13333] spark_catalog.gftest.sampleice [filters=] RuntimeFilters: []

```


Execution Plan before this PR：
```
== Parsed Logical Plan ==
'GlobalLimit 5
+- 'LocalLimit 5
   +- 'Project [*]
      +- 'UnresolvedRelation [gftest, sampleice], [], false

== Analyzed Logical Plan ==
id: bigint, data: string
GlobalLimit 5
+- LocalLimit 5
   +- Project [id#142L, data#143]
      +- SubqueryAlias spark_catalog.gftest.sampleice
         +- Project [id#142L, data#143]
            +- Filter (id#142L = cast(1 as bigint))
               +- RowFilterAndDataMaskingMarker
                  +- RelationV2[id#142L, data#143] spark_catalog.gftest.sampleice

== Optimized Logical Plan ==
GlobalLimit 5
+- LocalLimit 5
   +- Filter (isnotnull(id#142L) AND (id#142L = 1))
      +- RelationV2[id#142L, data#143] spark_catalog.gftest.sampleice

== Physical Plan ==
CollectLimit 5
+- *(1) Filter (isnotnull(id#142L) AND (id#142L = 1))
   +- *(1) ColumnarToRow
      +- BatchScan[id#142L, data#143] spark_catalog.gftest.sampleice [filters=id IS NOT NULL, id = 1] RuntimeFilters: []
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
