### PR TITLE
[KYUUBI #3220] Make kyuubi.engine.ui.stop.enabled false in HistoryServer

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/KyuubiHistoryServerPlugin.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/KyuubiHistoryServerPlugin.scala
@@ -41,9 +41,10 @@ class KyuubiHistoryServerPlugin extends AppHistoryServerPlugin {
   }
 
   override def setupUI(ui: SparkUI): Unit = {
-    val kyuubiConf = mergedKyuubiConf(ui.conf)
     val store = new EngineEventsStore(ui.store.store)
     if (store.getSessionCount > 0) {
+      val kyuubiConf = mergedKyuubiConf(ui.conf)
+      kyuubiConf.set(KyuubiConf.ENGINE_UI_STOP_ENABLED, false)
       EngineTab(
         None,
         Some(ui),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
close #3220

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Add screenshots for manual tests if appropriate
![image](https://user-images.githubusercontent.com/17894939/184284124-018023c9-0e27-43c9-a4ab-f4c9214849eb.png)

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
