### PR TITLE
[KYUUBI #3343] [Improvement] [AUTHZ] Skip privilege checks for CreateViewCommand of LocalTempView and GlobalTempView

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -21,6 +21,7 @@ import scala.collection.mutable.ArrayBuffer
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.analysis.{PersistedView, ViewType}
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
 import org.apache.spark.sql.catalyst.expressions.{Expression, NamedExpression}
@@ -295,8 +296,10 @@ object PrivilegesBuilder {
         outputObjs += databasePrivileges(quote(databases))
 
       case "CreateViewCommand" =>
-        val view = getPlanField[TableIdentifier]("name")
-        outputObjs += tablePrivileges(view)
+        if (getPlanField[ViewType]("viewType") == PersistedView) {
+          val view = getPlanField[TableIdentifier]("name")
+          outputObjs += tablePrivileges(view)
+        }
         val query =
           if (isSparkVersionAtMost("3.1")) {
             getPlanField[LogicalPlan]("child")

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -499,4 +499,51 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         })
     }
   }
+
+  test("[KYUUBI #3343] pass temporary view creation") {
+    val table = "hive_src"
+    val tempView = "temp_view"
+    val globalTempView = "global_temp_view"
+
+    withCleanTmpResources(Seq((table, "table"))) {
+      doAs("admin", sql(s"CREATE TABLE IF NOT EXISTS $table (id int)"))
+
+      doAs("admin", sql(s"CREATE TEMPORARY VIEW $tempView AS select * from $table"))
+
+      doAs(
+        "admin",
+        sql(s"CREATE OR REPLACE TEMPORARY VIEW $tempView" +
+          s" AS select * from $table"))
+
+      doAs("admin", sql(s"CREATE GLOBAL TEMPORARY VIEW $globalTempView AS SELECT * FROM $table"))
+
+      doAs(
+        "admin",
+        sql(s"CREATE OR REPLACE GLOBAL TEMPORARY VIEW $globalTempView" +
+          s" AS select * from $table"))
+    }
+  }
+
+  test("[KYUUBI #3343] check persisted view creation") {
+    val table = "hive_src"
+    val permView = "perm_view"
+
+    withCleanTmpResources(Seq((table, "table"))) {
+      doAs("admin", sql(s"CREATE TABLE IF NOT EXISTS $table (id int)"))
+
+      doAs("admin", sql(s"CREATE VIEW admin_perm_view AS SELECT * FROM $table"))
+
+      val e1 = intercept[AccessControlException](
+        doAs("someone", sql(s"CREATE VIEW $permView AS SELECT 1 as a")))
+      assert(e1.getMessage.contains(s"does not have [create] privilege on [default/$permView]"))
+
+      val e2 = intercept[AccessControlException](
+        doAs("someone", sql(s"CREATE VIEW $permView AS SELECT * FROM $table")))
+      if (isSparkV32OrGreater) {
+        assert(e2.getMessage.contains(s"does not have [select] privilege on [default/$table/id]"))
+      } else {
+        assert(e2.getMessage.contains(s"does not have [select] privilege on [$table]"))
+      }
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #3343

Privilege checks of CreateViewCommand retained for PersistedViews only, and skipped for LocalTempView or GlobalTempView.


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
