### PR TITLE
[KYUUBI #3300] [Authz] Support overriding usergroup with UserStore in AccessRequest 

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -42,6 +42,24 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
     s"ranger.plugin.${getServiceType}.authorize.in.single.call",
     false)
 
+  /**
+   * This configuration controls whether to override user's usergroups
+   * by the mapping fetched from Ranger's UserStore.
+   *
+   * It relies on Ranger's UserStore is a feature supported since Ranger 2.1.
+   *
+   * If true, user bound usergroups will be looked up in in Ranger's UserStore
+   * and the usergroups of AccessRequest is overriden.
+   *
+   * Please make sure configs in Ranger set properly:
+   * 1. set `ranger.plugin.spark.enable.implicit.userstore.enricher` to true
+   * 2. set cache path for UserStore in `ranger.plugin.hive.policy.cache.dir`
+   * 3. at least one condition of policies containing scripts, e.g. {{USER.attr}} in row-filter
+   */
+  def useUserGroupsFromUserStoreEnabled: Boolean = getRangerConf.getBoolean(
+    s"ranger.plugin.$getServiceType.use.usergroups.from.userstore.enabled",
+    false)
+
   def getFilterExpr(req: AccessRequest): Option[String] = {
     val result = evalRowFilterPolicies(req, null)
     Option(result)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix #3300 

1. support overriding usergroup in AccessRequest by fetching user-group relation mapping from UserStore (which introduced since Ranger 2.1+) in RangerBasePlugin.
2. policy condition authorized by usergroup  enabled, if any expression used with in filter or condition
3. add a switch config for it, disabled by default.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
