### PR TITLE
[KYUUBI #3298] Unify the approach of get classLoader in Kyuubi

### DIFF
--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Benchmark.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/Benchmark.scala
@@ -17,13 +17,6 @@
 
 package org.apache.kyuubi.tpcds.benchmark
 
-import scala.concurrent._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.DurationInt
-import scala.language.implicitConversions
-import scala.util.{Failure => SFailure, Success, Try}
-import scala.util.control.NonFatal
-
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 // scalastyle:off
@@ -43,7 +36,7 @@ abstract class Benchmark(
   implicit protected def toOption[A](a: A): Option[A] = Option(a)
 
   val buildInfo: Map[String, String] =
-    Try(getClass.getClassLoader.loadClass("org.apache.spark.BuildInfo")).map { cls =>
+    Try(Utils.getContextOrKyuubiClassLoader.loadClass("org.apache.spark.BuildInfo")).map { cls =>
       cls.getMethods
         .filter(_.getReturnType == classOf[String])
         .filterNot(_.getName == "toString")

--- a/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/TPCDS_2_4_Queries.scala
+++ b/dev/kyuubi-tpcds/src/main/scala/org/apache/kyuubi/tpcds/benchmark/TPCDS_2_4_Queries.scala
@@ -17,8 +17,6 @@
 
 package org.apache.kyuubi.tpcds.benchmark
 
-import scala.io.{Codec, Source}
-
 /**
  * This implements the official TPCDS v2.4 queries with only cosmetic modifications.
  */
@@ -133,7 +131,7 @@ trait TPCDS_2_4_Queries extends Benchmark {
     "ss_max")
 
   val tpcds2_4Queries: Seq[Query] = queryNames.map { queryName =>
-    val in = getClass.getClassLoader.getResourceAsStream(s"tpcds_2_4/$queryName.sql")
+    val in = Utils.getContextOrKyuubiClassLoader.getResourceAsStream(s"tpcds_2_4/$queryName.sql")
     val queryContent: String = Source.fromInputStream(in)(Codec.UTF8).mkString
     in.close()
 

--- a/extensions/spark/kyuubi-spark-connector-kudu/src/test/scala/org/apache/kyuubi/spark/connector/kudu/KuduMixin.scala
+++ b/extensions/spark/kyuubi-spark-connector-kudu/src/test/scala/org/apache/kyuubi/spark/connector/kudu/KuduMixin.scala
@@ -21,7 +21,7 @@ import java.io.File
 
 import com.dimafeng.testcontainers.{DockerComposeContainer, ExposedService, ForAllTestContainer}
 
-import org.apache.kyuubi.KyuubiFunSuite
+import org.apache.kyuubi.{KyuubiFunSuite, Utils}
 
 trait KuduMixin extends KyuubiFunSuite with ForAllTestContainer {
 
@@ -30,7 +30,8 @@ trait KuduMixin extends KyuubiFunSuite with ForAllTestContainer {
   override val container: DockerComposeContainer =
     DockerComposeContainer
       .Def(
-        composeFiles = new File(getClass.getClassLoader.getResource("kudu-compose.yml").toURI),
+        composeFiles =
+          new File(Utils.getContextOrKyuubiClassLoader.getResource("kudu-compose.yml").toURI),
         exposedServices = ExposedService("kudu-master", KUDU_MASTER_PORT) :: Nil)
       .createContainer()
 

--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSQuerySuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/test/scala/org/apache/kyuubi/spark/connector/tpcds/TPCDSQuerySuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.scalatest.tags.Slow
 
-import org.apache.kyuubi.KyuubiFunSuite
+import org.apache.kyuubi.{KyuubiFunSuite, Utils}
 import org.apache.kyuubi.spark.connector.common.GoldenFileUtils._
 import org.apache.kyuubi.spark.connector.common.LocalSparkSession.withSparkSession
 
@@ -65,7 +65,8 @@ class TPCDSQuerySuite extends KyuubiFunSuite {
     withSparkSession(SparkSession.builder.config(sparkConf).getOrCreate()) { spark =>
       spark.sql("USE tpcds.tiny")
       queries.map { queryName =>
-        val in = getClass.getClassLoader.getResourceAsStream(s"kyuubi/tpcds_3.2/$queryName.sql")
+        val in = Utils.getContextOrKyuubiClassLoader
+          .getResourceAsStream(s"kyuubi/tpcds_3.2/$queryName.sql")
         val queryContent: String = Source.fromInputStream(in)(Codec.UTF8).mkString
         in.close()
         queryName -> queryContent

--- a/extensions/spark/kyuubi-spark-connector-tpch/src/test/scala/org/apache/kyuubi/spark/connector/tpch/TPCHQuerySuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpch/src/test/scala/org/apache/kyuubi/spark/connector/tpch/TPCHQuerySuite.scala
@@ -24,7 +24,7 @@ import org.apache.spark.SparkConf
 import org.apache.spark.sql.SparkSession
 import org.scalatest.tags.Slow
 
-import org.apache.kyuubi.KyuubiFunSuite
+import org.apache.kyuubi.{KyuubiFunSuite, Utils}
 import org.apache.kyuubi.spark.connector.common.GoldenFileUtils._
 import org.apache.kyuubi.spark.connector.common.LocalSparkSession.withSparkSession
 
@@ -62,7 +62,7 @@ class TPCHQuerySuite extends KyuubiFunSuite {
     withSparkSession(SparkSession.builder.config(sparkConf).getOrCreate()) { spark =>
       spark.sql("USE tpch.tiny")
       queries.map { queryName =>
-        val in = getClass.getClassLoader.getResourceAsStream(
+        val in = Utils.getContextOrKyuubiClassLoader.getResourceAsStream(
           s"kyuubi/tpch/$queryName.sql")
         val queryContent: String = Source.fromInputStream(in)(Codec.UTF8).mkString
         in.close()

--- a/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/WithDorisContainer.scala
+++ b/externals/kyuubi-jdbc-engine/src/test/scala/org/apache/kyuubi/engine/jdbc/doris/WithDorisContainer.scala
@@ -22,6 +22,7 @@ import java.time.Duration
 import com.dimafeng.testcontainers.{DockerComposeContainer, ExposedService}
 import org.testcontainers.containers.wait.strategy.DockerHealthcheckWaitStrategy
 
+import org.apache.kyuubi.Utils
 import org.apache.kyuubi.engine.jdbc.WithJdbcServerContainer
 
 trait WithDorisContainer extends WithJdbcServerContainer {
@@ -37,7 +38,8 @@ trait WithDorisContainer extends WithJdbcServerContainer {
   override val container: DockerComposeContainer =
     DockerComposeContainer
       .Def(
-        composeFiles = new File(getClass.getClassLoader.getResource("doris-compose.yml").toURI),
+        composeFiles = new File(Utils.getContextOrKyuubiClassLoader
+          .getResource("doris-compose.yml").toURI),
         exposedServices = Seq[ExposedService](
           ExposedService(
             DORIS_FE_SERVICE_NAME,

--- a/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/doris/WithKyuubiServerAndDorisContainer.scala
+++ b/integration-tests/kyuubi-jdbc-it/src/test/scala/org/apache/kyuubi/it/jdbc/doris/WithKyuubiServerAndDorisContainer.scala
@@ -32,7 +32,7 @@ trait WithKyuubiServerAndDorisContainer extends WithKyuubiServer with WithDorisE
       .set(s"$KYUUBI_ENGINE_ENV_PREFIX.$KYUUBI_HOME", kyuubiHome)
       .set(
         ENGINE_JDBC_EXTRA_CLASSPATH,
-        getClass.getClassLoader.getResource(
+        Utils.getContextOrKyuubiClassLoader.getResource(
           "mysql/mysql-connector-java-8.0.30.jar").toURI.getPath)
   }
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/Utils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/Utils.scala
@@ -55,7 +55,7 @@ object Utils extends Logging {
       .map(d => new File(d + File.separator + KYUUBI_CONF_FILE_NAME))
       .filter(_.exists())
       .orElse {
-        Option(getClass.getClassLoader.getResource(KYUUBI_CONF_FILE_NAME)).map { url =>
+        Option(Utils.getContextOrKyuubiClassLoader.getResource(KYUUBI_CONF_FILE_NAME)).map { url =>
           new File(url.getFile)
         }.filter(_.exists())
       }
@@ -314,4 +314,19 @@ object Utils extends Logging {
   }
 
   def isCommandAvailable(cmd: String): Boolean = s"which $cmd".! == 0
+
+  /**
+   * Get the ClassLoader which loaded Kyuubi.
+   */
+  def getKyuubiClassLoader: ClassLoader = getClass.getClassLoader
+
+  /**
+   * Get the Context ClassLoader on this thread or, if not present, the ClassLoader that
+   * loaded Kyuubi.
+   *
+   * This should be used whenever passing a ClassLoader to Class.ForName or finding the currently
+   * active loader when setting up ClassLoader delegation chains.
+   */
+  def getContextOrKyuubiClassLoader: ClassLoader =
+    Option(Thread.currentThread().getContextClassLoader).getOrElse(getKyuubiClassLoader)
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/UtilsSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/UtilsSuite.scala
@@ -34,7 +34,7 @@ class UtilsSuite extends KyuubiFunSuite {
 
   test("build information check") {
     val buildFile = "kyuubi-version-info.properties"
-    val str = this.getClass.getClassLoader.getResourceAsStream(buildFile)
+    val str = Utils.getContextOrKyuubiClassLoader.getResourceAsStream(buildFile)
     val props = new Properties()
     assert(str !== null)
     props.load(str)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HadoopCredentialsManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/credentials/HadoopCredentialsManager.scala
@@ -30,7 +30,7 @@ import scala.util.{Failure, Success, Try}
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.security.Credentials
 
-import org.apache.kyuubi.Logging
+import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
 import org.apache.kyuubi.service.AbstractService
@@ -316,7 +316,9 @@ object HadoopCredentialsManager extends Logging {
 
   def loadProviders(kyuubiConf: KyuubiConf): Map[String, HadoopDelegationTokenProvider] = {
     val loader =
-      ServiceLoader.load(classOf[HadoopDelegationTokenProvider], getClass.getClassLoader)
+      ServiceLoader.load(
+        classOf[HadoopDelegationTokenProvider],
+        Utils.getContextOrKyuubiClassLoader)
     val providers = mutable.ArrayBuffer[HadoopDelegationTokenProvider]()
 
     val iterator = loader.iterator

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -24,7 +24,7 @@ import java.util.{Locale, ServiceLoader}
 import scala.collection.JavaConverters._
 import scala.util.control.NonFatal
 
-import org.apache.kyuubi.KyuubiException
+import org.apache.kyuubi.{KyuubiException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.KubernetesApplicationOperation.LABEL_KYUUBI_UNIQUE_KEY
 import org.apache.kyuubi.engine.flink.FlinkProcessBuilder
@@ -35,7 +35,7 @@ class KyuubiApplicationManager extends AbstractService("KyuubiApplicationManager
 
   // TODO: maybe add a configuration is better
   private val operations = {
-    ServiceLoader.load(classOf[ApplicationOperation], getClass.getClassLoader)
+    ServiceLoader.load(classOf[ApplicationOperation], Utils.getContextOrKyuubiClassLoader)
       .iterator().asScala.toSeq
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -77,7 +77,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
   }
 
   private def initSchema(): Unit = {
-    val classLoader = getClass.getClassLoader
+    val classLoader = Utils.getContextOrKyuubiClassLoader
     val initSchemaStream: Option[InputStream] = dbType match {
       case DERBY =>
         Option(classLoader.getResourceAsStream("sql/derby/metadata-store-schema-derby.sql"))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix https://github.com/apache/incubator-kyuubi/issues/3298

Curently, a serval snippets use `getClass.getClassLoader` to get the classLoader in Apache Kyuubi, this pr aims to unify this behavior in `Utils.getContextOrKyuubiClassLoader`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
