### PR TITLE
[BUILD] Suppress build log of dependencies classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1856,28 +1856,6 @@
                     <version>${maven.plugin.dependency.version}</version>
                     <executions>
                         <execution>
-                            <id>default-cli</id>
-                            <goals>
-                                <goal>build-classpath</goal>
-                            </goals>
-                            <configuration>
-                                <!-- This includes dependencies with 'runtime' and 'compile' scopes;
-                                     see the docs for includeScope for more details -->
-                                <includeScope>runtime</includeScope>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>generate-test-classpath</id>
-                            <phase>test-compile</phase>
-                            <goals>
-                                <goal>build-classpath</goal>
-                            </goals>
-                            <configuration>
-                                <includeScope>test</includeScope>
-                                <outputProperty>test_classpath</outputProperty>
-                            </configuration>
-                        </execution>
-                        <execution>
                             <id>copy-module-dependencies</id>
                             <phase>package</phase>
                             <goals>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Suppress build log of dependencies classpath
```
[INFO] --- maven-dependency-plugin:3.1.1:build-classpath (default-cli) @ kyuubi-metrics_2.12 ---
[INFO] Dependencies classpath:
/home/ubuntu/.m2/repository/io/dropwizard/metrics/metrics-jmx/4.2.8/metrics-jmx-4.2.8.jar:/home/ubuntu/.m2/repository/org/apache/logging/log4j/log4j-slf4j-impl/2.18.0/log4j-slf4j-impl-2.18.0.jar:/home/ubuntu/.m2/repository/org/apache/thrift/libfb303/0.9.3/libfb303-0.9.3.jar:/home/ubuntu/.m2/repository/io/prometheus/simpleclient_tracer_common/0.16.0/simpleclient_tracer_common-0.16.0.jar:/home/ubuntu/.m2/repository/org/eclipse/jetty/jetty-servlet/9.4.48.v20220622/jetty-servlet-9.4.48.v20220622.jar:/home/ubuntu/.m2/repository/io/prometheus/simpleclient/0.16.0/simpleclient-0.16.0.jar:/home/ubuntu/.m2/repository/org/apache/thrift/libthrift/0.9.3/libthrift-0.9.3.jar:/home/ubuntu/.m2/repository/io/prometheus/simpleclient_dropwizard/0.16.0/simpleclient_dropwizard-0.16.0.jar:/home/ubuntu/.m2/repository/io/prometheus/simpleclient_tracer_otel/0.16.0/simpleclient_tracer_otel-0.16.0.jar:/home/ubuntu/.m2/repository/io/dropwizard/metrics/metrics-json/4.2.8/metrics-json-4.2.8.jar:/home/ubuntu/.m2/repository/org/apache/hadoop/hadoop-client-runtime/3.3.4/hadoop-client-runtime-3.3.4.jar:/home/ubuntu/.m2/repository/io/prometheus/simpleclient_servlet_common/0.16.0/simpleclient_servlet_common-0.16.0.jar:/home/ubuntu/.m2/repository/org/apache/logging/log4j/log4j-1.2-api/2.18.0/log4j-1.2-api-2.18.0.jar:/home/ubuntu/.m2/repository/com/thoughtworks/paranamer/paranamer/2.8/paranamer-2.8.jar:/home/ubuntu/.m2/repository/org/apache/commons/commons-lang3/3.10/commons-lang3-3.10.jar:/home/ubuntu/.m2/repository/org/eclipse/jetty/jetty-util-ajax/9.4.48.v20220622/jetty-util-ajax-9.4.48.v20220622.jar:/home/ubuntu/.m2/repository/com/fasterxml/jackson/core/jackson-databind/2.13.3/jackson-databind-2.13.3.jar:/home/ubuntu/.m2/repository/io/prometheus/simpleclient_servlet/0.16.0/simpleclient_servlet-0.16.0.jar:/home/ubuntu/.m2/repository/org/eclipse/jetty/jetty-util/9.4.48.v20220622/jetty-util-9.4.48.v20220622.jar:/home/ubuntu/.m2/repository/io/dropwizard/metrics/metrics-jvm/4.2.8/metrics-jvm-4.2.8.jar:/home/ubuntu/apache-kyuubi/kyuubi-common/target/kyuubi-common_2.12-1.7.0-SNAPSHOT.jar:/home/ubuntu/.m2/repository/org/apache/logging/log4j/log4j-api/2.18.0/log4j-api-2.18.0.jar:/home/ubuntu/.m2/repository/org/scala-lang/scala-library/2.12.15/scala-library-2.12.15.jar:/home/ubuntu/.m2/repository/jakarta/servlet/jakarta.servlet-api/4.0.4/jakarta.servlet-api-4.0.4.jar:/home/ubuntu/.m2/repository/io/dropwizard/metrics/metrics-core/4.2.8/metrics-core-4.2.8.jar:/home/ubuntu/.m2/repository/org/eclipse/jetty/jetty-security/9.4.48.v20220622/jetty-security-9.4.48.v20220622.jar:/home/ubuntu/.m2/repository/org/eclipse/jetty/jetty-http/9.4.48.v20220622/jetty-http-9.4.48.v20220622.jar:/home/ubuntu/.m2/repository/org/apache/hadoop/hadoop-client-api/3.3.4/hadoop-client-api-3.3.4.jar:/home/ubuntu/.m2/repository/org/apache/hive/hive-service-rpc/3.1.3/hive-service-rpc-3.1.3.jar:/home/ubuntu/.m2/repository/org/eclipse/jetty/jetty-io/9.4.48.v20220622/jetty-io-9.4.48.v20220622.jar:/home/ubuntu/.m2/repository/org/slf4j/slf4j-api/1.7.35/slf4j-api-1.7.35.jar:/home/ubuntu/.m2/repository/org/slf4j/jcl-over-slf4j/1.7.35/jcl-over-slf4j-1.7.35.jar:/home/ubuntu/.m2/repository/com/zaxxer/HikariCP/4.0.3/HikariCP-4.0.3.jar:/home/ubuntu/.m2/repository/org/apache/logging/log4j/log4j-core/2.18.0/log4j-core-2.18.0.jar:/home/ubuntu/.m2/repository/commons-logging/commons-logging/1.1.3/commons-logging-1.1.3.jar:/home/ubuntu/.m2/repository/io/prometheus/simpleclient_common/0.16.0/simpleclient_common-0.16.0.jar:/home/ubuntu/.m2/repository/com/fasterxml/jackson/core/jackson-annotations/2.13.3/jackson-annotations-2.13.3.jar:/home/ubuntu/.m2/repository/org/eclipse/jetty/jetty-server/9.4.48.v20220622/jetty-server-9.4.48.v20220622.jar:/home/ubuntu/.m2/repository/org/slf4j/jul-to-slf4j/1.7.35/jul-to-slf4j-1.7.35.jar:/home/ubuntu/.m2/repository/com/fasterxml/jackson/core/jackson-core/2.13.3/jackson-core-2.13.3.jar:/home/ubuntu/.m2/repository/io/prometheus/simpleclient_tracer_otel_agent/0.16.0/simpleclient_tracer_otel_agent-0.16.0.jar:/home/ubuntu/.m2/repository/com/fasterxml/jackson/module/jackson-module-scala_2.12/2.13.3/jackson-module-scala_2.12-2.13.3.jar
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
