### PR TITLE
Backport HIVE-20583 - Use canonical hostname only for kerberos auth in HiveConnection

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -130,6 +130,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
       throw new KyuubiSQLException(e);
     }
     jdbcUriString = connParams.getJdbcUriString();
+    sessConfMap = connParams.getSessionVars();
     // JDBC URL: jdbc:hive2://<host>:<port>/dbName;sess_var_list?hive_conf_list#hive_var_list
     // each list: <key1>=<val1>;<key2>=<val2> and so on
     // sess_var_list -> sessConfMap
@@ -141,7 +142,6 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
       host = connParams.getHost();
     }
     port = connParams.getPort();
-    sessConfMap = connParams.getSessionVars();
 
     setupTimeout();
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -135,7 +135,11 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     // sess_var_list -> sessConfMap
     // hive_conf_list -> hiveConfMap
     // hive_var_list -> hiveVarMap
-    host = Utils.getCanonicalHostName(connParams.getHost());
+    if (isKerberosAuthMode()) {
+      host = Utils.getCanonicalHostName(connParams.getHost());
+    } else {
+      host = connParams.getHost();
+    }
     port = connParams.getPort();
     sessConfMap = connParams.getSessionVars();
 
@@ -200,7 +204,11 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
           }
           // Update with new values
           jdbcUriString = connParams.getJdbcUriString();
-          host = Utils.getCanonicalHostName(connParams.getHost());
+          if (isKerberosAuthMode()) {
+            host = Utils.getCanonicalHostName(connParams.getHost());
+          } else {
+            host = connParams.getHost();
+          }
           port = connParams.getPort();
         } else {
           errMsg = warnMsg;
@@ -814,6 +822,10 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
 
   private boolean isPlainSaslAuthMode() {
     return isSaslAuthMode() && !hasSessionValue(AUTH_PRINCIPAL);
+  }
+
+  private boolean isKerberosAuthMode() {
+    return isSaslAuthMode() && hasSessionValue(AUTH_PRINCIPAL);
   }
 
   private Subject createSubject() {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix #3352

[HIVE-17218](https://issues.apache.org/jira/browse/HIVE-17218): Canonical-ize hostnames for Hive metastore, and HS2 servers

This may have the problem mentioned by JIRA

[HIVE-20583](https://issues.apache.org/jira/browse/HIVE-20583): Use canonical hostname only for kerberos auth in HiveConnection

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
