### PR TITLE
[KYUUBI #3208] Fix Flaky Test - MetadataManagerSuite: metadata request metrics

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/MetadataManager.scala
@@ -36,10 +36,12 @@ class MetadataManager extends AbstractService("MetadataManager") {
 
   private var _metadataStore: MetadataStore = _
 
-  private val identifierRequestsRetryRefs =
+  // Visible for testing.
+  private[metadata] val identifierRequestsRetryRefs =
     new ConcurrentHashMap[String, MetadataRequestsRetryRef]()
 
-  private val identifierRequestsRetryingCounts =
+  // Visible for testing.
+  private[metadata] val identifierRequestsRetryingCounts =
     new ConcurrentHashMap[String, AtomicInteger]()
 
   private val requestsRetryTrigger =

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
@@ -19,6 +19,8 @@ package org.apache.kyuubi.server.metadata
 
 import java.util.UUID
 
+import scala.collection.JavaConverters._
+
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
 import org.apache.kyuubi.{KyuubiException, KyuubiFunSuite}
@@ -96,9 +98,12 @@ class MetadataManagerSuite extends KyuubiFunSuite {
       assert(!retryRef2.hasRemainingRequests())
       assert(metadataManager.getBatch(metadata2.identifier).getState === "RUNNING")
     }
-    metadataManager.deRegisterRequestsRetryRef(metadata.identifier)
-    metadataManager.deRegisterRequestsRetryRef(metadata2.identifier)
-    Thread.sleep(conf.get(KyuubiConf.METADATA_REQUEST_RETRY_INTERVAL) * 2)
+
+    metadataManager.identifierRequestsRetryRefs.clear()
+    eventually(timeout(3.seconds)) {
+      metadataManager.identifierRequestsRetryingCounts.asScala.forall(_._2.get() == 0)
+    }
+    metadataManager.identifierRequestsRetryingCounts.clear()
   }
 
   test("metadata request metrics") {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/MetadataManagerSuite.scala
@@ -96,6 +96,9 @@ class MetadataManagerSuite extends KyuubiFunSuite {
       assert(!retryRef2.hasRemainingRequests())
       assert(metadataManager.getBatch(metadata2.identifier).getState === "RUNNING")
     }
+    metadataManager.deRegisterRequestsRetryRef(metadata.identifier)
+    metadataManager.deRegisterRequestsRetryRef(metadata2.identifier)
+    Thread.sleep(conf.get(KyuubiConf.METADATA_REQUEST_RETRY_INTERVAL) * 2)
   }
 
   test("metadata request metrics") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Close #3208 
Fix flaky test:
```
MetadataManagerSuite:
- metadata request metrics *** FAILED ***
  2 did not equal 1 (MetadataManagerSuite.scala:141)
```

Cleanup the retrying metadata to prevent flaky test.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
