### PR TITLE
[KYUUBI #3360] [Improvement] [AUTHZ] Batch verifing column privileges for single AccessRequest in RuleAuthorization

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -76,13 +76,11 @@ object RuleAuthorization {
       val resource = request.getResource.asInstanceOf[AccessResource]
       resource.objectType match {
         case ObjectType.COLUMN if resource.getColumns.nonEmpty =>
-          val reqs = ArrayBuffer[AccessRequest]()
-          resource.getColumns.foreach { col =>
+          val reqs = resource.getColumns.map { col =>
             val cr = AccessResource(COLUMN, resource.getDatabase, resource.getTable, col)
-            val req = AccessRequest(cr, ugi, opType, request.accessType)
-            reqs += req
-          }
-          batchVerify(reqs.toList, auditHandler)
+            AccessRequest(cr, ugi, opType, request.accessType)
+          }.toList
+          batchVerify(reqs, auditHandler)
         case _ => verify(request, auditHandler)
       }
     }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -93,13 +93,14 @@ object RuleAuthorization {
   private def batchVerify(
       reqList: List[AccessRequest],
       auditHandler: SparkRangerAuditHandler): Unit = {
-    val rets = SparkRangerAdminPlugin.isAccessAllowed(
+    val results = SparkRangerAdminPlugin.isAccessAllowed(
       reqList.asJava.asInstanceOf[util.Collection[RangerAccessRequest]],
       auditHandler)
       .asScala.toList
 
-    reqList.zipWithIndex.map { case (req, idx) => (req, rets(idx)) }
-      .find { case (_, ret) => !ret.getIsAllowed }.orNull match {
+    reqList.zipWithIndex.map { case (req, idx) => (req, results(idx)) }
+      .find { case (_, r) => r != null && !r.getIsAllowed }
+      .orNull match {
       case (req, _) =>
         throw new AccessControlException(
           s"""

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -22,6 +22,7 @@ import java.util
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
+import org.apache.commons.collections.CollectionUtils
 import org.apache.ranger.plugin.policyengine.RangerAccessRequest
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -86,11 +87,16 @@ object RuleAuthorization {
     }
   }
 
+  @throws[AccessControlException]
   private def verify(
       requests: util.List[RangerAccessRequest],
       auditHandler: SparkRangerAuditHandler): Unit = {
+    if (CollectionUtils.isEmpty(requests)) {
+      return
+    }
+
     val results = SparkRangerAdminPlugin.isAccessAllowed(requests, auditHandler)
-    if (results != null && !results.isEmpty) {
+    if (CollectionUtils.isNotEmpty(results)) {
       requests.asScala.zip(results.asScala).foreach {
         case (req, result) =>
           if (result != null && !result.getIsAllowed) {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

fix #3360.

- support batch verifying calling to Ranger plugin, keep emitting exception for first unallowed request
- batch verifying privilege of columns for single resource

Befor PR,
```
case ObjectType.COLUMN if resource.getColumns.nonEmpty =>
  resource.getColumns.foreach { col =>
   ...
    verify(req, auditHandler)
  }
```

After PR,
```scala
case ObjectType.COLUMN if resource.getColumns.nonEmpty =>
    val reqs = ArrayBuffer[AccessRequest]()
    resource.getColumns.foreach { col =>
      ...
      reqs += req
    }
    batchVerify(reqs.toList, auditHandler)
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
