### PR TITLE
[KYUUBI #3222][FOLLOWUP] Fixing placeholder and config of user in JDBC Authentication Provider

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -140,7 +140,7 @@ kyuubi.authentication|NONE|A comma separated list of client authentication types
 kyuubi.authentication.custom.class|&lt;undefined&gt;|User-defined authentication implementation of org.apache.kyuubi.service.authentication.PasswdAuthenticationProvider|string|1.3.0
 kyuubi.authentication.jdbc.driver.class|&lt;undefined&gt;|Driver class name for JDBC Authentication Provider.|string|1.6.0
 kyuubi.authentication.jdbc.password|&lt;undefined&gt;|Database password for JDBC Authentication Provider.|string|1.6.0
-kyuubi.authentication.jdbc.query|&lt;undefined&gt;|Query SQL template with placeholders for JDBC Authentication Provider to execute. Authentication passes if the result set is not empty.The SQL statement must start with the SELECT clause. Available placeholders are `${user}` and `${password}`.|string|1.6.0
+kyuubi.authentication.jdbc.query|&lt;undefined&gt;|Query SQL template with placeholders for JDBC Authentication Provider to execute. Authentication passes if the result set is not empty.The SQL statement must start with the `SELECT` clause. Available placeholders are `${user}` and `${password}`.|string|1.6.0
 kyuubi.authentication.jdbc.url|&lt;undefined&gt;|JDBC URL for JDBC Authentication Provider.|string|1.6.0
 kyuubi.authentication.jdbc.user|&lt;undefined&gt;|Database user for JDBC Authentication Provider.|string|1.6.0
 kyuubi.authentication.ldap.attrs|mail|Specifies part of the search as an attribute returned by LDAP. For example: mail,name.|seq|1.6.0

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -140,9 +140,9 @@ kyuubi.authentication|NONE|A comma separated list of client authentication types
 kyuubi.authentication.custom.class|&lt;undefined&gt;|User-defined authentication implementation of org.apache.kyuubi.service.authentication.PasswdAuthenticationProvider|string|1.3.0
 kyuubi.authentication.jdbc.driver.class|&lt;undefined&gt;|Driver class name for JDBC Authentication Provider.|string|1.6.0
 kyuubi.authentication.jdbc.password|&lt;undefined&gt;|Database password for JDBC Authentication Provider.|string|1.6.0
-kyuubi.authentication.jdbc.query|&lt;undefined&gt;|Query SQL template with placeholders for JDBC Authentication Provider to execute. Authentication passes if at least one row fetched in the result set.Available placeholders are `${username}` and `${password}`.|string|1.6.0
+kyuubi.authentication.jdbc.query|&lt;undefined&gt;|Query SQL template with placeholders for JDBC Authentication Provider to execute. Authentication passes if the result set is not empty.The SQL statement must start with the SELECT clause. Available placeholders are `${user}` and `${password}`.|string|1.6.0
 kyuubi.authentication.jdbc.url|&lt;undefined&gt;|JDBC URL for JDBC Authentication Provider.|string|1.6.0
-kyuubi.authentication.jdbc.username|&lt;undefined&gt;|Database username for JDBC Authentication Provider.|string|1.6.0
+kyuubi.authentication.jdbc.user|&lt;undefined&gt;|Database user for JDBC Authentication Provider.|string|1.6.0
 kyuubi.authentication.ldap.attrs|mail|Specifies part of the search as an attribute returned by LDAP. For example: mail,name.|seq|1.6.0
 kyuubi.authentication.ldap.base.dn|&lt;undefined&gt;|LDAP base DN.|string|1.0.0
 kyuubi.authentication.ldap.binddn|&lt;undefined&gt;|The user with which to bind to the LDAP server, and search for the full domain name of the user being authenticated. For example: uid=admin,cn=Directory Manager,ou=users,dc=example,dc=com|string|1.6.0

--- a/docs/extensions/server/authentication.rst
+++ b/docs/extensions/server/authentication.rst
@@ -66,7 +66,7 @@ Enable Custom Authentication
 
 To enable the custom authentication method, we need to
 
-- put the jar package to ``$KYUUBI_HOME/jars`` directory to make it visible for
+- Put the jar package to ``$KYUUBI_HOME/jars`` directory to make it visible for
   the classpath of the kyuubi server.
 - Configure the following properties to ``$KYUUBI_HOME/conf/kyuubi-defaults.conf``
   on each node where kyuubi server is installed.

--- a/docs/security/jdbc.md
+++ b/docs/security/jdbc.md
@@ -20,7 +20,7 @@
 
 Kyuubi supports authentication via JDBC query. A query is prepared with user/password value and sent to the database configured in JDBC URL. Authentication passes if the result set is not empty.
 
-The query sql must start with `SELECT`. The SQL statement must start with the SELECT clause. Placeholders are supported and listed below for substitution:
+The SQL statement must start with the `SELECT` clause. Placeholders are supported and listed below for substitution:
 - `${user}`
 - `${password}`
 

--- a/docs/security/jdbc.md
+++ b/docs/security/jdbc.md
@@ -25,7 +25,7 @@ The SQL statement must start with the `SELECT` clause. Placeholders are supporte
 - `${password}`
 
 For example, `SELECT 1 FROM auth_db.auth_table WHERE user=${user} AND 
-passwd=MD5(CONCAT(salt,${password}))` will be prepared as: `SELECT 1 FROM auth_db.auth_table WHERE user=? AND passwd=MD5(CONCAT(salt,?))` with value replacement of `user` and `password` in string type.
+passwd=MD5(CONCAT(salt,${password}))` will be prepared as `SELECT 1 FROM auth_db.auth_table WHERE user=? AND passwd=MD5(CONCAT(salt,?))` with value replacement of `user` and `password` in string type.
 
 ## Enable JDBC Authentication 
 

--- a/docs/security/jdbc.md
+++ b/docs/security/jdbc.md
@@ -18,14 +18,14 @@
 
 # Configure Kyuubi to Use JDBC Authentication
 
-Kyuubi supports authentication via JDBC query. A query is prepared with username/password value and sent to the database configured in JDBC URL. The authentication passes if the result set is not empty.
+Kyuubi supports authentication via JDBC query. A query is prepared with user/password value and sent to the database configured in JDBC URL. Authentication passes if the result set is not empty.
 
 The query sql must start with `SELECT`. The SQL statement must start with the SELECT clause. Placeholders are supported and listed below for substitution:
-- `${username}`
+- `${user}`
 - `${password}`
 
-For example, `SELECT 1 FROM auth_db.auth_table WHERE user=${username} AND 
-passwd=MD5(CONCAT(salt,${password}))` will be prepared as: `SELECT 1 FROM auth_db.auth_table WHERE user=? AND passwd=MD5(CONCAT(salt,?))` with value replacement of `username` and `password` in string type.
+For example, `SELECT 1 FROM auth_db.auth_table WHERE user=${user} AND 
+passwd=MD5(CONCAT(salt,${password}))` will be prepared as: `SELECT 1 FROM auth_db.auth_table WHERE user=? AND passwd=MD5(CONCAT(salt,?))` with value replacement of `user` and `password` in string type.
 
 ## Enable JDBC Authentication 
 
@@ -43,7 +43,7 @@ Configure the following properties to `$KYUUBI_HOME/conf/kyuubi-defaults.conf` o
 kyuubi.authentication=JDBC
 kyuubi.authentication.jdbc.driver.class = com.mysql.jdbc.Driver
 kyuubi.authentication.jdbc.url = jdbc:mysql://127.0.0.1:3306/auth_db
-kyuubi.authentication.jdbc.username = bowenliang123
+kyuubi.authentication.jdbc.user = bowenliang123
 kyuubi.authentication.jdbc.password = bowenliang123@kyuubi
-kyuubi.authentication.jdbc.query = SELECT 1 FROM auth_table WHERE user=${username} AND passwd=MD5(CONCAT(salt,${password}))
+kyuubi.authentication.jdbc.query = SELECT 1 FROM auth_table WHERE user=${user} AND passwd=MD5(CONCAT(salt,${password}))
 ```

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -688,9 +688,9 @@ object KyuubiConf {
       .stringConf
       .createOptional
 
-  val AUTHENTICATION_JDBC_USERNAME: OptionalConfigEntry[String] =
-    buildConf("kyuubi.authentication.jdbc.username")
-      .doc("Database username for JDBC Authentication Provider.")
+  val AUTHENTICATION_JDBC_USER: OptionalConfigEntry[String] =
+    buildConf("kyuubi.authentication.jdbc.user")
+      .doc("Database user for JDBC Authentication Provider.")
       .version("1.6.0")
       .stringConf
       .createOptional
@@ -706,8 +706,8 @@ object KyuubiConf {
     buildConf("kyuubi.authentication.jdbc.query")
       .doc("Query SQL template with placeholders " +
         "for JDBC Authentication Provider to execute. " +
-        "Authentication passes if at least one row fetched in the result set." +
-        "Available placeholders are `${username}` and `${password}`.")
+        "Authentication passes if the result set is not empty." +
+        "Available placeholders are `${user}` and `${password}`.")
       .version("1.6.0")
       .stringConf
       .createOptional

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -707,6 +707,7 @@ object KyuubiConf {
       .doc("Query SQL template with placeholders " +
         "for JDBC Authentication Provider to execute. " +
         "Authentication passes if the result set is not empty." +
+        "The SQL statement must start with the SELECT clause. " +
         "Available placeholders are `${user}` and `${password}`.")
       .version("1.6.0")
       .stringConf

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -707,7 +707,7 @@ object KyuubiConf {
       .doc("Query SQL template with placeholders " +
         "for JDBC Authentication Provider to execute. " +
         "Authentication passes if the result set is not empty." +
-        "The SQL statement must start with the SELECT clause. " +
+        "The SQL statement must start with the `SELECT` clause. " +
         "Available placeholders are `${user}` and `${password}`.")
       .version("1.6.0")
       .stringConf

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -98,9 +98,8 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
   }
 
   private def checkJdbcConfigs(): Unit = {
-    val configLog =
-      (config: String, value: Option[String]) =>
-        s"JDBCAuthConfig: $config = '${value.orNull}'"
+    val configLog = (config: String, value: Option[String]) =>
+      s"JDBCAuthConfig: $config = '${value.orNull}'"
 
     debug(configLog("Driver Class", driverClass))
     debug(configLog("JDBC URL", authDbJdbcUrl))

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -42,8 +42,6 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
   private val authDbPassword = conf.get(AUTHENTICATION_JDBC_PASSWORD)
   private val authQuery = conf.get(AUTHENTICATION_JDBC_QUERY)
 
-
-
   checkJdbcConfigs()
 
   implicit private[kyuubi] val ds: DataSource = new DriverDataSource(

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -98,13 +98,16 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
   }
 
   private def checkJdbcConfigs(): Unit = {
-    def configLog(config: String, value: String): String = s"JDBCAuthConfig: $config = '$value'"
+    val configLog = {
+      case (config: String, value: Option[String]) => s"JDBCAuthConfig: $config = '${value.orNull}'"
+      case (config: String, value: String) => s"JDBCAuthConfig: $config = '$value'"
+    }
 
-    debug(configLog("Driver Class", driverClass.orNull))
-    debug(configLog("JDBC URL", authDbJdbcUrl.orNull))
-    debug(configLog("Database user", authDbUser.orNull))
+    debug(configLog("Driver Class", driverClass))
+    debug(configLog("JDBC URL", authDbJdbcUrl))
+    debug(configLog("Database user", authDbUser))
     debug(configLog("Database password", JdbcUtils.redactPassword(authDbPassword)))
-    debug(configLog("Query SQL", authQuery.orNull))
+    debug(configLog("Query SQL", authQuery))
 
     // Check if JDBC parameters valid
     require(driverClass.nonEmpty, "JDBC driver class is not configured.")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -74,13 +74,11 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
     try {
       debug(s"prepared auth query: $preparedQuery")
       JdbcUtils.executeQuery(preparedQuery) { pStmt =>
-        queryPlaceholders.zipWithIndex.map({
-          case (USER_SQL_PLACEHOLDER, i) => (user, i)
-          case (PASSWORD_SQL_PLACEHOLDER, i) => (password, i)
+        queryPlaceholders.zipWithIndex.foreach {
+          case (USER_SQL_PLACEHOLDER, i) => pStmt.setString(i + 1, user)
+          case (PASSWORD_SQL_PLACEHOLDER, i) => pStmt.setString(i + 1, password)
           case (p, _) => throw new IllegalArgumentException(
               s"Unrecognized placeholder in Query SQL: $p")
-        }).foreach {
-          case (value: String, i: Int) => pStmt.setString(i + 1, value)
         }
         pStmt.setMaxRows(1) // skipping more result rows to minimize I/O
       } { resultSet =>
@@ -139,5 +137,4 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
 
   private def queryPlaceholders: Iterator[String] =
     SQL_PLACEHOLDER_REGEX.findAllMatchIn(authQuery.get).map(_.matched)
-
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -98,15 +98,14 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
   }
 
   private def checkJdbcConfigs(): Unit = {
-    val configLog = {
-      case (config: String, value: Option[String]) => s"JDBCAuthConfig: $config = '${value.orNull}'"
-      case (config: String, value: String) => s"JDBCAuthConfig: $config = '$value'"
-    }
+    val configLog =
+      (config: String, value: Option[String]) =>
+        s"JDBCAuthConfig: $config = '${value.orNull}'"
 
     debug(configLog("Driver Class", driverClass))
     debug(configLog("JDBC URL", authDbJdbcUrl))
     debug(configLog("Database user", authDbUser))
-    debug(configLog("Database password", JdbcUtils.redactPassword(authDbPassword)))
+    debug(configLog("Database password", Some(JdbcUtils.redactPassword(authDbPassword))))
     debug(configLog("Query SQL", authQuery))
 
     // Check if JDBC parameters valid

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -126,10 +126,9 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
       warn(s"Query SQL does not contains '$PASSWORD_SQL_PLACEHOLDER' placeholder")
     }
 
-    queryPlaceholders.foreach {
-      case unsupported if !supportedPlaceholders.contains(unsupported) =>
-        throw new IllegalArgumentException(s"Unsupported placeholder in Query SQL: $unsupported")
-      case _ =>
+    queryPlaceholders.foreach { placeholder =>
+      require(supportedPlaceholders.contains(placeholder),
+        s"Unsupported placeholder in Query SQL: $placeholder")
     }
   }
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -79,7 +79,7 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
               s"Unrecognized placeholder in Query SQL: $p")
         }
       } { resultSet =>
-        if (resultSet == null || !resultSet.next()) {
+        if (!resultSet.next()) {
           throw new AuthenticationException("Password does not match or no such user. " +
             s"user: $user, password: ${JdbcUtils.redactPassword(Some(password))}")
         }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -70,16 +70,16 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
 
     try {
       debug(s"prepared auth query: $preparedQuery")
-      JdbcUtils.executeQuery(preparedQuery) { stmt =>
+      JdbcUtils.executeQuery(preparedQuery) { pStmt =>
         queryPlaceholders.zipWithIndex.map({
           case (USER_SQL_PLACEHOLDER, i) => (user, i)
           case (PASSWORD_SQL_PLACEHOLDER, i) => (password, i)
           case (p, _) => throw new IllegalArgumentException(
             s"Unrecognized placeholder in Query SQL: $p")
         }).foreach {
-          case (value: String, i: Int) => stmt.setString(i + 1, value)
+          case (value: String, i: Int) => pStmt.setString(i + 1, value)
         }
-        stmt.setMaxRows(1) // skipping more result rows to minimize I/O
+        pStmt.setMaxRows(1) // skipping more result rows to minimize I/O
       } { resultSet =>
         if (!resultSet.next()) {
           throw new AuthenticationException("Password does not match or no such user. " +

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -127,7 +127,8 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
     }
 
     queryPlaceholders.foreach { placeholder =>
-      require(supportedPlaceholders.contains(placeholder),
+      require(
+        supportedPlaceholders.contains(placeholder),
         s"Unsupported placeholder in Query SQL: $placeholder")
     }
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -71,13 +71,13 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
     try {
       debug(s"prepared auth query: $preparedQuery")
       JdbcUtils.executeQuery(preparedQuery) { stmt =>
-        stmt.setMaxRows(1) // minimum result size required for authentication
         queryPlaceholders.zipWithIndex.foreach {
           case (USER_SQL_PLACEHOLDER, i) => stmt.setString(i + 1, user)
           case (PASSWORD_SQL_PLACEHOLDER, i) => stmt.setString(i + 1, password)
           case (p, _) => throw new IllegalArgumentException(
               s"Unrecognized placeholder in Query SQL: $p")
         }
+        stmt.setMaxRows(1) // skipping more result rows to minimize I/O
       } { resultSet =>
         if (!resultSet.next()) {
           throw new AuthenticationException("Password does not match or no such user. " +

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImpl.scala
@@ -80,9 +80,8 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
         }
       } { resultSet =>
         if (resultSet == null || !resultSet.next()) {
-          val redactedPassword = redactPassword(Some(password))
           throw new AuthenticationException("Password does not match or no such user. " +
-            s"user: $user, password: $redactedPassword")
+            s"user: $user, password: ${JdbcUtils.redactPassword(Some(password))}")
         }
       }
     } catch {
@@ -99,7 +98,7 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
     debug(configLog("Driver Class", driverClass.orNull))
     debug(configLog("JDBC URL", authDbJdbcUrl.orNull))
     debug(configLog("Database user", authDbUser.orNull))
-    debug(configLog("Database password", redactPassword(authDbPassword)))
+    debug(configLog("Database password", JdbcUtils.redactPassword(authDbPassword)))
     debug(configLog("Query SQL", authQuery.orNull))
 
     // Check if JDBC parameters valid
@@ -129,10 +128,4 @@ class JdbcAuthenticationProviderImpl(conf: KyuubiConf) extends PasswdAuthenticat
   private def queryPlaceholders: Iterator[String] =
     SQL_PLACEHOLDER_REGEX.findAllMatchIn(authQuery.get).map(_.matched)
 
-  private def redactPassword(password: Option[String]): String = {
-    password match {
-      case Some(s) if !StringUtils.isBlank(s) => s"${"*" * s.length}(length: ${s.length})"
-      case None => "(empty)"
-    }
-  }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/JdbcUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/JdbcUtils.scala
@@ -100,8 +100,8 @@ object JdbcUtils extends Logging {
 
   def redactPassword(password: Option[String]): String = {
     password match {
-      case Some(s) if !StringUtils.isBlank(s) => s"${"*" * s.length}(length:${s.length})"
-      case None => "(empty)"
+      case Some(s) if StringUtils.isNotBlank(s) => s"${"*" * s.length}(length:${s.length})"
+      case _ => "(empty)"
     }
   }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/JdbcUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/JdbcUtils.scala
@@ -22,6 +22,8 @@ import javax.sql.DataSource
 
 import scala.util.control.NonFatal
 
+import org.apache.commons.lang3.StringUtils
+
 import org.apache.kyuubi.Logging
 
 object JdbcUtils extends Logging {
@@ -93,6 +95,13 @@ object JdbcUtils extends Logging {
         while (rs.next()) builder += rowMapper(rs)
         builder.result
       }
+    }
+  }
+
+  def redactPassword(password: Option[String]): String = {
+    password match {
+      case Some(s) if !StringUtils.isBlank(s) => s"${"*" * s.length}(length:${s.length})"
+      case None => "(empty)"
     }
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
@@ -146,9 +146,8 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
     _conf.set(
       AUTHENTICATION_JDBC_QUERY,
       "SELECT 1 FROM user_auth WHERE unknown_column=${user} and passwd=${password}")
-    val providerImpl2 = new JdbcAuthenticationProviderImpl(_conf)
     val e12 = intercept[AuthenticationException] {
-      providerImpl2.authenticate(authUser, authPasswd)
+      new JdbcAuthenticationProviderImpl(_conf).authenticate(authUser, authPasswd)
     }
     assert(e12.getCause.getMessage.contains("Column 'UNKNOWN_COLUMN' is either not in any table"))
   }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
@@ -96,7 +96,7 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
     assert(e4.isInstanceOf[AuthenticationException])
     assert(e4.getMessage.contains(s"Password does not match or no such user. " +
       s"user: $authUser, " +
-      s"password: ${"*" * authPasswd.length}(length: ${authPasswd.length})"))
+      s"password: ${"*" * authPasswd.length}(length:${authPasswd.length})"))
 
     var _conf = conf.clone
     _conf.unset(AUTHENTICATION_JDBC_URL)

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
@@ -17,16 +17,17 @@
 
 package org.apache.kyuubi.service.authentication
 
-import com.zaxxer.hikari.util.DriverDataSource
-import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf._
-import org.apache.kyuubi.util.JdbcUtils
-import org.apache.kyuubi.{KyuubiFunSuite, Utils}
-
 import java.sql.DriverManager
 import java.util.Properties
 import javax.security.sasl.AuthenticationException
 import javax.sql.DataSource
+
+import com.zaxxer.hikari.util.DriverDataSource
+
+import org.apache.kyuubi.{KyuubiFunSuite, Utils}
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.util.JdbcUtils
 
 class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
   protected val dbUser: String = "liangbowen"

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
@@ -122,5 +122,15 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
     _conf.unset(AUTHENTICATION_JDBC_URL)
     val e10 = intercept[IllegalArgumentException] { new JdbcAuthenticationProviderImpl(_conf) }
     assert(e10.getMessage.contains("JDBC url is not configured"))
+
+    _conf = conf.clone
+    _conf.set(AUTHENTICATION_JDBC_QUERY, "SELECT 1 FROM user_auth")
+    new JdbcAuthenticationProviderImpl(_conf)
+
+    _conf.set(AUTHENTICATION_JDBC_QUERY, "SELECT 1 FROM user_auth WHERE passwd=${password}")
+    new JdbcAuthenticationProviderImpl(_conf)
+
+    _conf.set(AUTHENTICATION_JDBC_QUERY, "SELECT 1 FROM user_auth WHERE username=${user}")
+    new JdbcAuthenticationProviderImpl(_conf)
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
@@ -30,8 +30,8 @@ import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.util.JdbcUtils
 
 class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
-  protected val dbUser: String = "liangbowen"
-  protected val dbPasswd: String = "liangbowen"
+  protected val dbUser: String = "bowenliang123"
+  protected val dbPasswd: String = "bowenliang123@kyuubi"
   protected val authDbName: String = "auth_db"
   protected val dbUrl: String = s"jdbc:derby:memory:$authDbName"
   protected val jdbcUrl: String = s"$dbUrl;create=true"
@@ -44,8 +44,8 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
     dbUser,
     dbPasswd)
 
-  protected val authUser: String = "liangtiancheng"
-  protected val authPasswd: String = "liangtiancheng"
+  protected val authUser: String = "kyuubiuser"
+  protected val authPasswd: String = "kyuubiuuserpassword"
 
   protected val conf: KyuubiConf = new KyuubiConf()
     .set(AUTHENTICATION_JDBC_DRIVER, authDbDriverClz)
@@ -90,13 +90,14 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
     }
     assert(e1.getMessage.contains("user is null"))
 
+    val wrong_password = "wrong_password"
     val e4 = intercept[AuthenticationException] {
-      providerImpl.authenticate(authUser, "wrong_password")
+      providerImpl.authenticate(authUser, wrong_password)
     }
     assert(e4.isInstanceOf[AuthenticationException])
     assert(e4.getMessage.contains(s"Password does not match or no such user. " +
       s"user: $authUser, " +
-      s"password: ${"*" * authPasswd.length}(length:${authPasswd.length})"))
+      s"password: ${"*" * wrong_password.length}(length:${wrong_password.length})"))
 
     var _conf = conf.clone
     _conf.unset(AUTHENTICATION_JDBC_URL)

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
@@ -132,5 +132,13 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
 
     _conf.set(AUTHENTICATION_JDBC_QUERY, "SELECT 1 FROM user_auth WHERE username=${user}")
     new JdbcAuthenticationProviderImpl(_conf)
+
+    _conf.set(AUTHENTICATION_JDBC_QUERY,
+      "SELECT 1 FROM user_auth WHERE user=${unknown_placeholder} and username=${user}")
+    val providerImpl2 = new JdbcAuthenticationProviderImpl(_conf)
+    val e11 = intercept[AuthenticationException] {
+      providerImpl2.authenticate(authUser, authPasswd)
+    }
+    assert(e11.getMessage.contains("Unrecognized placeholder in Query SQL: ${unknown_placeholder}"))
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
@@ -35,10 +35,11 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
   protected val authDbName: String = "auth_db"
   protected val dbUrl: String = s"jdbc:derby:memory:$authDbName"
   protected val jdbcUrl: String = s"$dbUrl;create=true"
+  private val authDbDriverClz = "org.apache.derby.jdbc.AutoloadedDriver"
 
   implicit private val ds: DataSource = new DriverDataSource(
     jdbcUrl,
-    "org.apache.derby.jdbc.AutoloadedDriver",
+    authDbDriverClz,
     new Properties,
     dbUser,
     dbPasswd)
@@ -47,13 +48,13 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
   protected val authPasswd: String = "liangtiancheng"
 
   protected val conf: KyuubiConf = new KyuubiConf()
-    .set(AUTHENTICATION_JDBC_DRIVER, "org.apache.derby.jdbc.AutoloadedDriver")
+    .set(AUTHENTICATION_JDBC_DRIVER, authDbDriverClz)
     .set(AUTHENTICATION_JDBC_URL, jdbcUrl)
-    .set(AUTHENTICATION_JDBC_USERNAME, dbUser)
+    .set(AUTHENTICATION_JDBC_USER, dbUser)
     .set(AUTHENTICATION_JDBC_PASSWORD, dbPasswd)
     .set(
       AUTHENTICATION_JDBC_QUERY,
-      "SELECT 1 FROM user_auth WHERE username=${username} and passwd=${password}")
+      "SELECT 1 FROM user_auth WHERE username=${user} and passwd=${password}")
 
   override def beforeAll(): Unit = {
     // init db
@@ -100,9 +101,9 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
     assert(e5.getMessage.contains("JDBC url is not configured"))
 
     _conf = conf.clone
-    _conf.unset(AUTHENTICATION_JDBC_USERNAME)
+    _conf.unset(AUTHENTICATION_JDBC_USER)
     val e6 = intercept[IllegalArgumentException] { new JdbcAuthenticationProviderImpl(_conf) }
-    assert(e6.getMessage.contains("JDBC username is not configured"))
+    assert(e6.getMessage.contains("JDBC user is not configured"))
 
     _conf = conf.clone
     _conf.unset(AUTHENTICATION_JDBC_QUERY)
@@ -111,7 +112,7 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
 
     _conf.set(
       AUTHENTICATION_JDBC_QUERY,
-      "INSERT INTO user_auth (username, password) VALUES ('demouser','demopassword');")
+      "INSERT INTO user_auth (user, password) VALUES ('demouser','demopassword');")
     val e9 = intercept[IllegalArgumentException] { new JdbcAuthenticationProviderImpl(_conf) }
     assert(e9.getMessage.contains("Query SQL must start with 'SELECT'"))
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/service/authentication/JdbcAuthenticationProviderImplSuite.scala
@@ -17,17 +17,16 @@
 
 package org.apache.kyuubi.service.authentication
 
+import com.zaxxer.hikari.util.DriverDataSource
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.util.JdbcUtils
+import org.apache.kyuubi.{KyuubiFunSuite, Utils}
+
 import java.sql.DriverManager
 import java.util.Properties
 import javax.security.sasl.AuthenticationException
 import javax.sql.DataSource
-
-import com.zaxxer.hikari.util.DriverDataSource
-
-import org.apache.kyuubi.{KyuubiFunSuite, Utils}
-import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf._
-import org.apache.kyuubi.util.JdbcUtils
 
 class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
   protected val dbUser: String = "liangbowen"
@@ -94,6 +93,9 @@ class JdbcAuthenticationProviderImplSuite extends KyuubiFunSuite {
       providerImpl.authenticate(authUser, "wrong_password")
     }
     assert(e4.isInstanceOf[AuthenticationException])
+    assert(e4.getMessage.contains(s"Password does not match or no such user. " +
+      s"user: $authUser, " +
+      s"password: ${"*" * authPasswd.length}(length: ${authPasswd.length})"))
 
     var _conf = conf.clone
     _conf.unset(AUTHENTICATION_JDBC_URL)

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/util/JdbcUtilsSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/util/JdbcUtilsSuite.scala
@@ -78,6 +78,5 @@ class JdbcUtilsSuite extends KyuubiFunSuite {
       JdbcUtils.redactPassword(None)
     }
 
-
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/util/JdbcUtilsSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/util/JdbcUtilsSuite.scala
@@ -65,5 +65,9 @@ class JdbcUtilsSuite extends KyuubiFunSuite {
       assert(rs.next())
       assert(!rs.next())
     }
+
+    assertResult("****************(length:16)") {
+      JdbcUtils.redactPassword(Some("sample_pass_word"))
+    }
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/util/JdbcUtilsSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/util/JdbcUtilsSuite.scala
@@ -69,5 +69,15 @@ class JdbcUtilsSuite extends KyuubiFunSuite {
     assertResult("****************(length:16)") {
       JdbcUtils.redactPassword(Some("sample_pass_word"))
     }
+
+    assertResult("(empty)") {
+      JdbcUtils.redactPassword(Some(""))
+    }
+
+    assertResult("(empty)") {
+      JdbcUtils.redactPassword(None)
+    }
+
+
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

To fix the config name and placeholder with `username` introduced in https://github.com/apache/incubator-kyuubi/pull/3235 violate this convention as in JDBC driver use `user` keyword used for connection user rather than `username`, 

1. change config name from `kyuubi.authentication.jdbc.username` to `kyuubi.authentication.jdbc.user`
2. change placeholder from `${username}` to `${user}`
3. update docs and config description related to above changes, and sync the update in jdbc auth docs statement details to config docs.
4. fix error in throwing AuthenticationException with auth db password. ut added for the fix.
5. other minor update in docs of custom auth


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
