### PR TITLE
[KYUUBI #3217] [DOCS] Doc for using Marcos in row-level filter in Authz

### DIFF
--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -74,9 +74,8 @@ for pointing to the right Ranger admin server.
 
 </configuration>
 ```
-##### Using Marcos in Row Level Filters
-  - Macros are now supported for using user/group/tag in row filter expressions, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify the row-filter condition expression by replacing explicit condition query by using user/group/tag's attributes. Considering a user with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan. More supported marcros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550).
-  - Add the follow configs to `ranger-spark-security.xml` to enable UserStore Enricher which is required by macros and scripts.
+##### Using Macros in Row Level Filters
+  - Macros are now supported for using user/group/tag in row filter expressions, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify row filter expressions by using user/group/tag's attributes instead of explicit conditions. Considering a user with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan. More supported macros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550). Add the following configs to `ranger-spark-security.xml` to enable UserStore Enricher required by macros.
    
 ```xml
     <property>
@@ -88,7 +87,7 @@ for pointing to the right Ranger admin server.
     <property>
         <name>ranger.plugin.hive.policy.cache.dir</name>
         <value>./a ranger hive service name/policycache</value>
-        <description>policycache cache path of hive service def for caching UserStore, Tags, etc.</description>
+        <description>As Authz plugin reuses hive service def, a policy cache path is required for caching UserStore and Tags for "hive" service def, while "ranger.plugin.spark.policy.cache.dir config" is the path for caching policies in service. </description>
     </property>    
 ```
 

--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -74,6 +74,25 @@ for pointing to the right Ranger admin server.
 
 </configuration>
 ```
+- Additional configs for using Marcos in row-level filter
+  - Macros are now supported for using user/group/tag in row-filter condition expression, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify the row-filter condition expression by replacing explicit condition query by using user/group/tag's attributes. 
+  - Consider user `bowenliang123` with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan.
+  - More supported marcros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550).
+  - Add the follow configs to `ranger-spark-security.xml` to enable UserStore Enricher which is required by macros and scripts.
+   
+```xml
+    <property>
+        <name>ranger.plugin.spark.enable.implicit.userstore.enricher</name>
+        <value>true</value>
+        <description>Enable UserStoreEnricher for fetching user and group attributes if using macros or scripts in row-filters since Ranger 2.3</description>
+    </property>
+
+    <property>
+        <name>ranger.plugin.hive.policy.cache.dir</name>
+        <value>./a ranger hive service name/policycache</value>
+        <description>policycache cache path of hive service def for caching UserStore, Tags, etc.</description>
+    </property>    
+```
 
 #### ranger-spark-audit.xml
 

--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -75,7 +75,7 @@ for pointing to the right Ranger admin server.
 </configuration>
 ```
 ##### Using Marcos in Row Level Filters
-  - Macros are now supported for using user/group/tag in row-filter condition expression, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify the row-filter condition expression by replacing explicit condition query by using user/group/tag's attributes. Consider user `bowenliang123` with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan. More supported marcros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550).
+  - Macros are now supported for using user/group/tag in row filter expressions, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify the row-filter condition expression by replacing explicit condition query by using user/group/tag's attributes. Considering a user with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan. More supported marcros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550).
   - Add the follow configs to `ranger-spark-security.xml` to enable UserStore Enricher which is required by macros and scripts.
    
 ```xml

--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -74,7 +74,7 @@ for pointing to the right Ranger admin server.
 
 </configuration>
 ```
-- Additional configs for using Marcos in row-level filter
+##### Using Marcos in Row Level Filters
   - Macros are now supported for using user/group/tag in row-filter condition expression, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify the row-filter condition expression by replacing explicit condition query by using user/group/tag's attributes. 
   - Consider user `bowenliang123` with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan.
   - More supported marcros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550).

--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -75,7 +75,8 @@ for pointing to the right Ranger admin server.
 </configuration>
 ```
 ##### Using Macros in Row Level Filters
-  - Macros are now supported for using user/group/tag in row filter expressions, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify row filter expressions by using user/group/tag's attributes instead of explicit conditions. Considering a user with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan. More supported macros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550). Add the following configs to `ranger-spark-security.xml` to enable UserStore Enricher required by macros.
+
+Macros are now supported for using user/group/tag in row filter expressions, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify row filter expressions by using user/group/tag's attributes instead of explicit conditions. Considering a user with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan. More supported macros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550). Add the following configs to `ranger-spark-security.xml` to enable UserStore Enricher required by macros.
    
 ```xml
     <property>

--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -75,9 +75,7 @@ for pointing to the right Ranger admin server.
 </configuration>
 ```
 ##### Using Marcos in Row Level Filters
-  - Macros are now supported for using user/group/tag in row-filter condition expression, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify the row-filter condition expression by replacing explicit condition query by using user/group/tag's attributes. 
-  - Consider user `bowenliang123` with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan.
-  - More supported marcros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550).
+  - Macros are now supported for using user/group/tag in row-filter condition expression, introduced in [Ranger 2.3](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes). This feature helps significantly simplify the row-filter condition expression by replacing explicit condition query by using user/group/tag's attributes. Consider user `bowenliang123` with an attribute `born_city` of value `Guangzhou `, the row filter condition as `city='${{USER.born_city}}'` will be transformed to `city='Guangzhou'` in execution plan. More supported marcros and usage refer to [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) and [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550).
   - Add the follow configs to `ranger-spark-security.xml` to enable UserStore Enricher which is required by macros and scripts.
    
 ```xml


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Support macros in Row-filter condition expression, introduced in Ranger 2.3 ([release notes](https://cwiki.apache.org/confluence/display/RANGER/Apache+Ranger+2.3.0+-+Release+Notes)), is an major feature to significantly simplify the row-filter condition expression in practice by replacing explicit condition query by using user/group's attributes.

- [RANGER-3605](https://issues.apache.org/jira/browse/RANGER-3605) : Support macros in row-filter/condition expressions
- [RANGER-3550](https://issues.apache.org/jira/browse/RANGER-3550) : support for using user/tag attributes in row-filter expressions and conditions
Consider user liangtiancheng with attribute born_city = guangzhou, we can define the row filter condition with city='${{USER.born_city}}' with the macro feature.

However, This feature implicit relies on an config named `ranger.plugin.spark.enable.implicit.userstore.enricher` and the default value false will prevent RangerUserStoreEnricher fetching user/group and their attributes. Macros in row-filter condition will fallback to null value (as lack of user attributes value in UserStore of auth context) in script transformation unexpectedly and imperceptibly.

Improving doc of ranger-spark-security.xml to aware of this feature and related config.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
