### PR TITLE
Filter Spark event logger outside the spark engine

### DIFF
--- a/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/HiveSQLEngine.scala
+++ b/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/HiveSQLEngine.scala
@@ -26,7 +26,6 @@ import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.{KyuubiConf, KyuubiReservedKeys}
-import org.apache.kyuubi.config.KyuubiConf.ENGINE_EVENT_LOGGERS
 import org.apache.kyuubi.engine.hive.HiveSQLEngine.currentEngine
 import org.apache.kyuubi.engine.hive.events.{HiveEngineEvent, HiveEventHandlerRegister}
 import org.apache.kyuubi.events.EventBus
@@ -66,7 +65,6 @@ object HiveSQLEngine extends Logging {
   var currentEngine: Option[HiveSQLEngine] = None
   val hiveConf = new HiveConf()
   val kyuubiConf = new KyuubiConf()
-  kyuubiConf.set(ENGINE_EVENT_LOGGERS.key, "JSON")
 
   def startEngine(): Unit = {
     try {

--- a/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/event/HiveEventLoggingServiceSuite.scala
+++ b/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/event/HiveEventLoggingServiceSuite.scala
@@ -26,16 +26,17 @@ import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path}
 
 import org.apache.kyuubi.Utils
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.ENGINE_EVENT_JSON_LOG_PATH
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_JSON_LOG_PATH, ENGINE_EVENT_LOGGERS}
 import org.apache.kyuubi.engine.hive.HiveSQLEngine
 import org.apache.kyuubi.engine.hive.events.{HiveEngineEvent, HiveOperationEvent, HiveSessionEvent}
-import org.apache.kyuubi.events.JsonProtocol
+import org.apache.kyuubi.events.{EventLoggerType, JsonProtocol}
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
 import org.apache.kyuubi.service.ServiceState
 
 class HiveEventLoggingServiceSuite extends HiveJDBCTestHelper {
 
   private val kyuubiConf = new KyuubiConf()
+    .set(ENGINE_EVENT_LOGGERS.key, EventLoggerType.JSON.toString)
   private val logRoot = kyuubiConf.get(ENGINE_EVENT_JSON_LOG_PATH)
   private val currentDate = Utils.getDateFromTimestamp(System.currentTimeMillis())
   private val hostName = InetAddress.getLocalHost.getCanonicalHostName

--- a/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/event/HiveEventLoggingServiceSuite.scala
+++ b/externals/kyuubi-hive-sql-engine/src/test/scala/org/apache/kyuubi/engine/hive/event/HiveEventLoggingServiceSuite.scala
@@ -25,8 +25,8 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path}
 
 import org.apache.kyuubi.Utils
-import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_JSON_LOG_PATH, ENGINE_EVENT_LOGGERS}
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_JSON_LOG_PATH, ENGINE_EVENT_LOGGERS, ENGINE_TYPE}
+import org.apache.kyuubi.engine.EngineType
 import org.apache.kyuubi.engine.hive.HiveSQLEngine
 import org.apache.kyuubi.engine.hive.events.{HiveEngineEvent, HiveOperationEvent, HiveSessionEvent}
 import org.apache.kyuubi.events.{EventLoggerType, JsonProtocol}
