### PR TITLE
Backport HIVE-21899 - Utils.getCanonicalHostName() may return IP address depending on DNS infra

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -442,7 +442,13 @@ public class Utils {
    */
   public static String getCanonicalHostName(String hostName) {
     try {
-      return InetAddress.getByName(hostName).getCanonicalHostName();
+      InetAddress addr = InetAddress.getByName(hostName);
+      String canonicalHostname = addr.getCanonicalHostName();
+      if (canonicalHostname.equals(addr.getHostAddress())) {
+        return hostName;
+      } else {
+        return canonicalHostname;
+      }
     } catch (UnknownHostException exception) {
       LOG.warn("Could not retrieve canonical hostname for " + hostName, exception);
       return hostName;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Fix https://github.com/apache/incubator-kyuubi/issues/3352

It's a regression issue, that came from upgrading from Hive 2.3 to Hive 3.1.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
