### PR TITLE
[KYUUBI #3312] Add subquery support for sql lineage parser

### DIFF
--- a/docs/extensions/engines/spark/lineage.md
+++ b/docs/extensions/engines/spark/lineage.md
@@ -56,9 +56,9 @@ The lineage of this SQL:
 
 #### Lineage specific identification
 
-- `__aggregate__`. Means that the column is an aggregate expression 
-  and cannot extract the specific column, such as `count(*)`. Lineage of the column
-  like `default.test_table0.__aggregate__`.
+- `__count__`. Means that the column is an `count(*)` aggregate expression 
+  and cannot extract the specific column. Lineage of the column
+  like `default.test_table0.__count__`.
 - `__local__`. Means that the lineage of the table is a `LocalRelation` and not the real table,
   like `__local__.a`
 

--- a/docs/extensions/engines/spark/lineage.md
+++ b/docs/extensions/engines/spark/lineage.md
@@ -54,6 +54,15 @@ The lineage of this SQL:
 }
 ```
 
+#### Lineage specific identification
+
+- `__aggregate__`. Means that the column is an aggregate expression 
+  and cannot extract the specific column, such as `count(*)`. Lineage of the column
+  like `default.test_table0.__aggregate__`.
+- `__local__`. Means that the lineage of the table is a `LocalRelation` and not the real table,
+  like `__local__.a`
+
+
 ### SQL type support
 
 Currently supported column lineage for spark's `Command` and `Query` type:

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/events/OperationLineageEvent.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/events/OperationLineageEvent.scala
@@ -41,6 +41,12 @@ class Lineage(
   }
 
   override def hashCode(): Int = super.hashCode()
+
+  override def toString: String = {
+    s"inputTables($inputTables)\n" +
+      s"outputTables($outputTables)\n" +
+      s"columnLineage($columnLineage)"
+  }
 }
 
 object Lineage {

--- a/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/test/scala/org/apache/kyuubi/plugin/lineage/helper/SparkSQLLineageParserHelperSuite.scala
@@ -713,7 +713,7 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
       List(),
       List(
         ("a", Set("test_db0.test_table0.key")),
-        ("b", Set("test_db0.test_table0.__aggregate__")),
+        ("b", Set("test_db0.test_table0.__count__")),
         ("c", Set()))))
 
     val sql1 = """select count(*) as a, 1 as b from test_db0.test_table0"""
@@ -722,7 +722,7 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
       List("test_db0.test_table0"),
       List(),
       List(
-        ("a", Set("test_db0.test_table0.__aggregate__")),
+        ("a", Set("test_db0.test_table0.__count__")),
         ("b", Set()))))
 
     val sql2 = """select every(count(key) == 1) as a, 1 as b from test_db0.test_table0"""
@@ -740,7 +740,7 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
       List("test_db0.test_table0"),
       List(),
       List(
-        ("a", Set("test_db0.test_table0.__aggregate__")),
+        ("a", Set("test_db0.test_table0.__count__")),
         ("b", Set()))))
 
     val sql4 = """select first(key) as a, 1 as b from test_db0.test_table0"""
@@ -759,6 +759,26 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
       List(),
       List(
         ("a", Set("test_db0.test_table0.key")),
+        ("b", Set()))))
+
+    val sql6 =
+      """select every(count(value) + sum(key) == 1) as a,
+        | 1 as b from test_db0.test_table0""".stripMargin
+    val ret6 = exectractLineage(sql6)
+    assert(ret6 == Lineage(
+      List("test_db0.test_table0"),
+      List(),
+      List(
+        ("a", Set("test_db0.test_table0.value", "test_db0.test_table0.key")),
+        ("b", Set()))))
+
+    val sql7 = """select every(count(*) + sum(key) == 1) as a, 1 as b from test_db0.test_table0"""
+    val ret7 = exectractLineage(sql7)
+    assert(ret7 == Lineage(
+      List("test_db0.test_table0"),
+      List(),
+      List(
+        ("a", Set("test_db0.test_table0.__count__", "test_db0.test_table0.key")),
         ("b", Set()))))
 
   }
@@ -805,7 +825,7 @@ class SparkSQLLineageParserHelperSuite extends KyuubiFunSuite
         List("default.table0", "default.table1"),
         List(),
         List(
-          ("aa", Set("default.table0.__aggregate__")),
+          ("aa", Set("default.table0.__count__")),
           ("bb", Set("default.table1.b")))))
 
       // ListQuery


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

close #3312 
### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

SQL supported like:
```sql

-- ScalarQuery
select (select a from table0) as aa, b as bb from table0
select (select count(*) from table0) as aa, b as bb from table0

-- Left Semi or Anti Join
select * from table0 where table0.a in (select a from table1)
select * from table0 where table0.a not in (select a from table1)
select * from table0 where exists (select * from table1 where table0.c = table1.c)

```



### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
