### PR TITLE
[KYUUBI #3226][DOC] [FOLLOWUP] Kyuubi authZ only support spark 3.x

### DIFF
--- a/docs/security/authorization/spark/build.md
+++ b/docs/security/authorization/spark/build.md
@@ -55,8 +55,7 @@ The available `spark.version`s are shown in the following table.
 |       3.2.x       |      √      |                                                                -                                                                 |
 |       3.1.x       |      √      |                                                                -                                                                 |
 |       3.0.x       |      √      |                                                                -                                                                 |
-|       2.4.x       |      √      |                                                                -                                                                 |
-| 2.3.x and earlier |      ×      | [PR 2367](https://github.com/apache/incubator-kyuubi/pull/2367) is used to track how we work with older releases with scala 2.11 |
+| 2.4.x and earlier |      ×      | [PR 2367](https://github.com/apache/incubator-kyuubi/pull/2367) is used to track how we work with older releases with scala 2.11 |
 
 Currently, Spark released with Scala 2.12 are supported.
 

--- a/extensions/spark/kyuubi-spark-authz/README.md
+++ b/extensions/spark/kyuubi-spark-authz/README.md
@@ -39,8 +39,7 @@ build/mvn clean package -pl :kyuubi-spark-authz_2.12 -Dspark.version=3.2.1 -Dran
 - [x] 3.2.x (default)
 - [x] 3.1.x
 - [x] 3.0.x
-- [x] 2.4.x
-- [ ] 2.3.x and earlier
+- [ ] 2.4.x and earlier
 
 ### Supported Apache Ranger Versions
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Currently, Apache Kyuubi support Spark 3.0.0 and above, but Kyuubi-AuthZ support Spark 2.4, Spark 3.0 and above, to avoid subsequent maintenance costs, we plan to move out support for Spark 2.4.

This pr aims to modify the documentation to indicate that version 2.4 is not supported

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
