### PR TITLE
Fast fail the kyuubi connection if the engine application has been terminated

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -64,6 +64,22 @@ trait ApplicationOperation {
 object ApplicationState extends Enumeration {
   type ApplicationState = Value
   val PENDING, RUNNING, FINISHED, KILLED, FAILED, ZOMBIE, NOT_FOUND, UNKNOWN = Value
+
+  def applicationFailed(state: ApplicationState): Boolean = state match {
+    case FAILED => true
+    case KILLED => true
+    case _ => false
+  }
+
+  def applicationTerminated(state: ApplicationState): Boolean = {
+    state match {
+      case FAILED => true
+      case KILLED => true
+      case FINISHED => true
+      case NOT_FOUND => true
+      case _ => false
+    }
+  }
 }
 
 case class ApplicationInfo(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -76,6 +76,7 @@ object ApplicationState extends Enumeration {
       case FAILED => true
       case KILLED => true
       case FINISHED => true
+      case NOT_FOUND => true
       case _ => false
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/ApplicationOperation.scala
@@ -65,18 +65,17 @@ object ApplicationState extends Enumeration {
   type ApplicationState = Value
   val PENDING, RUNNING, FINISHED, KILLED, FAILED, ZOMBIE, NOT_FOUND, UNKNOWN = Value
 
-  def applicationFailed(state: ApplicationState): Boolean = state match {
+  def isFailed(state: ApplicationState): Boolean = state match {
     case FAILED => true
     case KILLED => true
     case _ => false
   }
 
-  def applicationTerminated(state: ApplicationState): Boolean = {
+  def isTerminated(state: ApplicationState): Boolean = {
     state match {
       case FAILED => true
       case KILLED => true
       case FINISHED => true
-      case NOT_FOUND => true
       case _ => false
     }
   }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -216,7 +216,7 @@ private[kyuubi] class EngineRef(
                 }
                 throw new KyuubiSQLException(
                   s"""
-                     |The engine application has been in terminate state. Please check the engine log.
+                     |The engine application has been terminated. Please check the engine log.
                      |FYI: ${appInfo.toMap.mkString("(\n", ",\n", "\n)")}
                      |""".stripMargin,
                   builder.getError)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -208,6 +208,10 @@ private[kyuubi] class EngineRef(
 
         engineManager.getApplicationInfo(builder.clusterManager(), engineRefId).foreach { appInfo =>
           if (ApplicationState.isTerminated(appInfo.state)) {
+            MetricsSystem.tracing { ms =>
+              ms.incCount(MetricRegistry.name(ENGINE_FAIL, appUser))
+              ms.incCount(MetricRegistry.name(ENGINE_FAIL, "ENGINE_TERMINATE"))
+            }
             throw new KyuubiSQLException(
               s"""
                  |The engine application has been in terminate state. Please check the engine log.

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -206,19 +206,21 @@ private[kyuubi] class EngineRef(
           }
         }
 
-        Option(engineManager).foreach { engineMgr =>
-          engineMgr.getApplicationInfo(builder.clusterManager(), engineRefId).foreach { appInfo =>
-            if (ApplicationState.isTerminated(appInfo.state)) {
-              MetricsSystem.tracing { ms =>
-                ms.incCount(MetricRegistry.name(ENGINE_FAIL, appUser))
-                ms.incCount(MetricRegistry.name(ENGINE_FAIL, "ENGINE_TERMINATE"))
+        if (exitValue == Some(0)) {
+          Option(engineManager).foreach { engineMgr =>
+            engineMgr.getApplicationInfo(builder.clusterManager(), engineRefId).foreach { appInfo =>
+              if (ApplicationState.isTerminated(appInfo.state)) {
+                MetricsSystem.tracing { ms =>
+                  ms.incCount(MetricRegistry.name(ENGINE_FAIL, appUser))
+                  ms.incCount(MetricRegistry.name(ENGINE_FAIL, "ENGINE_TERMINATE"))
+                }
+                throw new KyuubiSQLException(
+                  s"""
+                     |The engine application has been in terminate state. Please check the engine log.
+                     |FYI: ${appInfo.toMap.mkString("(\n", ",\n", "\n)")}
+                     |""".stripMargin,
+                  builder.getError)
               }
-              throw new KyuubiSQLException(
-                s"""
-                   |The engine application has been in terminate state. Please check the engine log.
-                   |FYI: ${appInfo.toMap.mkString("(\n", ",\n", "\n)")}
-                   |""".stripMargin,
-                builder.getError)
             }
           }
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -207,7 +207,7 @@ private[kyuubi] class EngineRef(
         }
 
         engineManager.getApplicationInfo(builder.clusterManager(), engineRefId).foreach { appInfo =>
-          if (ApplicationState.applicationTerminated(appInfo.state)) {
+          if (ApplicationState.isTerminated(appInfo.state)) {
             engineRef = discoveryClient.getEngineByRefId(engineSpace, engineRefId)
             if (engineRef.isEmpty) {
               throw new KyuubiSQLException(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -206,6 +206,8 @@ private[kyuubi] class EngineRef(
           }
         }
 
+        // even the submit process succeeds, the application might meet failure when initializing,
+        // check the engine application state from engine manager and fast fail on engine terminate
         if (exitValue == Some(0)) {
           Option(engineManager).foreach { engineMgr =>
             engineMgr.getApplicationInfo(builder.clusterManager(), engineRefId).foreach { appInfo =>

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -217,7 +217,7 @@ private[kyuubi] class EngineRef(
                 throw new KyuubiSQLException(
                   s"""
                      |The engine application has been terminated. Please check the engine log.
-                     |FYI: ${appInfo.toMap.mkString("(\n", ",\n", "\n)")}
+                     |ApplicationInfo: ${appInfo.toMap.mkString("(\n", ",\n", "\n)")}
                      |""".stripMargin,
                   builder.getError)
               }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -206,18 +206,20 @@ private[kyuubi] class EngineRef(
           }
         }
 
-        engineManager.getApplicationInfo(builder.clusterManager(), engineRefId).foreach { appInfo =>
-          if (ApplicationState.isTerminated(appInfo.state)) {
-            MetricsSystem.tracing { ms =>
-              ms.incCount(MetricRegistry.name(ENGINE_FAIL, appUser))
-              ms.incCount(MetricRegistry.name(ENGINE_FAIL, "ENGINE_TERMINATE"))
+        Option(engineManager).foreach { engineMgr =>
+          engineMgr.getApplicationInfo(builder.clusterManager(), engineRefId).foreach { appInfo =>
+            if (ApplicationState.isTerminated(appInfo.state)) {
+              MetricsSystem.tracing { ms =>
+                ms.incCount(MetricRegistry.name(ENGINE_FAIL, appUser))
+                ms.incCount(MetricRegistry.name(ENGINE_FAIL, "ENGINE_TERMINATE"))
+              }
+              throw new KyuubiSQLException(
+                s"""
+                   |The engine application has been in terminate state. Please check the engine log.
+                   |FYI: ${appInfo.toMap.mkString("(\n", ",\n", "\n)")}
+                   |""".stripMargin,
+                builder.getError)
             }
-            throw new KyuubiSQLException(
-              s"""
-                 |The engine application has been in terminate state. Please check the engine log.
-                 |FYI: ${appInfo.toMap.mkString("(\n", ",\n", "\n)")}
-                 |""".stripMargin,
-              builder.getError)
           }
         }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -208,15 +208,12 @@ private[kyuubi] class EngineRef(
 
         engineManager.getApplicationInfo(builder.clusterManager(), engineRefId).foreach { appInfo =>
           if (ApplicationState.isTerminated(appInfo.state)) {
-            engineRef = discoveryClient.getEngineByRefId(engineSpace, engineRefId)
-            if (engineRef.isEmpty) {
-              throw new KyuubiSQLException(
-                s"""
-                   |The engine application has been in terminate state. Please check the engine log.
-                   |FYI: ${appInfo.toMap.mkString("(\n", ",\n", "\n)")}
-                   |""".stripMargin,
-                builder.getError)
-            }
+            throw new KyuubiSQLException(
+              s"""
+                 |The engine application has been in terminate state. Please check the engine log.
+                 |FYI: ${appInfo.toMap.mkString("(\n", ",\n", "\n)")}
+                 |""".stripMargin,
+              builder.getError)
           }
         }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -339,10 +339,10 @@ class BatchJobSubmission(
 
 object BatchJobSubmission {
   def applicationFailed(applicationStatus: Option[ApplicationInfo]): Boolean = {
-    applicationStatus.map(_.state).exists(ApplicationState.applicationFailed)
+    applicationStatus.map(_.state).exists(ApplicationState.isFailed)
   }
 
   def applicationTerminated(applicationStatus: Option[ApplicationInfo]): Boolean = {
-    applicationStatus.map(_.state).exists(ApplicationState.applicationTerminated)
+    applicationStatus.map(_.state).exists(ApplicationState.isTerminated)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -339,20 +339,10 @@ class BatchJobSubmission(
 
 object BatchJobSubmission {
   def applicationFailed(applicationStatus: Option[ApplicationInfo]): Boolean = {
-    applicationStatus.map(_.state).exists {
-      case ApplicationState.FAILED => true
-      case ApplicationState.KILLED => true
-      case _ => false
-    }
+    applicationStatus.map(_.state).exists(ApplicationState.applicationFailed)
   }
 
   def applicationTerminated(applicationStatus: Option[ApplicationInfo]): Boolean = {
-    applicationStatus.map(_.state).exists {
-      case ApplicationState.FAILED => true
-      case ApplicationState.KILLED => true
-      case ApplicationState.FINISHED => true
-      case ApplicationState.NOT_FOUND => true
-      case _ => false
-    }
+    applicationStatus.map(_.state).exists(ApplicationState.applicationTerminated)
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -339,10 +339,20 @@ class BatchJobSubmission(
 
 object BatchJobSubmission {
   def applicationFailed(applicationStatus: Option[ApplicationInfo]): Boolean = {
-    applicationStatus.map(_.state).exists(ApplicationState.isFailed)
+    applicationStatus.map(_.state).exists {
+      case ApplicationState.FAILED => true
+      case ApplicationState.KILLED => true
+      case _ => false
+    }
   }
 
   def applicationTerminated(applicationStatus: Option[ApplicationInfo]): Boolean = {
-    applicationStatus.map(_.state).exists(ApplicationState.isTerminated)
+    applicationStatus.map(_.state).exists {
+      case ApplicationState.FAILED => true
+      case ApplicationState.KILLED => true
+      case ApplicationState.FINISHED => true
+      case ApplicationState.NOT_FOUND => true
+      case _ => false
+    }
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/BatchJobSubmission.scala
@@ -339,20 +339,10 @@ class BatchJobSubmission(
 
 object BatchJobSubmission {
   def applicationFailed(applicationStatus: Option[ApplicationInfo]): Boolean = {
-    applicationStatus.map(_.state).exists {
-      case ApplicationState.FAILED => true
-      case ApplicationState.KILLED => true
-      case _ => false
-    }
+    applicationStatus.map(_.state).exists(ApplicationState.isFailed)
   }
 
   def applicationTerminated(applicationStatus: Option[ApplicationInfo]): Boolean = {
-    applicationStatus.map(_.state).exists {
-      case ApplicationState.FAILED => true
-      case ApplicationState.KILLED => true
-      case ApplicationState.FINISHED => true
-      case ApplicationState.NOT_FOUND => true
-      case _ => false
-    }
+    applicationStatus.map(_.state).exists(ApplicationState.isTerminated)
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
@@ -188,7 +188,7 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
       }
       val elapsedTime = System.currentTimeMillis() - startTime
       assert(elapsedTime < 60 * 1000)
-      assert(exception.getMessage contains "The engine application has been in terminate state.")
+      assert(exception.getMessage contains "The engine application has been terminated.")
     }
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/WithKyuubiServerOnYarn.scala
@@ -174,4 +174,8 @@ class KyuubiOperationYarnClusterSuite extends WithKyuubiServerOnYarn with HiveJD
       assert(batchJobSubmissionOp.getStatus.state === OperationState.ERROR)
     }
   }
+
+  test("fast fail the kyuubi connection on engine terminated") {
+
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

We met the case that the LaunchEngine operation is succeed.

But the spark engine met exception and terminated with SUCCESS state.

And then the kyuubi connection stuck until reach the `kyuubi.session.engine.initialize.timeout`.

The engine application terminated in 1.5 minutes and the engine init timeout is 10m.

FYI:
![image](https://user-images.githubusercontent.com/6757692/186137705-615d3ae3-51cf-4afb-bbd9-9c1638c02181.png)

So, we shall check the engine application state when waiting the engine initialization, and fast fail the connection if the application has been in terminated state.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
