### PR TITLE
[KYUUBI #3272] Synchronize graceful shutdown with main stop sequence

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/KyuubiServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/KyuubiServiceDiscovery.scala
@@ -32,6 +32,7 @@ class KyuubiServiceDiscovery(
     if (!isServerLost.get()) {
       discoveryClient.deregisterService()
       discoveryClient.closeClient()
+      gracefulShutdownLatch.await() // wait for graceful shutdown triggered by watcher
     } else {
       warn(s"The Zookeeper ensemble is LOST")
     }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceDiscovery.scala
@@ -17,6 +17,7 @@
 
 package org.apache.kyuubi.ha.client
 
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.atomic.AtomicBoolean
 
 import org.apache.kyuubi.Logging
@@ -34,6 +35,7 @@ abstract class ServiceDiscovery(
     name: String,
     val fe: FrontendService) extends AbstractService(name) {
 
+  protected val gracefulShutdownLatch = new CountDownLatch(1)
   protected val isServerLost = new AtomicBoolean(false)
 
   /**
@@ -68,6 +70,7 @@ abstract class ServiceDiscovery(
       Thread.sleep(1000 * 60)
     }
     isServerLost.set(isLost)
+    gracefulShutdownLatch.countDown()
     fe.serverable.stop()
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fixes #3272 

Kyuubi server stop sequence doesn't respect graceful shutdown triggered in the discovery clients' `DeRegisterWatcher` loops. This leads to frontend service components being stopped before sessions close, resetting connections and leading to client disruption.

PR synchronizes these threads to ensure that service components wait for client sessions to close before continuing the stop sequence. 
* Existing service discovery deregistration functionality is maintained to ensure that new connections are established with healthy instances once the stop sequence has begun.
* Existing Hadoop shutdown hooks ensure that the watcher can be timed out, and are configurable via `hadoop.service.shutdown.timeout`. The Kyuubi server will always shut down within 30 seconds when using default config.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
