### PR TITLE
[KYUUBI #3023][FOLLOWUP] Kyuubi Hive JDBC: Replace UGI-based Kerberos authentication w/ JAAS

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -630,7 +630,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
       Subject subject = createSubject();
       String serverPrincipal = sessConfMap.get(AUTH_PRINCIPAL);
       return KerberosSaslHelper.createSubjectAssumedTransport(
-          subject, serverPrincipal, socketTransport, saslProps);
+          subject, serverPrincipal, host, socketTransport, saslProps);
     } catch (Exception e) {
       throw new KyuubiSQLException(
           "Could not create secure connection to " + jdbcUriString + ": " + e.getMessage(),

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosAuthentication.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosAuthentication.java
@@ -89,7 +89,7 @@ public class KerberosAuthentication {
   private static KerberosPrincipal createKerberosPrincipal(String principal) {
     try {
       return new KerberosPrincipal(
-          KerberosUtils.canonicalPrincipal(
+          KerberosUtils.canonicalClientPrincipal(
               principal, InetAddress.getLocalHost().getCanonicalHostName()));
     } catch (IOException e) {
       throw new UncheckedIOException(e);

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosSaslHelper.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosSaslHelper.java
@@ -31,10 +31,12 @@ public final class KerberosSaslHelper {
   public static TTransport createSubjectAssumedTransport(
       Subject subject,
       String serverPrincipal,
+      String host,
       TTransport underlyingTransport,
       Map<String, String> saslProps)
       throws SaslException {
-    String[] names = KerberosUtils.splitPrincipal(serverPrincipal);
+    String resolvedPrincipal = KerberosUtils.canonicalPrincipal(serverPrincipal, host);
+    String[] names = KerberosUtils.splitPrincipal(resolvedPrincipal);
     TTransport saslTransport =
         new TSaslClientTransport(
             "GSSAPI", null, names[0], names[1], saslProps, null, underlyingTransport);

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosUtils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/auth/KerberosUtils.java
@@ -46,6 +46,15 @@ public final class KerberosUtils {
     return format("%s/%s@%s", names[0], hostname.toLowerCase(ENGLISH), names[2]);
   }
 
+  public static String canonicalClientPrincipal(String principal, String hostname) {
+    String[] components = splitPrincipal(principal);
+    if (components.length != 3 || !components[1].equals(HOSTNAME_PATTERN)) {
+      return principal;
+    } else {
+      return canonicalPrincipal(principal, hostname);
+    }
+  }
+
   public static KerberosTicket getTgt(Subject subject) {
     Set<KerberosTicket> tickets = subject.getPrivateCredentials(KerberosTicket.class);
     for (KerberosTicket ticket : tickets) {


### PR DESCRIPTION
### _Why are the changes needed?_
1. `principal` supports `X/_HOST@EXAMPLE.COM`
2. `kyuubiClientPrincipal` supports headless keytab, `X@EXAMPLE.COM`

https://github.com/apache/incubator-kyuubi/pull/3023

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
