### PR TITLE
[KYUUBI #1776][FOLLOWUP] Fill empty td tag for `Failure Reason` column in EngineTable

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -388,7 +388,9 @@ private class StatementStatsPagedTable(
       }
     }
       </td>
-      {if (event.exception.isDefined) errorMessageCell(event.exception.get.getMessage)}
+      {
+      if (event.exception.isDefined) errorMessageCell(event.exception.get.getMessage) else <td></td>
+    }
     </tr>
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Followup #1776

'Failure Reason' column needs to be filled with empty td tag when there is no exception:
![微信截图_20220812135529](https://user-images.githubusercontent.com/17894939/184293709-d2ae7cdd-5625-422d-b6d7-7368429cf600.png)

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Add screenshots for manual tests if appropriate
![微信截图_20220812135453](https://user-images.githubusercontent.com/17894939/184293704-ab7613b2-28ea-4ac0-9aed-e5382251365d.png)

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
