### PR TITLE
SparkConfParser supports parse bytes and time

### DIFF
--- a/docs/connector/spark/tpch.rst
+++ b/docs/connector/spark/tpch.rst
@@ -75,7 +75,7 @@ To add TPC-H tables as a catalog, we can set the following configurations in ``$
    spark.sql.catalog.tpch.useAnsiStringType=false
 
    # (optional) Maximum bytes per task, consider reducing it if you want higher parallelism.
-   spark.sql.catalog.tpch.read.maxPartitionBytes=134217728
+   spark.sql.catalog.tpch.read.maxPartitionBytes=128m
 
 TPC-H Operations
 ----------------

--- a/extensions/spark/kyuubi-spark-connector-common/pom.xml
+++ b/extensions/spark/kyuubi-spark-connector-common/pom.xml
@@ -66,16 +66,27 @@
         </dependency>
 
         <dependency>
-            <groupId>org.scalatestplus</groupId>
-            <artifactId>scalacheck-1-15_${scala.binary.version}</artifactId>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.binary.version}</artifactId>
+            <type>test-jar</type>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-sql_${scala.binary.version}</artifactId>
-            <version>${spark.version}</version>
-            <type>test-jar</type>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client-runtime</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scalatestplus</groupId>
+            <artifactId>scalacheck-1-15_${scala.binary.version}</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/extensions/spark/kyuubi-spark-connector-common/src/main/java/org/apache/kyuubi/spark/connector/common/JavaUtils.java
+++ b/extensions/spark/kyuubi-spark-connector-common/src/main/java/org/apache/kyuubi/spark/connector/common/JavaUtils.java
@@ -1,0 +1,184 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.spark.connector.common;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.spark.network.util.ByteUnit;
+
+/** Copied from Apache Spark org.apache.spark.network.util.JavaUtils */
+public class JavaUtils {
+
+  private static final Map<String, TimeUnit> timeSuffixes;
+
+  static {
+    timeSuffixes = new HashMap<>();
+    timeSuffixes.put("us", TimeUnit.MICROSECONDS);
+    timeSuffixes.put("ms", TimeUnit.MILLISECONDS);
+    timeSuffixes.put("s", TimeUnit.SECONDS);
+    timeSuffixes.put("m", TimeUnit.MINUTES);
+    timeSuffixes.put("min", TimeUnit.MINUTES);
+    timeSuffixes.put("h", TimeUnit.HOURS);
+    timeSuffixes.put("d", TimeUnit.DAYS);
+  }
+
+  private static final Map<String, ByteUnit> byteSuffixes;
+
+  static {
+    byteSuffixes = new HashMap<>();
+    byteSuffixes.put("b", ByteUnit.BYTE);
+    byteSuffixes.put("k", ByteUnit.KiB);
+    byteSuffixes.put("kb", ByteUnit.KiB);
+    byteSuffixes.put("m", ByteUnit.MiB);
+    byteSuffixes.put("mb", ByteUnit.MiB);
+    byteSuffixes.put("g", ByteUnit.GiB);
+    byteSuffixes.put("gb", ByteUnit.GiB);
+    byteSuffixes.put("t", ByteUnit.TiB);
+    byteSuffixes.put("tb", ByteUnit.TiB);
+    byteSuffixes.put("p", ByteUnit.PiB);
+    byteSuffixes.put("pb", ByteUnit.PiB);
+  }
+
+  /**
+   * Convert a passed time string (e.g. 50s, 100ms, or 250us) to a time count in the given unit. The
+   * unit is also considered the default if the given string does not specify a unit.
+   */
+  public static long timeStringAs(String str, TimeUnit unit) {
+    String lower = str.toLowerCase(Locale.ROOT).trim();
+
+    try {
+      Matcher m = Pattern.compile("(-?[0-9]+)([a-z]+)?").matcher(lower);
+      if (!m.matches()) {
+        throw new NumberFormatException("Failed to parse time string: " + str);
+      }
+
+      long val = Long.parseLong(m.group(1));
+      String suffix = m.group(2);
+
+      // Check for invalid suffixes
+      if (suffix != null && !timeSuffixes.containsKey(suffix)) {
+        throw new NumberFormatException("Invalid suffix: \"" + suffix + "\"");
+      }
+
+      // If suffix is valid use that, otherwise none was provided and use the default passed
+      return unit.convert(val, suffix != null ? timeSuffixes.get(suffix) : unit);
+    } catch (NumberFormatException e) {
+      String timeError =
+          "Time must be specified as seconds (s), "
+              + "milliseconds (ms), microseconds (us), minutes (m or min), hour (h), or day (d). "
+              + "E.g. 50s, 100ms, or 250us.";
+
+      throw new NumberFormatException(timeError + "\n" + e.getMessage());
+    }
+  }
+
+  /**
+   * Convert a time parameter such as (50s, 100ms, or 250us) to milliseconds for internal use. If no
+   * suffix is provided, the passed number is assumed to be in ms.
+   */
+  public static long timeStringAsMs(String str) {
+    return timeStringAs(str, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Convert a time parameter such as (50s, 100ms, or 250us) to seconds for internal use. If no
+   * suffix is provided, the passed number is assumed to be in seconds.
+   */
+  public static long timeStringAsSec(String str) {
+    return timeStringAs(str, TimeUnit.SECONDS);
+  }
+
+  /**
+   * Convert a passed byte string (e.g. 50b, 100kb, or 250mb) to the given. If no suffix is
+   * provided, a direct conversion to the provided unit is attempted.
+   */
+  public static long byteStringAs(String str, ByteUnit unit) {
+    String lower = str.toLowerCase(Locale.ROOT).trim();
+
+    try {
+      Matcher m = Pattern.compile("([0-9]+)([a-z]+)?").matcher(lower);
+      Matcher fractionMatcher = Pattern.compile("([0-9]+\\.[0-9]+)([a-z]+)?").matcher(lower);
+
+      if (m.matches()) {
+        long val = Long.parseLong(m.group(1));
+        String suffix = m.group(2);
+
+        // Check for invalid suffixes
+        if (suffix != null && !byteSuffixes.containsKey(suffix)) {
+          throw new NumberFormatException("Invalid suffix: \"" + suffix + "\"");
+        }
+
+        // If suffix is valid use that, otherwise none was provided and use the default passed
+        return unit.convertFrom(val, suffix != null ? byteSuffixes.get(suffix) : unit);
+      } else if (fractionMatcher.matches()) {
+        throw new NumberFormatException(
+            "Fractional values are not supported. Input was: " + fractionMatcher.group(1));
+      } else {
+        throw new NumberFormatException("Failed to parse byte string: " + str);
+      }
+
+    } catch (NumberFormatException e) {
+      String byteError =
+          "Size must be specified as bytes (b), "
+              + "kibibytes (k), mebibytes (m), gibibytes (g), tebibytes (t), or pebibytes(p). "
+              + "E.g. 50b, 100k, or 250m.";
+
+      throw new NumberFormatException(byteError + "\n" + e.getMessage());
+    }
+  }
+
+  /**
+   * Convert a passed byte string (e.g. 50b, 100k, or 250m) to bytes for internal use.
+   *
+   * <p>If no suffix is provided, the passed number is assumed to be in bytes.
+   */
+  public static long byteStringAsBytes(String str) {
+    return byteStringAs(str, ByteUnit.BYTE);
+  }
+
+  /**
+   * Convert a passed byte string (e.g. 50b, 100k, or 250m) to kibibytes for internal use.
+   *
+   * <p>If no suffix is provided, the passed number is assumed to be in kibibytes.
+   */
+  public static long byteStringAsKb(String str) {
+    return byteStringAs(str, ByteUnit.KiB);
+  }
+
+  /**
+   * Convert a passed byte string (e.g. 50b, 100k, or 250m) to mebibytes for internal use.
+   *
+   * <p>If no suffix is provided, the passed number is assumed to be in mebibytes.
+   */
+  public static long byteStringAsMb(String str) {
+    return byteStringAs(str, ByteUnit.MiB);
+  }
+
+  /**
+   * Convert a passed byte string (e.g. 50b, 100k, or 250m) to gibibytes for internal use.
+   *
+   * <p>If no suffix is provided, the passed number is assumed to be in gibibytes.
+   */
+  public static long byteStringAsGb(String str) {
+    return byteStringAs(str, ByteUnit.GiB);
+  }
+}

--- a/extensions/spark/kyuubi-spark-connector-common/src/main/scala/org/apache/kyuubi/spark/connector/common/SparkConfParser.scala
+++ b/extensions/spark/kyuubi-spark-connector-common/src/main/scala/org/apache/kyuubi/spark/connector/common/SparkConfParser.scala
@@ -73,7 +73,7 @@ case class SparkConfParser(
     private var optionName: Option[String] = None
     private var sessionConfName: Option[String] = None
     private var tablePropertyName: Option[String] = None
-    private var defaultValue: Option[String] = None
+    private var defaultStringValue: Option[String] = None
 
     def option(name: String): ConfParser[T] = {
       this.optionName = Some(name)
@@ -90,8 +90,8 @@ case class SparkConfParser(
       this
     }
 
-    def defaultValue(value: String): ConfParser[T] = {
-      this.defaultValue = Some(value)
+    def defaultStringValue(value: String): ConfParser[T] = {
+      this.defaultStringValue = Some(value)
       this
     }
 
@@ -106,13 +106,13 @@ case class SparkConfParser(
       if (valueOpt.isEmpty && properties != null) {
         valueOpt = tablePropertyName.flatMap(name => Option(properties.get(name)))
       }
-      valueOpt.orElse(defaultValue).map(conversion)
+      valueOpt.orElse(defaultStringValue).map(conversion)
     }
 
     protected def conversion(value: String): T
 
     def parse(): T = {
-      assert(defaultValue.isDefined, "Default value cannot be empty.")
+      assert(defaultStringValue.isDefined, "Default value cannot be empty.")
       parseOptional().get
     }
 

--- a/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/SparkConfParserSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/SparkConfParserSuite.scala
@@ -43,22 +43,22 @@ class SparkConfParserSuite extends SparkFunSuite {
   }
 
   test("parse options config") {
-    assert(confParser.stringConf().option("optKey1").defaultValue("test").parse() === "test")
-    assert(confParser.booleanConf().option("booleanKey").defaultValue("true").parse() === false)
-    assert(confParser.intConf().option("intKey").defaultValue("0").parse() === 10)
-    assert(confParser.longConf().option("longKey").defaultValue("0").parse() === Long.MaxValue)
-    assert(confParser.doubleConf().option("doubleKey").defaultValue("0.0").parse() === 1.1)
-    assert(confParser.bytesConf().option("bytesKey").defaultValue("0k").parse() === 1024L)
-    assert(confParser.timeConf().option("timeKey").defaultValue("0s").parse() === 1000L)
+    assert(confParser.stringConf().option("optKey1").defaultStringValue("test").parse() === "test")
+    assert(confParser.booleanConf().option("booleanKey").defaultStringValue("true").parse() === false)
+    assert(confParser.intConf().option("intKey").defaultStringValue("0").parse() === 10)
+    assert(confParser.longConf().option("longKey").defaultStringValue("0").parse() === Long.MaxValue)
+    assert(confParser.doubleConf().option("doubleKey").defaultStringValue("0.0").parse() === 1.1)
+    assert(confParser.bytesConf().option("bytesKey").defaultStringValue("0k").parse() === 1024L)
+    assert(confParser.timeConf().option("timeKey").defaultStringValue("0s").parse() === 1000L)
   }
 
   test("parse properties config") {
     assert(confParser.intConf().option("key1")
       .tableProperty("key1")
-      .defaultValue("0").parse() === 111)
+      .defaultStringValue("0").parse() === 111)
     assert(confParser.stringConf()
       .option("propertyKey1")
       .tableProperty("propertyKey1")
-      .defaultValue("test").parse() === "propertyValue1")
+      .defaultStringValue("test").parse() === "propertyValue1")
   }
 }

--- a/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/SparkConfParserSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/SparkConfParserSuite.scala
@@ -19,13 +19,10 @@ package org.apache.kyuubi.spark.connector.common
 
 import scala.collection.JavaConverters._
 
-// scalastyle:off anyfunsuite
+import org.apache.spark.SparkFunSuite
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
-import org.scalatest.BeforeAndAfterAll
-import org.scalatest.funsuite.AnyFunSuite
 
-class SparkConfParserSuite extends AnyFunSuite with BeforeAndAfterAll {
-// scalastyle:on anyfunsuite
+class SparkConfParserSuite extends SparkFunSuite {
 
   private var confParser: SparkConfParser = _
 

--- a/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/SparkConfParserSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/SparkConfParserSuite.scala
@@ -17,9 +17,9 @@
 
 package org.apache.kyuubi.spark.connector.common
 
-// scalastyle:off anyfunsuite
 import scala.collection.JavaConverters._
 
+// scalastyle:off anyfunsuite
 import org.apache.spark.sql.util.CaseInsensitiveStringMap
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.funsuite.AnyFunSuite
@@ -27,39 +27,41 @@ import org.scalatest.funsuite.AnyFunSuite
 class SparkConfParserSuite extends AnyFunSuite with BeforeAndAfterAll {
 // scalastyle:on anyfunsuite
 
-  test("parse options config") {
-    assert(confParser.stringConf().option("optKey1").defaultValue("test").parse() === "optValue1")
-    assert(confParser.booleanConf().option("booleanKey").defaultValue(true).parse() === false)
-    assert(confParser.intConf().option("intKey").defaultValue(0).parse() === 10)
-    assert(confParser.longConf().option("longKey").defaultValue(0).parse() === Long.MaxValue)
-    assert(confParser.doubleConf().option("doubleKey").defaultValue(0.0).parse() === 1.1)
-  }
-
-  test("parse properties config") {
-    assert(confParser.intConf().option("key1")
-      .tableProperty("key1")
-      .defaultValue(0).parse() === 111)
-    assert(confParser.stringConf()
-      .option("propertyKey1")
-      .tableProperty("propertyKey1")
-      .defaultValue("test").parse() === "propertyValue1")
-  }
-
-  private var confParser: SparkConfParser = null
+  private var confParser: SparkConfParser = _
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()
     val options = new CaseInsensitiveStringMap(Map(
       "key1" -> "111",
-      "optKey1" -> "optValue1",
       "booleanKey" -> "false",
       "intKey" -> "10",
       "longKey" -> String.valueOf(Long.MaxValue),
-      "doubleKey" -> "1.1").asJava)
+      "doubleKey" -> "1.1",
+      "bytesKey" -> "1k",
+      "timeKey" -> "1s").asJava)
     val properties = Map(
       "key1" -> "333",
       "propertyKey1" -> "propertyValue1")
     confParser = SparkConfParser(options, null, properties.asJava)
   }
 
+  test("parse options config") {
+    assert(confParser.stringConf().option("optKey1").defaultValue("test").parse() === "test")
+    assert(confParser.booleanConf().option("booleanKey").defaultValue("true").parse() === false)
+    assert(confParser.intConf().option("intKey").defaultValue("0").parse() === 10)
+    assert(confParser.longConf().option("longKey").defaultValue("0").parse() === Long.MaxValue)
+    assert(confParser.doubleConf().option("doubleKey").defaultValue("0.0").parse() === 1.1)
+    assert(confParser.bytesConf().option("bytesKey").defaultValue("0k").parse() === 1024L)
+    assert(confParser.timeConf().option("timeKey").defaultValue("0s").parse() === 1000L)
+  }
+
+  test("parse properties config") {
+    assert(confParser.intConf().option("key1")
+      .tableProperty("key1")
+      .defaultValue("0").parse() === 111)
+    assert(confParser.stringConf()
+      .option("propertyKey1")
+      .tableProperty("propertyKey1")
+      .defaultValue("test").parse() === "propertyValue1")
+  }
 }

--- a/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/SparkConfParserSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-common/src/test/scala/org/apache/kyuubi/spark/connector/common/SparkConfParserSuite.scala
@@ -44,9 +44,11 @@ class SparkConfParserSuite extends SparkFunSuite {
 
   test("parse options config") {
     assert(confParser.stringConf().option("optKey1").defaultStringValue("test").parse() === "test")
-    assert(confParser.booleanConf().option("booleanKey").defaultStringValue("true").parse() === false)
+    assert(
+      confParser.booleanConf().option("booleanKey").defaultStringValue("true").parse() === false)
     assert(confParser.intConf().option("intKey").defaultStringValue("0").parse() === 10)
-    assert(confParser.longConf().option("longKey").defaultStringValue("0").parse() === Long.MaxValue)
+    assert(
+      confParser.longConf().option("longKey").defaultStringValue("0").parse() === Long.MaxValue)
     assert(confParser.doubleConf().option("doubleKey").defaultStringValue("0.0").parse() === 1.1)
     assert(confParser.bytesConf().option("bytesKey").defaultStringValue("0k").parse() === 1024L)
     assert(confParser.timeConf().option("timeKey").defaultStringValue("0s").parse() === 1000L)

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSConf.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSConf.scala
@@ -62,7 +62,7 @@ case class TPCDSReadConf(
   private val confParser: SparkConfParser =
     SparkConfParser(options, spark.conf, table.properties)
 
-  lazy val maxPartitionBytes: Long = confParser.longConf()
+  lazy val maxPartitionBytes: Long = confParser.bytesConf()
     .option(MAX_PARTITION_BYTES_CONF)
     .sessionConf(s"$TPCDS_CONNECTOR_READ_CONF_PREFIX.$MAX_PARTITION_BYTES_CONF")
     .tableProperty(s"$TPCDS_CONNECTOR_READ_CONF_PREFIX.$MAX_PARTITION_BYTES_CONF")

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSConf.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSConf.scala
@@ -75,11 +75,11 @@ object TPCDSConf {
 
   val TPCDS_CONNECTOR_CONF_PREFIX = "spark.connector.tpcds"
   val USE_ANSI_STRING_TYPE = "useAnsiStringType"
-  val USE_ANSI_STRING_TYPE_DEFAULT = false
+  val USE_ANSI_STRING_TYPE_DEFAULT = "false"
   val USE_TABLE_SCHEMA_2_6 = "useTableSchema_2_6"
-  val USE_TABLE_SCHEMA_2_6_DEFAULT = true
+  val USE_TABLE_SCHEMA_2_6_DEFAULT = "true"
 
   val TPCDS_CONNECTOR_READ_CONF_PREFIX = s"$TPCDS_CONNECTOR_CONF_PREFIX.read"
   val MAX_PARTITION_BYTES_CONF = "maxPartitionBytes"
-  val MAX_PARTITION_BYTES_DEFAULT: Long = 128 * 1024 * 1024L
+  val MAX_PARTITION_BYTES_DEFAULT = "128m"
 }

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSConf.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSConf.scala
@@ -38,7 +38,7 @@ case class TPCDSConf(spark: SparkSession, options: CaseInsensitiveStringMap) {
   lazy val useAnsiStringType: Boolean = confParser.booleanConf()
     .option(USE_ANSI_STRING_TYPE)
     .sessionConf(s"$TPCDS_CONNECTOR_CONF_PREFIX.$USE_ANSI_STRING_TYPE")
-    .defaultValue(USE_ANSI_STRING_TYPE_DEFAULT)
+    .defaultStringValue(USE_ANSI_STRING_TYPE_DEFAULT)
     .parse()
 
   // 09-26-2017 v2.6.0
@@ -50,7 +50,7 @@ case class TPCDSConf(spark: SparkSession, options: CaseInsensitiveStringMap) {
   lazy val useTableSchema_2_6: Boolean = confParser.booleanConf()
     .option(USE_TABLE_SCHEMA_2_6)
     .sessionConf(s"$TPCDS_CONNECTOR_CONF_PREFIX.$USE_TABLE_SCHEMA_2_6")
-    .defaultValue(USE_TABLE_SCHEMA_2_6_DEFAULT)
+    .defaultStringValue(USE_TABLE_SCHEMA_2_6_DEFAULT)
     .parse()
 }
 
@@ -66,7 +66,7 @@ case class TPCDSReadConf(
     .option(MAX_PARTITION_BYTES_CONF)
     .sessionConf(s"$TPCDS_CONNECTOR_READ_CONF_PREFIX.$MAX_PARTITION_BYTES_CONF")
     .tableProperty(s"$TPCDS_CONNECTOR_READ_CONF_PREFIX.$MAX_PARTITION_BYTES_CONF")
-    .defaultValue(MAX_PARTITION_BYTES_DEFAULT)
+    .defaultStringValue(MAX_PARTITION_BYTES_DEFAULT)
     .parse()
 }
 

--- a/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHConf.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHConf.scala
@@ -38,7 +38,7 @@ case class TPCHConf(spark: SparkSession, options: CaseInsensitiveStringMap) {
   lazy val useAnsiStringType: Boolean = confParser.booleanConf()
     .option(USE_ANSI_STRING_TYPE)
     .sessionConf(s"$TPCH_CONNECTOR_CONF_PREFIX.$USE_ANSI_STRING_TYPE")
-    .defaultValue(USE_ANSI_STRING_TYPE_DEFAULT)
+    .defaultStringValue(USE_ANSI_STRING_TYPE_DEFAULT)
     .parse()
 }
 
@@ -54,7 +54,7 @@ case class TPCHReadConf(
     .option(MAX_PARTITION_BYTES_CONF)
     .sessionConf(s"$TPCH_CONNECTOR_READ_CONF_PREFIX.$MAX_PARTITION_BYTES_CONF")
     .tableProperty(s"$TPCH_CONNECTOR_READ_CONF_PREFIX.$MAX_PARTITION_BYTES_CONF")
-    .defaultValue(MAX_PARTITION_BYTES_DEFAULT)
+    .defaultStringValue(MAX_PARTITION_BYTES_DEFAULT)
     .parse()
 }
 

--- a/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHConf.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHConf.scala
@@ -50,7 +50,7 @@ case class TPCHReadConf(
   private val confParser: SparkConfParser =
     SparkConfParser(options, spark.conf, table.properties)
 
-  lazy val maxPartitionBytes: Long = confParser.longConf()
+  lazy val maxPartitionBytes: Long = confParser.bytesConf()
     .option(MAX_PARTITION_BYTES_CONF)
     .sessionConf(s"$TPCH_CONNECTOR_READ_CONF_PREFIX.$MAX_PARTITION_BYTES_CONF")
     .tableProperty(s"$TPCH_CONNECTOR_READ_CONF_PREFIX.$MAX_PARTITION_BYTES_CONF")

--- a/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHConf.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHConf.scala
@@ -63,9 +63,9 @@ object TPCHConf {
 
   val TPCH_CONNECTOR_CONF_PREFIX = "spark.connector.tpch"
   val USE_ANSI_STRING_TYPE = "useAnsiStringType"
-  val USE_ANSI_STRING_TYPE_DEFAULT = false
+  val USE_ANSI_STRING_TYPE_DEFAULT = "false"
 
   val TPCH_CONNECTOR_READ_CONF_PREFIX = s"$TPCH_CONNECTOR_CONF_PREFIX.read"
   val MAX_PARTITION_BYTES_CONF = "maxPartitionBytes"
-  val MAX_PARTITION_BYTES_DEFAULT: Long = 128 * 1024 * 1024L
+  val MAX_PARTITION_BYTES_DEFAULT = "128m"
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
SparkConfParser supports parse bytes and time for better user experience.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
