### PR TITLE
Construct lifetimeTerminatingChecker only when needed

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -49,7 +49,7 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
 
   private val shutdown = new AtomicBoolean(false)
 
-  private var lifetimeTerminatingChecker: Option[ScheduledExecutorService] = None
+  @volatile private var lifetimeTerminatingChecker: Option[ScheduledExecutorService] = None
 
   override def initialize(conf: KyuubiConf): Unit = {
     val listener = new SparkSQLEngineListener(this)


### PR DESCRIPTION
### _Why are the changes needed?_
Construct `lifetimeTerminatingChecker` only when needed.
The default value of `kyuubi.session.engine.spark.max.lifetime` is 0, so the `lifetimeTerminatingChecker` is not enabled, there is no need to construct a `ThreadScheduledExecutor`, and `shutdown` can also be avoided when stopping.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
