### PR TITLE
[KYUUBI #3371] [FEATURE] [AUTHZ] Support checking access privileges in single call and throws all disallowed in exception

### DIFF
--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -92,13 +92,13 @@ Macros are now supported for using user/group/tag in row filter expressions, int
     </property>    
 ```
 
-##### Checking all required Access privileges
-By default, Authz plugin checks required privileges one by one and throw the first unsatisfied privilege in exception. Setting `ranger.plugin.spark.enable.full.access.check` to enable access checking in one single call and all disallowed privileges will be thrown in exception message.
+##### Throwing all disallowed privileges
+By default, Authz plugin checks required privileges one by one and throw the first unsatisfied privilege in exception. By setting `ranger.plugin.spark.enable.full.access.check` to `true`, Authz plugin execute access checking in single call and throws all disallowed privileges in exception message.
 ```xml
     <property>
         <name>ranger.plugin.plugin.authorize.in.single.call</name>
         <value>true</value>
-        <description>Enable access checks in single call and showing all disallowed privileges in exception. Default value is false.</description>
+        <description>Enable access checks in single call with all disallowed privileges thrown in exception. Default value is false.</description>
     </property>
 ```
 

--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -93,13 +93,13 @@ Macros are now supported for using user/group/tag in row filter expressions, int
 ```
 
 ##### Checking all required Access privileges
-By default, Authz plugin checks required privileges one by one and throw the first unsatisfied privilege in exception message. By adding the following config `ranger.plugin.spark.enable.full.access.check`, full access checking for all privileges is enabled and it collects all unsatisfied privileges on related resources in exception message.
+By default, Authz plugin checks required privileges one by one and throw the first unsatisfied privilege in exception. Setting `ranger.plugin.spark.enable.full.access.check` to enable access checking in one single call and all disallowed privileges will be thrown in exception message.
 ```xml
     <property>
-        <name>ranger.plugin.spark.enable.full.access.check</name>
+        <name>ranger.plugin.plugin.authorize.in.single.call</name>
         <value>true</value>
-        <description>Enable access checking for all privileges required by the query. Default value is false.</description>
-    </property>    
+        <description>Enable access checks in single call and showing all disallowed privileges in exception. Default value is false.</description>
+    </property>
 ```
 
 #### ranger-spark-audit.xml

--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -93,10 +93,10 @@ Macros are now supported for using user/group/tag in row filter expressions, int
 ```
 
 ##### Throwing all disallowed privileges
-By default, Authz plugin checks required privileges one by one and throw the first unsatisfied privilege in exception. By setting `ranger.plugin.spark.enable.full.access.check` to `true`, Authz plugin execute access checking in single call and throws all disallowed privileges in exception message.
+By default, Authz plugin checks required privileges one by one and throw the first unsatisfied privilege in exception. By setting `ranger.plugin.spark.authorize.in.single.call` to `true`, Authz plugin executes access checks in single call and throws all disallowed privileges in exception message.
 ```xml
     <property>
-        <name>ranger.plugin.plugin.authorize.in.single.call</name>
+        <name>ranger.plugin.spark.authorize.in.single.call</name>
         <value>true</value>
         <description>Enable access checks in single call with all disallowed privileges thrown in exception. Default value is false.</description>
     </property>

--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -92,7 +92,7 @@ Macros are now supported for using user/group/tag in row filter expressions, int
     </property>    
 ```
 
-##### Throwing all disallowed privileges
+##### Showing all disallowed privileges
 By default, Authz plugin checks required privileges one by one and throw the first unsatisfied privilege in exception. By setting `ranger.plugin.spark.authorize.in.single.call` to `true`, Authz plugin executes access checks in single call and throws all disallowed privileges in exception message.
 ```xml
     <property>

--- a/docs/security/authorization/spark/install.md
+++ b/docs/security/authorization/spark/install.md
@@ -92,6 +92,16 @@ Macros are now supported for using user/group/tag in row filter expressions, int
     </property>    
 ```
 
+##### Checking all required Access privileges
+By default, Authz plugin checks required privileges one by one and throw the first unsatisfied privilege in exception message. By adding the following config `ranger.plugin.spark.enable.full.access.check`, full access checking for all privileges is enabled and it collects all unsatisfied privileges on related resources in exception message.
+```xml
+    <property>
+        <name>ranger.plugin.spark.enable.full.access.check</name>
+        <value>true</value>
+        <description>Enable access checking for all privileges required by the query. Default value is false.</description>
+    </property>    
+```
+
 #### ranger-spark-audit.xml
 
 Create `ranger-spark-audit.xml` in `$SPARK_HOME/conf` and add the following configurations

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -20,6 +20,7 @@ package org.apache.kyuubi.plugin.spark.authz.ranger
 import java.util
 
 import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.commons.collections.CollectionUtils
@@ -48,6 +49,8 @@ object RuleAuthorization {
 
   val KYUUBI_AUTHZ_TAG = TreeNodeTag[Boolean]("__KYUUBI_AUTHZ_TAG")
 
+  val CONF_FULL_ACCESS_CHECK_ENABLE = "kyuubi.authz.enable.full.access.check"
+
   def checkPrivileges(spark: SparkSession, plan: LogicalPlan): Unit = {
     val auditHandler = new SparkRangerAuditHandler
     val ugi = getAuthzUgi(spark.sparkContext)
@@ -73,6 +76,7 @@ object RuleAuthorization {
     addAccessRequest(inputs, isInput = true)
     addAccessRequest(outputs, isInput = false)
 
+    val accessReqs = ArrayBuffer[Seq[RangerAccessRequest]]()
     requests.foreach { request =>
       val resource = request.getResource.asInstanceOf[AccessResource]
       resource.objectType match {
@@ -80,9 +84,22 @@ object RuleAuthorization {
           val reqs = resource.getColumns.map { col =>
             val cr = AccessResource(COLUMN, resource.getDatabase, resource.getTable, col)
             AccessRequest(cr, ugi, opType, request.accessType).asInstanceOf[RangerAccessRequest]
-          }.asJava
-          verify(reqs, auditHandler)
-        case _ => verify(util.Collections.singletonList(request), auditHandler)
+          }
+          accessReqs += reqs
+        case _ => accessReqs += Seq(request)
+      }
+    }
+    val isEnabledFullAccessCheck = "true".equalsIgnoreCase(
+      spark.sparkContext.getLocalProperty(CONF_FULL_ACCESS_CHECK_ENABLE))
+    if (isEnabledFullAccessCheck) {
+      verify(
+        accessReqs.toStream.flatMap(_.toStream).asJava,
+        auditHandler,
+        isEnabledFullAccessCheck = true)
+    } else {
+      accessReqs.foreach {
+        reqList =>
+          verify(reqList.asJava, auditHandler, isEnabledFullAccessCheck = false)
       }
     }
   }
@@ -90,21 +107,50 @@ object RuleAuthorization {
   @throws[AccessControlException]
   private def verify(
       requests: util.List[RangerAccessRequest],
-      auditHandler: SparkRangerAuditHandler): Unit = {
+      auditHandler: SparkRangerAuditHandler,
+      isEnabledFullAccessCheck: Boolean): Unit = {
     if (CollectionUtils.isEmpty(requests)) {
       return
     }
 
     val results = SparkRangerAdminPlugin.isAccessAllowed(requests, auditHandler)
-    if (CollectionUtils.isNotEmpty(results)) {
-      requests.asScala.zip(results.asScala).foreach {
-        case (req, result) =>
-          if (result != null && !result.getIsAllowed) {
-            throw new AccessControlException(
-              s"Permission denied: user [${req.getUser}] does not have [${req.getAccessType}]" +
-                s" privilege on [${req.getResource.getAsString}]")
-          }
+    val disallowedReqs = requests.asScala.zip(results.asScala).filter {
+      case (_, result) => result != null && !result.getIsAllowed
+    } map { case (req, _) => req }
+
+    if (disallowedReqs.isEmpty) {
+      return
+    }
+
+    if (!isEnabledFullAccessCheck) {
+      val req = disallowedReqs.headOption.orNull
+      if (req != null) {
+        if (!isEnabledFullAccessCheck) {
+          throw new AccessControlException(
+            s"Permission denied: user [${req.getUser}]" +
+              s" does not have [${req.getAccessType}]" +
+              s" privilege on [${req.getResource.getAsString}]")
+        }
       }
+    } else {
+      val accessType2ResMap: mutable.Map[String, mutable.Set[String]] =
+        mutable.SortedMap()
+      disallowedReqs.foreach { req =>
+        {
+          val resourceSet = accessType2ResMap.getOrElseUpdate(
+            req.getAccessType,
+            mutable.SortedSet[String]())
+          resourceSet += req.getResource.getAsString
+        }
+      }
+
+      val user: String = disallowedReqs.head.getUser
+      val privilegeErrorMsg = accessType2ResMap.map {
+        case (accessType, resSet) =>
+          s"[${accessType}] privilege on [${resSet.mkString(",")}]"
+      }.mkString(", ")
+      throw new AccessControlException(
+        s"Permission denied: user [${user}] does not have ${privilegeErrorMsg}")
     }
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -17,22 +17,19 @@
 
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
-import java.util
-
 import scala.collection.JavaConverters._
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
-import org.apache.commons.collections.CollectionUtils
 import org.apache.ranger.plugin.policyengine.RangerAccessRequest
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.catalyst.rules.Rule
 import org.apache.spark.sql.catalyst.trees.TreeNodeTag
 
-import org.apache.kyuubi.plugin.spark.authz.{AccessControlException, ObjectType, _}
+import org.apache.kyuubi.plugin.spark.authz._
 import org.apache.kyuubi.plugin.spark.authz.ObjectType._
 import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization.KYUUBI_AUTHZ_TAG
+import org.apache.kyuubi.plugin.spark.authz.ranger.SparkRangerAdminPlugin._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 class RuleAuthorization(spark: SparkSession) extends Rule[LogicalPlan] {
@@ -48,9 +45,6 @@ class RuleAuthorization(spark: SparkSession) extends Rule[LogicalPlan] {
 object RuleAuthorization {
 
   val KYUUBI_AUTHZ_TAG = TreeNodeTag[Boolean]("__KYUUBI_AUTHZ_TAG")
-
-  val CONF_FULL_ACCESS_CHECK_ENABLE =
-    s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.enable.full.access.check"
 
   def checkPrivileges(spark: SparkSession, plan: LogicalPlan): Unit = {
     val auditHandler = new SparkRangerAuditHandler
@@ -90,68 +84,20 @@ object RuleAuthorization {
         case _ => accessReqs += Seq(request)
       }
     }
-    val isEnabledFullAccessCheck =
-      SparkRangerAdminPlugin.getConfig.getBoolean(CONF_FULL_ACCESS_CHECK_ENABLE, false)
-    if (isEnabledFullAccessCheck) {
-      verify(
+
+    if (isEnabledFullAccessCheck()) {
+      SparkRangerAdminPlugin.verify(
         accessReqs.toStream.flatMap(_.toStream).asJava,
         auditHandler,
-        isEnabledFullAccessCheck = true)
+        enabledFullAccessViolationMsg = true)
     } else {
       accessReqs.foreach {
         reqList =>
-          verify(reqList.asJava, auditHandler, isEnabledFullAccessCheck = false)
+          SparkRangerAdminPlugin.verify(
+            reqList.asJava,
+            auditHandler,
+            enabledFullAccessViolationMsg = false)
       }
-    }
-  }
-
-  @throws[AccessControlException]
-  private def verify(
-      requests: util.List[RangerAccessRequest],
-      auditHandler: SparkRangerAuditHandler,
-      isEnabledFullAccessCheck: Boolean): Unit = {
-    if (CollectionUtils.isEmpty(requests)) {
-      return
-    }
-
-    val results = SparkRangerAdminPlugin.isAccessAllowed(requests, auditHandler)
-
-    val disallowedReqs = requests.asScala.zip(results.asScala).filter {
-      case (_, result) => result != null && !result.getIsAllowed
-    } map { case (req, _) => req }
-    if (disallowedReqs.isEmpty) {
-      return
-    }
-
-    if (!isEnabledFullAccessCheck) {
-      val req = disallowedReqs.headOption.orNull
-      if (req != null) {
-        if (!isEnabledFullAccessCheck) {
-          throw new AccessControlException(
-            s"Permission denied: user [${req.getUser}]" +
-              s" does not have [${req.getAccessType}]" +
-              s" privilege on [${req.getResource.getAsString}]")
-        }
-      }
-    } else {
-      val accessType2ResMap: mutable.Map[String, mutable.Set[String]] =
-        mutable.SortedMap()
-      disallowedReqs.foreach { req =>
-        {
-          val resourceSet = accessType2ResMap.getOrElseUpdate(
-            req.getAccessType,
-            mutable.SortedSet[String]())
-          resourceSet += req.getResource.getAsString
-        }
-      }
-
-      val user: String = disallowedReqs.head.getUser
-      val privilegeErrorMsg = accessType2ResMap.map {
-        case (accessType, resSet) =>
-          s"[${accessType}] privilege on [${resSet.mkString(",")}]"
-      }.mkString(", ")
-      throw new AccessControlException(
-        s"Permission denied: user [${user}] does not have ${privilegeErrorMsg}")
     }
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -17,9 +17,6 @@
 
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
-import java.util.Collections
-
-import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
 import org.apache.ranger.plugin.policyengine.RangerAccessRequest
@@ -85,10 +82,10 @@ object RuleAuthorization {
     }
 
     if (authorizeInSingleCall) {
-      verify(requestArrays.flatten.asJava, auditHandler)
+      verify(requestArrays.flatten, auditHandler)
     } else {
       requestArrays.flatten.foreach { req =>
-        verify(Collections.singletonList(req), auditHandler)
+        verify(Seq(req), auditHandler)
       }
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -84,10 +84,10 @@ object RuleAuthorization {
     }
 
     if (authorizeInSingleCall) {
-      verify(requestArrays.flatten.asJava, auditHandler, authorizeInSingleCall)
+      verify(requestArrays.flatten.asJava, auditHandler)
     } else {
-      requestArrays.foreach {
-        requests => verify(requests.asJava, auditHandler, authorizeInSingleCall)
+      requestArrays.foreach { requests =>
+        verify(requests.asJava, auditHandler)
       }
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.plugin.spark.authz.ranger
 
+import java.util.Collections
+
 import scala.collection.JavaConverters._
 import scala.collection.mutable.ArrayBuffer
 
@@ -30,8 +32,7 @@ import org.apache.kyuubi.plugin.spark.authz._
 import org.apache.kyuubi.plugin.spark.authz.ObjectType._
 import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization.KYUUBI_AUTHZ_TAG
 import org.apache.kyuubi.plugin.spark.authz.ranger.SparkRangerAdminPlugin._
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
-
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._;
 class RuleAuthorization(spark: SparkSession) extends Rule[LogicalPlan] {
   override def apply(plan: LogicalPlan): LogicalPlan = plan match {
     case p if !plan.getTagValue(KYUUBI_AUTHZ_TAG).contains(true) =>
@@ -87,7 +88,9 @@ object RuleAuthorization {
       verify(requestArrays.flatten.asJava, auditHandler)
     } else {
       requestArrays.foreach { requests =>
-        verify(requests.asJava, auditHandler)
+        requests.foreach { req =>
+          verify(Collections.singletonList(req), auditHandler)
+        }
       }
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -87,10 +87,8 @@ object RuleAuthorization {
     if (authorizeInSingleCall) {
       verify(requestArrays.flatten.asJava, auditHandler)
     } else {
-      requestArrays.foreach { requests =>
-        requests.foreach { req =>
-          verify(Collections.singletonList(req), auditHandler)
-        }
+      requestArrays.flatten.foreach { req =>
+        verify(Collections.singletonList(req), auditHandler)
       }
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -110,11 +110,11 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql") {
         if (indices.nonEmpty) {
           val user = requests.head.getUser
           val accessTypeToResource =
-            indices.foldLeft(mutable.Map.empty[String, mutable.Set[String]])((m, idx) => {
+            indices.foldLeft(mutable.LinkedHashMap.empty[String, mutable.Set[String]])((m, idx) => {
               val req = requests(idx)
               val accessType = req.getAccessType
               val resource = req.getResource.getAsString
-              m.getOrElseUpdate(accessType, mutable.Set.empty[String]) += resource
+              m.getOrElseUpdate(accessType, mutable.LinkedHashSet.empty[String]) += resource
               m
             })
           val errorMsg = accessTypeToResource

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -26,8 +26,10 @@ import org.apache.ranger.plugin.service.RangerBasePlugin
 
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
+import org.apache.kyuubi.plugin.spark.authz.util.RangerConfigProvider
 
-object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql") {
+object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql")
+  with RangerConfigProvider {
 
   /**
    * For a Spark SQL query, it may contain 0 or more privilege objects to verify, e.g. a typical
@@ -36,8 +38,9 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql") {
    * This configuration controls whether to verify the privilege objects in single call or
    * to verify them one by one.
    */
-  def authorizeInSingleCall: Boolean =
-    getConfig.getBoolean(s"ranger.plugin.${getServiceType}.authorize.in.single.call", false)
+  def authorizeInSingleCall: Boolean = getRangerConf.getBoolean(
+    s"ranger.plugin.${getServiceType}.authorize.in.single.call",
+    false)
 
   def getFilterExpr(req: AccessRequest): Option[String] = {
     val result = evalRowFilterPolicies(req, null)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -31,10 +31,15 @@ import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql") {
 
-  val CONF_ENABLE_FULL_ACCESS_VIOLATION_MSG =
-    s"ranger.plugin.${getServiceType}.enable.full.access.violation.msg"
-  val isEnabledFullAccessCheck: () => Boolean =
-    () => getConfig.getBoolean(CONF_ENABLE_FULL_ACCESS_VIOLATION_MSG, false)
+  /**
+   * For a Spark SQL query, it may contain 0 or more privilege objects to verify, e.g. a typical
+   * JOIN operator may have two tables and their columns to verify.
+   *
+   * This configuration controls whether to verify the privilege objects in a single RPC call or
+   * to verify them one by one.
+   */
+  def authorizeInSingleCall: Boolean =
+    getConfig.getBoolean(s"ranger.plugin.${getServiceType}.authorize.in.single.call", false)
 
   def getFilterExpr(req: AccessRequest): Option[String] = {
     val result = evalRowFilterPolicies(req, null)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -35,7 +35,7 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql") {
    * For a Spark SQL query, it may contain 0 or more privilege objects to verify, e.g. a typical
    * JOIN operator may have two tables and their columns to verify.
    *
-   * This configuration controls whether to verify the privilege objects in a single RPC call or
+   * This configuration controls whether to verify the privilege objects in single call or
    * to verify them one by one.
    */
   def authorizeInSingleCall: Boolean =
@@ -95,6 +95,12 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql") {
     digits
   }
 
+  /**
+   * batch verifying RangerAccessRequests
+   * and throws exception with all disallowed privileges
+   * for accessType and resources
+   * in alphabet order
+   */
   @throws[AccessControlException]
   def verify(
       requests: util.List[RangerAccessRequest],
@@ -125,6 +131,7 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql") {
       case (accessType, resSet) =>
         s"[${accessType}] privilege on [${resSet.mkString(",")}]"
     }.mkString(", ")
+
     throw new AccessControlException(
       s"Permission denied: user [${user}] does not have ${privilegeErrorMsg}")
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/SparkRangerAdminPlugin.scala
@@ -96,7 +96,6 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql") {
    * batch verifying RangerAccessRequests
    * and throws exception with all disallowed privileges
    * for accessType and resources
-   * in alphabet order
    */
   @throws[AccessControlException]
   def verify(
@@ -111,11 +110,11 @@ object SparkRangerAdminPlugin extends RangerBasePlugin("spark", "sparkSql") {
         if (indices.nonEmpty) {
           val user = requests.head.getUser
           val accessTypeToResource =
-            indices.foldLeft(mutable.SortedMap.empty[String, mutable.Set[String]])((m, idx) => {
+            indices.foldLeft(mutable.Map.empty[String, mutable.Set[String]])((m, idx) => {
               val req = requests(idx)
               val accessType = req.getAccessType
               val resource = req.getResource.getAsString
-              m.getOrElseUpdate(accessType, mutable.SortedSet.empty[String]) += resource
+              m.getOrElseUpdate(accessType, mutable.Set.empty[String]) += resource
               m
             })
           val errorMsg = accessTypeToResource

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -48,7 +48,17 @@ private[authz] object AuthZUtils {
       methodName: String,
       args: (Class[_], AnyRef)*): AnyRef = {
     val (types, values) = args.unzip
-    val method = obj.getClass.getDeclaredMethod(methodName, types: _*)
+    val method = obj.getClass.getMethod(methodName, types: _*)
+    method.setAccessible(true)
+    method.invoke(obj, values: _*)
+  }
+
+  def invokeStatic(
+      obj: Class[_],
+      methodName: String,
+      args: (Class[_], AnyRef)*): AnyRef = {
+    val (types, values) = args.unzip
+    val method = obj.getMethod(methodName, types: _*)
     method.setAccessible(true)
     method.invoke(obj, values: _*)
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/RangerConfigProvider.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/RangerConfigProvider.scala
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz.util
+
+import org.apache.hadoop.conf.Configuration
+
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
+
+trait RangerConfigProvider {
+
+  /**
+   * Get plugin config of different Ranger versions
+   *
+   * @return instance of
+   *         org.apache.ranger.authorization.hadoop.config.RangerPluginConfig
+   *         for Ranger 2.1 and above,
+   *         or instance of
+   *         org.apache.ranger.authorization.hadoop.config.RangerConfiguration
+   *         for Ranger 2.0 and below
+   */
+  def getRangerConf: Configuration = {
+    try {
+      // for Ranger 2.1+
+      invoke(this, "getConfig").asInstanceOf[Configuration]
+    } catch {
+      case _: NoSuchMethodException =>
+        // for Ranger 2.0 and below
+        invokeStatic(
+          Class.forName("org.apache.ranger.authorization.hadoop.config.RangerConfiguration"),
+          "getInstance")
+          .asInstanceOf[Configuration]
+    }
+  }
+}

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -616,8 +616,8 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       val e2 = intercept[AccessControlException](doAs("someone", sql(insertSql1)))
       assert(e2.getMessage.contains(s"does not have" +
         s" [select] privilege on" +
-        s" [$db1/$srcTable1/city,$db1/$srcTable1/id,$db1/$srcTable1/name," +
-        s"$db1/$srcTable2/age,$db1/$srcTable2/id]," +
+        s" [$db1/$srcTable1/id,$db1/$srcTable1/city,$db1/$srcTable1/age," +
+        s"$db1/$srcTable2/name,$db1/$srcTable2/id]," +
         s" [update] privilege on [$db1/$sinkTable1]"))
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -35,8 +35,8 @@ import org.scalatest.funsuite.AnyFunSuite
 
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
-import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization.CONF_FULL_ACCESS_CHECK_ENABLE
 import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization.KYUUBI_AUTHZ_TAG
+import org.apache.kyuubi.plugin.spark.authz.ranger.SparkRangerAdminPlugin.CONF_ENABLE_FULL_ACCESS_VIOLATION_MSG
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getFieldVal
 
 abstract class RangerSparkExtensionSuite extends AnyFunSuite
@@ -596,13 +596,13 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         sql(s"CREATE TABLE IF NOT EXISTS $db1.$sinkTable" +
           s" (id int, name string, city string)"))
 
-      SparkRangerAdminPlugin.getConfig.setBoolean(CONF_FULL_ACCESS_CHECK_ENABLE, false)
+      SparkRangerAdminPlugin.getConfig.setBoolean(CONF_ENABLE_FULL_ACCESS_VIOLATION_MSG, false)
       val e1 = intercept[AccessControlException](
         doAs("someone", sql(s"select * from $db1.$table")).explain)
       assert(e1.getMessage.contains(s"does not have [select] privilege on" +
         s" [$db1/$table/id]"))
 
-      SparkRangerAdminPlugin.getConfig.setBoolean(CONF_FULL_ACCESS_CHECK_ENABLE, true)
+      SparkRangerAdminPlugin.getConfig.setBoolean(CONF_ENABLE_FULL_ACCESS_VIOLATION_MSG, true)
       val e2 = intercept[AccessControlException](
         doAs("someone", sql(s"select * from $db1.$table")).explain)
       assert(e2.getMessage.contains(s"does not have [select] privilege on" +

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -596,13 +596,13 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         sql(s"CREATE TABLE IF NOT EXISTS $db1.$sinkTable" +
           s" (id int, name string, city string)"))
 
-      spark.sparkContext.setLocalProperty(CONF_FULL_ACCESS_CHECK_ENABLE, "false")
+      SparkRangerAdminPlugin.getConfig.setBoolean(CONF_FULL_ACCESS_CHECK_ENABLE, false)
       val e1 = intercept[AccessControlException](
         doAs("someone", sql(s"select * from $db1.$table")).explain)
       assert(e1.getMessage.contains(s"does not have [select] privilege on" +
         s" [$db1/$table/id]"))
 
-      spark.sparkContext.setLocalProperty(CONF_FULL_ACCESS_CHECK_ENABLE, "true")
+      SparkRangerAdminPlugin.getConfig.setBoolean(CONF_FULL_ACCESS_CHECK_ENABLE, true)
       val e2 = intercept[AccessControlException](
         doAs("someone", sql(s"select * from $db1.$table")).explain)
       assert(e2.getMessage.contains(s"does not have [select] privilege on" +

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -36,7 +36,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization.KYUUBI_AUTHZ_TAG
-import org.apache.kyuubi.plugin.spark.authz.ranger.SparkRangerAdminPlugin.CONF_ENABLE_FULL_ACCESS_VIOLATION_MSG
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.getFieldVal
 
 abstract class RangerSparkExtensionSuite extends AnyFunSuite
@@ -596,13 +595,17 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
         sql(s"CREATE TABLE IF NOT EXISTS $db1.$sinkTable" +
           s" (id int, name string, city string)"))
 
-      SparkRangerAdminPlugin.getConfig.setBoolean(CONF_ENABLE_FULL_ACCESS_VIOLATION_MSG, false)
+      SparkRangerAdminPlugin.getConfig.setBoolean(
+        s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
+        false)
       val e1 = intercept[AccessControlException](
         doAs("someone", sql(s"select * from $db1.$table")).explain)
       assert(e1.getMessage.contains(s"does not have [select] privilege on" +
         s" [$db1/$table/id]"))
 
-      SparkRangerAdminPlugin.getConfig.setBoolean(CONF_ENABLE_FULL_ACCESS_VIOLATION_MSG, true)
+      SparkRangerAdminPlugin.getConfig.setBoolean(
+        s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
+        true)
       val e2 = intercept[AccessControlException](
         doAs("someone", sql(s"select * from $db1.$table")).explain)
       assert(e2.getMessage.contains(s"does not have [select] privilege on" +

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -616,8 +616,8 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       val e2 = intercept[AccessControlException](doAs("someone", sql(insertSql1)))
       assert(e2.getMessage.contains(s"does not have" +
         s" [select] privilege on" +
-        s" [$db1/$srcTable1/id,$db1/$srcTable1/city,$db1/$srcTable1/age," +
-        s"$db1/$srcTable2/name,$db1/$srcTable2/id]," +
+        s" [$db1/$srcTable1/id,$db1/$srcTable1/name,$db1/$srcTable1/city," +
+        s"$db1/$srcTable2/age,$db1/$srcTable2/id]," +
         s" [update] privilege on [$db1/$sinkTable1]"))
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -610,7 +610,7 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       val e1 = intercept[AccessControlException](doAs("someone", sql(insertSql1)))
       assert(e1.getMessage.contains(s"does not have [select] privilege on [$db1/$srcTable1/id]"))
 
-      SparkRangerAdminPlugin.getConfig.setBoolean(
+      SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
         true)
       val e2 = intercept[AccessControlException](doAs("someone", sql(insertSql1)))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

to close #3371 

Adding an ranger plugin config for enabling full access privileges,  Authz checks all access privileges and throw exception with message of unsatisfied  privileges on different resources in natural order in execution plan.



### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
