### PR TITLE
[KYUUBI #3064] Fix scala NPE issue when adding non-local jar URI to class loader

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -19,6 +19,7 @@ package org.apache.kyuubi.engine.spark.operation
 
 import java.io.File
 
+import scala.reflect.internal.util.ScalaClassLoader.URLClassLoader
 import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}
 
 import org.apache.hadoop.fs.Path
@@ -68,7 +69,8 @@ class ExecuteScala(
       if (legacyOutput.nonEmpty) {
         warn(s"Clearing legacy output from last interpreting:\n $legacyOutput")
       }
-      spark.sharedState.jarClassLoader.getURLs.foreach { jar =>
+      val replUrls = repl.classLoader.getParent.asInstanceOf[URLClassLoader].getURLs
+      spark.sharedState.jarClassLoader.getURLs.filterNot(replUrls.contains).foreach { jar =>
         try {
           if ("file".equals(jar.toURI.getScheme)) {
             repl.addUrlsToClassPath(jar)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -77,7 +77,10 @@ class ExecuteScala(
           } else {
             spark.sparkContext.addFile(jar.toString)
             val localJarFile = new File(SparkFiles.get(new Path(jar.toURI.getPath).getName))
-            repl.addUrlsToClassPath(localJarFile.toURI.toURL)
+            val localJarUrl = localJarFile.toURI.toURL
+            if (!replUrls.contains(localJarUrl)) {
+              repl.addUrlsToClassPath(localJarUrl)
+            }
           }
         } catch {
           case e: Throwable => error(s"Error adding $jar to repl class path", e)

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteScala.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.engine.spark.operation
 
-import java.net.URL
+import java.io.File
 
 import scala.tools.nsc.interpreter.Results.{Error, Incomplete, Success}
 
@@ -73,12 +73,12 @@ class ExecuteScala(
           if ("file".equals(jar.toURI.getScheme)) {
             repl.addUrlsToClassPath(jar)
           } else {
-            val fileName = new Path(jar.toURI.getPath).getName
-            val localJarUrl = new URL(SparkFiles.get(fileName))
-            repl.addUrlsToClassPath(localJarUrl)
+            spark.sparkContext.addFile(jar.toString)
+            val localJarFile = new File(SparkFiles.get(new Path(jar.toURI.getPath).getName))
+            repl.addUrlsToClassPath(localJarFile.toURI.toURL)
           }
         } catch {
-          case e: Throwable => error(s"Error adding $jar to class loader", e)
+          case e: Throwable => error(s"Error adding $jar to repl class path", e)
         }
       }
 

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -33,7 +33,7 @@ trait SparkQueryTests extends HiveJDBCTestHelper {
 
   protected lazy val SPARK_ENGINE_MAJOR_MINOR_VERSION: (Int, Int) = sparkEngineMajorMinorVersion
 
-  protected lazy val httpMode = false;
+  protected lazy val httpMode = false
 
   test("execute statement - select null") {
     withJdbcStatement() { statement =>

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSecuredDFSService.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSecuredDFSService.scala
@@ -60,4 +60,5 @@ trait WithSecuredDFSService extends KerberizedTestHelper {
   }
 
   def getHadoopConf: Configuration = miniDFSService.getHadoopConf
+  def getHadoopConfDir: String = miniDFSService.getHadoopConfDir
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSimpleDFSService.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithSimpleDFSService.scala
@@ -41,6 +41,7 @@ trait WithSimpleDFSService extends KyuubiFunSuite {
   }
 
   def getHadoopConf: Configuration = miniDFSService.getHadoopConf
+  def getHadoopConfDir: String = miniDFSService.getHadoopConfDir
 
   def getDefaultFS: String = miniDFSService.getHadoopConf.get("fs.defaultFS")
   def getDFSPort: Int = miniDFSService.getDFSPort

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/MiniDFSService.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/MiniDFSService.scala
@@ -17,19 +17,24 @@
 
 package org.apache.kyuubi.server
 
+import java.io.{File, FileWriter}
+import java.net.InetAddress
+
+import scala.collection.JavaConverters._
+
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.hdfs.MiniDFSCluster
 import org.apache.hadoop.hdfs.client.HdfsClientConfigKeys
 import org.apache.hadoop.security.UserGroupInformation
 
-import org.apache.kyuubi.Logging
+import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.service.AbstractService
 
 class MiniDFSService(name: String, hdfsConf: Configuration)
   extends AbstractService(name)
   with Logging {
-
+  private val hadoopConfDir: File = Utils.createTempDir().toFile
   private var hdfsCluster: MiniDFSCluster = _
 
   def this(hdfsConf: Configuration = new Configuration()) =
@@ -55,6 +60,7 @@ class MiniDFSService(name: String, hdfsConf: Configuration)
       s"NameNode address in configuration is " +
         s"${hdfsConf.get(HdfsClientConfigKeys.DFS_NAMENODE_RPC_ADDRESS_KEY)}")
     super.start()
+    saveHadoopConf()
   }
 
   override def stop(): Unit = {
@@ -62,6 +68,21 @@ class MiniDFSService(name: String, hdfsConf: Configuration)
     super.stop()
   }
 
+  private def saveHadoopConf(): Unit = {
+    val configToWrite = new Configuration(false)
+    val hostName = InetAddress.getLocalHost.getHostName
+    hdfsConf.iterator().asScala.foreach { kv =>
+      val key = kv.getKey
+      val value = kv.getValue.replaceAll(hostName, "localhost")
+      configToWrite.set(key, value)
+      getConf.set(key, value)
+    }
+    val writer = new FileWriter(new File(hadoopConfDir, "hdfs-site.xml"))
+    configToWrite.writeXml(writer)
+    writer.close()
+  }
+
   def getHadoopConf: Configuration = hdfsConf
   def getDFSPort: Int = hdfsCluster.getNameNodePort
+  def getHadoopConfDir: String = hadoopConfDir.getAbsolutePath
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Close #3064 

Refer the comments by @cxzl25 

Spark uses the code
 `URL.setURLStreamHandlerFactory(new FsUrlStreamHandlerFactory(hadoopConf))` supports the class path from HDFS.
But because the scala compiler only supports adding file schema urls to the class path, non-file schema urls will cause NPE.

```java
Error: Error operating ExecuteScala: java.lang.NullPointerException
	at scala.tools.nsc.classpath.FileUtils$AbstractFileOps$.isJarOrZip$extension(FileUtils.scala:32)
	at scala.tools.nsc.classpath.ClassPathFactory$.newClassPath(ClassPathFactory.scala:90)
	at scala.tools.nsc.Global.$anonfun$extendCompilerClassPath$1(Global.scala:832)
```

scala.tools.nsc.Global#extendCompilerClassPath
```scala
AbstractFile.getURL(u) 
```

scala.reflect.io.AbstractFile#getURL
```scala
  def getURL(url: URL): AbstractFile =
    if (url.getProtocol == "file") {
      val f = new java.io.File(url.toURI)
      if (f.isDirectory) getDirectory(f)
      else getFile(f)
    } else null
```

spark-shell supports --jars hdfs jar. At this time, submit will download the remote jar to the local and pass it to spark-shell through the `spark.repl.local.jars` configuration.


In this pr, I localize the remote jar url at first, and then add it into repl class path.
### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
