### PR TITLE
Transfer the TGetInfoReq to kyuubi engine side to check the connection valid and keep connection alive

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -75,7 +75,7 @@ abstract class AbstractSession(
     }
   }
 
-  private def withAcquireRelease[T](userAccess: Boolean = true)(f: => T): T = {
+  protected def withAcquireRelease[T](userAccess: Boolean = true)(f: => T): T = {
     acquire(userAccess)
     try f
     finally release(userAccess)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -227,6 +227,13 @@ class KyuubiSyncThriftClient private (
     resp.getOperationHandle
   }
 
+  def getInfo(infoType: TGetInfoType): TGetInfoResp = {
+    val req = new TGetInfoReq(_remoteSessionHandle, infoType)
+    val resp = withLockAcquiredAsyncRequest(GetInfo(req))
+    ThriftUtils.verifyTStatus(resp.getStatus)
+    resp
+  }
+
   def getTypeInfo: TOperationHandle = {
     val req = new TGetTypeInfoReq(_remoteSessionHandle)
     val resp = withLockAcquiredAsyncRequest(GetTypeInfo(req))

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -197,4 +197,14 @@ class KyuubiSessionImpl(
       MetricsSystem.tracing(_.decCount(MetricRegistry.name(CONN_OPEN, user)))
     }
   }
+
+  override def getInfo(infoType: TGetInfoType): TGetInfoValue = {
+    if (client != null) {
+      withAcquireRelease() {
+        client.getInfo(infoType).getInfoValue
+      }
+    } else {
+      super.getInfo(infoType)
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/contributions.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Now the connection path is:

`client`-> `kyuubiServer` -> `kyuubiEngine`

Maybe the connection between `client -> kyuubiServer` is valid, but the connection between `kyuubiServer -> kyuubiEngine` is not.

So we need check the whole path.

BTW, before, if customer invoke KyuubiConnection::isValid, it can make the connection between client and kyuubiServer keep alive.

Now, it can make the whole connection path keep alive.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
