### PR TITLE
[KYUUBI #3226][FOLLOWUP] Revert - Privileges should be checked only once in RuleAuthorization

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -22,26 +22,19 @@ import scala.collection.mutable.ArrayBuffer
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
-import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 
 import org.apache.kyuubi.plugin.spark.authz.{ObjectType, _}
 import org.apache.kyuubi.plugin.spark.authz.ObjectType._
-import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization.KYUUBI_AUTHZ_TAG
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 class RuleAuthorization(spark: SparkSession) extends Rule[LogicalPlan] {
-  override def apply(plan: LogicalPlan): LogicalPlan = plan match {
-    case p if !plan.getTagValue(KYUUBI_AUTHZ_TAG).contains(true) =>
-      RuleAuthorization.checkPrivileges(spark, p)
-      p.setTagValue(KYUUBI_AUTHZ_TAG, true)
-      p
-    case p => p // do nothing if checked privileges already.
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    RuleAuthorization.checkPrivileges(spark, plan)
+    plan
   }
 }
 
 object RuleAuthorization {
-
-  val KYUUBI_AUTHZ_TAG = TreeNodeTag[Boolean]("__KYUUBI_AUTHZ_TAG")
 
   def checkPrivileges(spark: SparkSession, plan: LogicalPlan): Unit = {
     val auditHandler = new SparkRangerAuditHandler

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -27,14 +27,12 @@ import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
-import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.scalatest.BeforeAndAfterAll
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
-import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization.KYUUBI_AUTHZ_TAG
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getFieldVal
 
 abstract class RangerSparkExtensionSuite extends AnyFunSuite
@@ -59,68 +57,6 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
       resource: String = "default/src",
       user: String = UserGroupInformation.getCurrentUser.getShortUserName): String = {
     s"Permission denied: user [$user] does not have [$privilege] privilege on [$resource]"
-  }
-
-  test("[KYUUBI #3226] RuleAuthorization: Should check privileges once only.") {
-    val logicalPlan = doAs("admin", sql("SHOW TABLES").queryExecution.logical)
-    val rule = new RuleAuthorization(spark)
-
-    (1 until 10).foreach { i =>
-      if (i == 1) {
-        assert(logicalPlan.getTagValue(KYUUBI_AUTHZ_TAG).isEmpty)
-      } else {
-        assert(logicalPlan.getTagValue(KYUUBI_AUTHZ_TAG).getOrElse(false))
-      }
-      rule.apply(logicalPlan)
-    }
-
-    assert(logicalPlan.getTagValue(KYUUBI_AUTHZ_TAG).getOrElse(false))
-  }
-
-  test("[KYUUBI #3226]: Another session should also check even if the plan is cached.") {
-    val testTable = "mytable"
-    val create =
-      s"""
-         | CREATE TABLE IF NOT EXISTS $testTable
-         | (id string)
-         | using parquet
-         |""".stripMargin
-    val select = s"SELECT * FROM $testTable"
-    try {
-      // create tmp table
-      doAs(
-        "admin", {
-          sql(create)
-
-          // session1: first query, should auth once.[LogicalRelation]
-          val df = sql(select)
-          val plan1 = df.queryExecution.optimizedPlan
-          assert(plan1.getTagValue(KYUUBI_AUTHZ_TAG).getOrElse(false))
-
-          // cache
-          df.cache()
-
-          // session1: second query, should auth once.[InMemoryRelation]
-          // (don't need to check in again, but it's okay to check in once)
-          val plan2 = sql(select).queryExecution.optimizedPlan
-          assert(plan1 != plan2 && plan2.getTagValue(KYUUBI_AUTHZ_TAG).getOrElse(false))
-
-          // session2: should auth once.
-          val otherSessionDf = spark.newSession().sql(select)
-
-          // KYUUBI_AUTH_TAG is None
-          assert(otherSessionDf.queryExecution.logical.getTagValue(KYUUBI_AUTHZ_TAG).isEmpty)
-          val plan3 = otherSessionDf.queryExecution.optimizedPlan
-          // make sure it use cache.
-          assert(plan3.isInstanceOf[InMemoryRelation])
-          // auth once only.
-          assert(plan3.getTagValue(KYUUBI_AUTHZ_TAG).getOrElse(false))
-        })
-
-    } finally {
-      // finally, drop tmp table
-      doAs("admin", sql(s"DROP TABLE IF EXISTS $testTable"))
-    }
   }
 
   test("auth: databases") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This pr aims to revert https://github.com/apache/incubator-kyuubi/pull/3262, this is due to the fact that the patch does not support Spark 2.4, but authZ does.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
