### PR TITLE
Fix the problem that |release| in the document was not replaced correctly

### DIFF
--- a/docs/connector/flink/flink_table_store.rst
+++ b/docs/connector/flink/flink_table_store.rst
@@ -42,7 +42,7 @@ Dependencies
 
 The **classpath** of kyuubi flink sql engine with Flink Table Store supported consists of
 
-1. kyuubi-flink-sql-engine-|release|_2.12.jar, the engine jar deployed with Kyuubi distributions
+1. kyuubi-flink-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with Kyuubi distributions
 2. a copy of flink distribution
 3. flink-table-store-dist-<version>.jar (example: flink-table-store-dist-0.2.jar), which can be found in the `Maven Central`_
 

--- a/docs/connector/flink/hudi.rst
+++ b/docs/connector/flink/hudi.rst
@@ -42,7 +42,7 @@ Dependencies
 
 The **classpath** of kyuubi flink sql engine with Hudi supported consists of
 
-1. kyuubi-flink-sql-engine-|release|_2.12.jar, the engine jar deployed with Kyuubi distributions
+1. kyuubi-flink-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with Kyuubi distributions
 2. a copy of flink distribution
 3. hudi-flink<flink.version>-bundle_<scala.version>-<hudi.version>.jar (example: hudi-flink1.14-bundle_2.12-0.11.1.jar), which can be found in the `Maven Central`_
 

--- a/docs/connector/flink/iceberg.rst
+++ b/docs/connector/flink/iceberg.rst
@@ -43,7 +43,7 @@ Dependencies
 
 The **classpath** of kyuubi flink sql engine with Iceberg supported consists of
 
-1. kyuubi-flink-sql-engine-|release|_2.12.jar, the engine jar deployed with Kyuubi distributions
+1. kyuubi-flink-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with Kyuubi distributions
 2. a copy of flink distribution
 3. iceberg-flink-runtime-<flink.version>-<iceberg.version>.jar (example: iceberg-flink-runtime-1.14-0.14.0.jar), which can be found in the `Maven Central`_
 

--- a/docs/connector/spark/delta_lake.rst
+++ b/docs/connector/spark/delta_lake.rst
@@ -46,7 +46,7 @@ Dependencies
 
 The **classpath** of kyuubi spark sql engine with delta lake supported consists of
 
-1. kyuubi-spark-sql-engine-|release|_2.12.jar, the engine jar deployed with kyuubi distributions
+1. kyuubi-spark-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with kyuubi distributions
 2. a copy of spark distribution
 3. delta-core & delta-storage, which can be found in the `Maven Central`_
 

--- a/docs/connector/spark/flink_table_store.rst
+++ b/docs/connector/spark/flink_table_store.rst
@@ -44,7 +44,7 @@ Dependencies
 
 The **classpath** of kyuubi spark sql engine with Flink Table Store supported consists of
 
-1. kyuubi-spark-sql-engine-|release|_2.12.jar, the engine jar deployed with Kyuubi distributions
+1. kyuubi-spark-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with Kyuubi distributions
 2. a copy of spark distribution
 3. flink-table-store-spark-<version>.jar (example: flink-table-store-spark-0.2.jar), which can be found in the `Maven Central`_
 

--- a/docs/connector/spark/hudi.rst
+++ b/docs/connector/spark/hudi.rst
@@ -43,7 +43,7 @@ Dependencies
 
 The **classpath** of kyuubi spark sql engine with Hudi supported consists of
 
-1. kyuubi-spark-sql-engine-|release|_2.12.jar, the engine jar deployed with Kyuubi distributions
+1. kyuubi-spark-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with Kyuubi distributions
 2. a copy of spark distribution
 3. hudi-spark<spark.version>-bundle_<scala.version>-<hudi.version>.jar (example: hudi-spark3.2-bundle_2.12-0.11.1.jar), which can be found in the `Maven Central`_
 

--- a/docs/connector/spark/iceberg.rst
+++ b/docs/connector/spark/iceberg.rst
@@ -45,7 +45,7 @@ Dependencies
 
 The **classpath** of kyuubi spark sql engine with Iceberg supported consists of
 
-1. kyuubi-spark-sql-engine-|release|_2.12.jar, the engine jar deployed with Kyuubi distributions
+1. kyuubi-spark-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with Kyuubi distributions
 2. a copy of spark distribution
 3. iceberg-spark-runtime-<spark.version>_<scala.version>-<iceberg.version>.jar (example: iceberg-spark-runtime-3.2_2.12-0.14.0.jar), which can be found in the `Maven Central`_
 

--- a/docs/connector/spark/tidb.rst
+++ b/docs/connector/spark/tidb.rst
@@ -47,7 +47,7 @@ Dependencies
 ************
 The classpath of kyuubi spark sql engine with TiDB supported consists of
 
-1. kyuubi-spark-sql-engine-|release|_2.12.jar, the engine jar deployed with Kyuubi distributions
+1. kyuubi-spark-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with Kyuubi distributions
 2. a copy of spark distribution
 3. tispark-assembly-<spark.version>_<scala.version>-<tispark.version>.jar (example: tispark-assembly-3.2_2.12-3.0.1.jar), which can be found in the `Maven Central`_
 

--- a/docs/connector/trino/flink_table_store.rst
+++ b/docs/connector/trino/flink_table_store.rst
@@ -43,7 +43,7 @@ Dependencies
 
 The **classpath** of kyuubi trino sql engine with Flink Table Store supported consists of
 
-1. kyuubi-trino-sql-engine-|release|.jar, the engine jar deployed with Kyuubi distributions
+1. kyuubi-trino-sql-engine-\ |release|\ _2.12.jar, the engine jar deployed with Kyuubi distributions
 2. a copy of trino distribution
 3. flink-table-store-trino-<version>.jar (example: flink-table-store-trino-0.2.jar), which code can be found in the `Source Code`_
 4. flink-shaded-hadoop-2-uber-2.8.3-10.0.jar, which code can be found in the `Pre-bundled Hadoop 2.8.3`_


### PR DESCRIPTION
### _Why are the changes needed?_
Fix the problem that `|release|` in the document was not replaced correctly.

Current

<img width="1062" alt="image" src="https://user-images.githubusercontent.com/3898450/185038285-de195262-b911-43dd-b06f-da2a91710f56.png">

Fix

<img width="808" alt="image" src="https://user-images.githubusercontent.com/3898450/185038329-0bf9a437-cedf-42d0-8811-3ead3380a20e.png">



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
