### PR TITLE
[TEST] Remove the unstable flink process builder test case

### DIFF
--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/flink/FlinkProcessBuilderSuite.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 import scala.collection.immutable.ListMap
 import scala.util.matching.Regex
 
-import org.apache.kyuubi.{KyuubiException, KyuubiFunSuite}
+import org.apache.kyuubi.KyuubiFunSuite
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_FLINK_EXTRA_CLASSPATH, ENGINE_FLINK_JAVA_OPTIONS, ENGINE_FLINK_MEMORY}
 import org.apache.kyuubi.engine.flink.FlinkProcessBuilder._
@@ -92,12 +92,6 @@ class FlinkProcessBuilderSuite extends KyuubiFunSuite {
       override def env: Map[String, String] = envWithAllHadoop
     }
     matchActualAndExpected(builder)
-  }
-
-  test("all hadoop related environment variables are configured except FLINK_HADOOP_CLASSPATH") {
-    assertThrows[KyuubiException](new FlinkProcessBuilder("vinoyang", conf) {
-      override def env: Map[String, String] = envWithoutHadoopCLASSPATH
-    })
   }
 
   test("only FLINK_HADOOP_CLASSPATH environment variables are configured") {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix https://github.com/apache/incubator-kyuubi/issues/3405

The test case is unstable, the result depends on whether we pre-build `kyuubi-flink-sql-engine` first, so we just remove it to avoid confusing users.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