@@ -35,7 +35,8 @@ import org.apache.kyuubi.service.ServiceState
 
 class HiveEventLoggingServiceSuite extends HiveJDBCTestHelper {
 
-  private val kyuubiConf = new KyuubiConf()
+  private val kyuubiConf = HiveSQLEngine.kyuubiConf
+    .set(ENGINE_TYPE.key, EngineType.HIVE_SQL.toString)
     .set(ENGINE_EVENT_LOGGERS.key, EventLoggerType.JSON.toString)
   private val logRoot = kyuubiConf.get(ENGINE_EVENT_JSON_LOG_PATH)
   private val currentDate = Utils.getDateFromTimestamp(System.currentTimeMillis())

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoSqlEngine.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoSqlEngine.scala
@@ -24,7 +24,6 @@ import scala.util.control.NonFatal
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.Utils.{addShutdownHook, TRINO_ENGINE_SHUTDOWN_PRIORITY}
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.ENGINE_EVENT_LOGGERS
 import org.apache.kyuubi.engine.trino.TrinoSqlEngine.{countDownLatch, currentEngine}
 import org.apache.kyuubi.engine.trino.event.{TrinoEngineEvent, TrinoEventHandlerRegister}
 import org.apache.kyuubi.events.EventBus
@@ -59,7 +58,6 @@ object TrinoSqlEngine extends Logging {
   private val countDownLatch = new CountDownLatch(1)
 
   val kyuubiConf: KyuubiConf = KyuubiConf()
-    .set(ENGINE_EVENT_LOGGERS.key, "JSON")
 
   var currentEngine: Option[TrinoSqlEngine] = None
 

--- a/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/event/TrinoSqlEventSuite.scala
+++ b/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/event/TrinoSqlEventSuite.scala
@@ -25,7 +25,8 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path}
 
 import org.apache.kyuubi.Utils
-import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_JSON_LOG_PATH, ENGINE_EVENT_LOGGERS, ENGINE_SHARE_LEVEL, ENGINE_TRINO_CONNECTION_CATALOG}
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_JSON_LOG_PATH, ENGINE_EVENT_LOGGERS, ENGINE_SHARE_LEVEL, ENGINE_TRINO_CONNECTION_CATALOG, ENGINE_TYPE}
+import org.apache.kyuubi.engine.EngineType
 import org.apache.kyuubi.engine.trino.WithTrinoEngine
 import org.apache.kyuubi.events.{EventLoggerType, JsonProtocol}
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
@@ -38,6 +39,7 @@ class TrinoSqlEventSuite extends WithTrinoEngine with HiveJDBCTestHelper {
   private val hostName = InetAddress.getLocalHost.getCanonicalHostName
 
   override def withKyuubiConf: Map[String, String] = Map(
+    ENGINE_TYPE.key -> EngineType.TRINO.toString,
     ENGINE_TRINO_CONNECTION_CATALOG.key -> "memory",
     ENGINE_SHARE_LEVEL.key -> "SERVER",
     ENGINE_EVENT_LOGGERS.key -> EventLoggerType.JSON.toString)

--- a/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/event/TrinoSqlEventSuite.scala
+++ b/externals/kyuubi-trino-engine/src/test/scala/org/apache/kyuubi/engine/trino/event/TrinoSqlEventSuite.scala
@@ -25,9 +25,9 @@ import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, FSDataInputStream, Path}
 
 import org.apache.kyuubi.Utils
-import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_JSON_LOG_PATH, ENGINE_SHARE_LEVEL, ENGINE_TRINO_CONNECTION_CATALOG}
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_JSON_LOG_PATH, ENGINE_EVENT_LOGGERS, ENGINE_SHARE_LEVEL, ENGINE_TRINO_CONNECTION_CATALOG}
 import org.apache.kyuubi.engine.trino.WithTrinoEngine
-import org.apache.kyuubi.events.JsonProtocol
+import org.apache.kyuubi.events.{EventLoggerType, JsonProtocol}
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
 import org.apache.kyuubi.service.ServiceState
 
@@ -39,7 +39,8 @@ class TrinoSqlEventSuite extends WithTrinoEngine with HiveJDBCTestHelper {
 
   override def withKyuubiConf: Map[String, String] = Map(
     ENGINE_TRINO_CONNECTION_CATALOG.key -> "memory",
-    ENGINE_SHARE_LEVEL.key -> "SERVER")
+    ENGINE_SHARE_LEVEL.key -> "SERVER",
+    ENGINE_EVENT_LOGGERS.key -> EventLoggerType.JSON.toString)
 
   override protected val schema = "default"
 

--- a/kyuubi-events/src/main/scala/org/apache/kyuubi/events/EventHandlerRegister.scala
+++ b/kyuubi-events/src/main/scala/org/apache/kyuubi/events/EventHandlerRegister.scala
@@ -18,14 +18,22 @@ package org.apache.kyuubi.events
 
 import org.apache.kyuubi.{KyuubiException, Logging}
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_LOGGERS, SERVER_EVENT_LOGGERS}
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_EVENT_LOGGERS, ENGINE_TYPE, SERVER_EVENT_LOGGERS}
+import org.apache.kyuubi.engine.EngineType
 import org.apache.kyuubi.events.EventLoggerType.EventLoggerType
 import org.apache.kyuubi.events.handler.EventHandler
 
 trait EventHandlerRegister extends Logging {
 
   def registerEngineEventLoggers(conf: KyuubiConf): Unit = {
-    val loggers = conf.get(ENGINE_EVENT_LOGGERS)
+    val engineType = conf.get(ENGINE_TYPE)
+    val loggers =
+      if (!EngineType.SPARK_SQL.toString.equalsIgnoreCase(engineType)) {
+        conf.get(ENGINE_EVENT_LOGGERS).filter(!EventLoggerType.SPARK.toString.equalsIgnoreCase(_))
+      } else {
+        conf.get(ENGINE_EVENT_LOGGERS)
+      }
+
     register(loggers, conf)
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The default value of kyuubi.engine.event.loggers is SPARK, but it can't be used outside the spark engine, so filter it.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
