### PR TITLE
[KYUUBI #3424] [FEATURE] [AUTHZ] Access privilege checks for namespaces and tables of DatasourceV2

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -217,11 +217,11 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.spark</groupId>
-            <artifactId>spark-catalyst_${scala.binary.version}</artifactId>
-            <type>test-jar</type>
-        </dependency>
+        <!--<dependency>-->
+        <!--    <groupId>org.apache.spark</groupId>-->
+        <!--    <artifactId>spark-catalyst_${scala.binary.version}</artifactId>-->
+        <!--    <type>test-jar</type>-->
+        <!--</dependency>-->
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -217,12 +217,6 @@
             <scope>provided</scope>
         </dependency>
 
-        <!--<dependency>-->
-        <!--    <groupId>org.apache.spark</groupId>-->
-        <!--    <artifactId>spark-catalyst_${scala.binary.version}</artifactId>-->
-        <!--    <type>test-jar</type>-->
-        <!--</dependency>-->
-
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client-api</artifactId>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -47,9 +47,14 @@ object OperationType extends Enumeration {
       case "AlterDatabaseSetLocationCommand" |
           "SetNamespaceLocation" => ALTERDATABASE_LOCATION
       case "AlterTableAddColumnsCommand" |
-          "AlterHoodieTableAddColumnsCommand" => ALTERTABLE_ADDCOLS
+          "AlterHoodieTableAddColumnsCommand" |
+          "AddColumns" |
+          "AlterColumn" |
+          "DropColumns" => ALTERTABLE_ADDCOLS
       case "AlterTableAddPartitionCommand" => ALTERTABLE_ADDPARTS
-      case "AlterTableChangeColumnCommand" => ALTERTABLE_REPLACECOLS
+      case "AlterTableChangeColumnCommand" |
+          "RenameColumn" |
+          "ReplaceColumns" => ALTERTABLE_REPLACECOLS
       case "AlterTableDropPartitionCommand" => ALTERTABLE_DROPPARTS
       case "AlterTableRenameCommand" => ALTERTABLE_RENAME
       case "AlterTableRecoverPartitionsCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -48,6 +48,7 @@ object OperationType extends Enumeration {
           "SetNamespaceLocation" => ALTERDATABASE_LOCATION
       case "AlterTableAddColumnsCommand" |
           "AlterHoodieTableAddColumnsCommand" |
+          "AlterTable" | // todo identify add col for AlterTable
           "AddColumns" |
           "AlterColumn" |
           "DropColumns" => ALTERTABLE_ADDCOLS
@@ -77,6 +78,7 @@ object OperationType extends Enumeration {
           "CreateDataSourceTableCommand" |
           "CreateTableLikeCommand" |
           "CreateTable" |
+          "CreateV2Table" |
           "CreateTableAsSelect" => CREATETABLE
       case "CreateViewCommand" |
           "CacheTableCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -61,7 +61,7 @@ object OperationType extends Enumeration {
           "AlterTableUnsetPropertiesCommand" => ALTERTABLE_PROPERTIES
       case ava if ava.contains("AlterViewAs") => ALTERVIEW_AS
       case ac if ac.startsWith("Analyze") => ANALYZE_TABLE
-      case "AppendData" => ALTERTABLE_ADDPARTS
+      case "AppendData" => QUERY
       case "CreateDatabaseCommand" | "CreateNamespace" => CREATEDATABASE
       case "CreateFunctionCommand" | "CreateFunction" => CREATEFUNCTION
       case "CreateTableAsSelect" |
@@ -90,8 +90,7 @@ object OperationType extends Enumeration {
           "InsertIntoDataSourceDirCommand" |
           "InsertIntoHiveTable" |
           "InsertIntoHiveDirCommand" |
-          "SaveIntoDataSourceCommand" |
-          "AppendData" => QUERY // todo AppendData redundant and shadowed conflict
+          "SaveIntoDataSourceCommand" => QUERY
       case "LoadDataCommand" => LOAD
       case "SetCommand" => SHOWCONF
       case "RefreshFunctionCommand" | "RefreshFunction" => RELOADFUNCTION

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -79,8 +79,7 @@ object OperationType extends Enumeration {
           "OptimizedCreateHiveTableAsSelectCommand" => CREATETABLE_AS_SELECT
       case "CreateTableCommand" |
           "CreateDataSourceTableCommand" |
-          "CreateTableLikeCommand" |
-          "CreateTableAsSelect" => CREATETABLE
+          "CreateTableLikeCommand" => CREATETABLE
       case "CreateViewCommand" |
           "CacheTableCommand" |
           "CreateTempViewUsing" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -44,21 +44,15 @@ object OperationType extends Enumeration {
       case "AddFilesCommand" => EXPLAIN
       case "AddJarsCommand" => EXPLAIN
       case "AddPartitions" => ALTERTABLE_ADDPARTS
-      case "AlterColumn" => ALTERTABLE_REPLACECOLS
       case "AlterDatabasePropertiesCommand" |
           "SetNamespaceProperties" => ALTERDATABASE
       case "AlterDatabaseSetLocationCommand" |
           "SetNamespaceLocation" => ALTERDATABASE_LOCATION
       case "AlterTableAddColumnsCommand" |
           "AlterHoodieTableAddColumnsCommand" |
-          "AlterTable" |
-          "AddColumns" |
-          "AlterColumn" |
-          "DropColumns" => ALTERTABLE_ADDCOLS
+          "AlterTable" => ALTERTABLE_ADDCOLS
       case "AlterTableAddPartitionCommand" => ALTERTABLE_ADDPARTS
-      case "AlterTableChangeColumnCommand" |
-          "RenameColumn" |
-          "ReplaceColumns" => ALTERTABLE_REPLACECOLS
+      case "AlterTableChangeColumnCommand" => ALTERTABLE_REPLACECOLS
       case "AlterTableDropPartitionCommand" => ALTERTABLE_DROPPARTS
       case "AlterTableRenameCommand" => ALTERTABLE_RENAME
       case "AlterTableRecoverPartitionsCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -38,7 +38,7 @@ object OperationType extends Enumeration {
   def apply(clzName: String): OperationType = {
     clzName match {
       case v2Cmd if v2Commands.accept(v2Cmd) =>
-        v2Commands.withName(v2Cmd).operType
+        v2Commands.withName(v2Cmd).operationType
 
       case "AddArchivesCommand" => EXPLAIN
       case "AddFilesCommand" => EXPLAIN

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.plugin.spark.authz
 
+import org.apache.kyuubi.plugin.spark.authz.v2Commands._
+
 object OperationType extends Enumeration {
 
   type OperationType = Value
@@ -37,6 +39,9 @@ object OperationType extends Enumeration {
    */
   def apply(clzName: String): OperationType = {
     clzName match {
+      case v2Cmd if v2Commands.accept(v2Cmd) =>
+        v2Commands.withName(v2Cmd).operType
+
       case "AddArchivesCommand" => EXPLAIN
       case "AddFilesCommand" => EXPLAIN
       case "AddJarsCommand" => EXPLAIN
@@ -68,7 +73,7 @@ object OperationType extends Enumeration {
       case ava if ava.contains("AlterViewAs") => ALTERVIEW_AS
       case ac if ac.startsWith("Analyze") => ANALYZE_TABLE
       case "AppendData" => QUERY
-      case "CreateDatabaseCommand" | "CreateNamespace" => CREATEDATABASE
+      case "CreateDatabaseCommand" => CREATEDATABASE
       case "CreateFunctionCommand" | "CreateFunction" => CREATEFUNCTION
       case "CreateTableAsSelect" |
           "CreateDataSourceTableAsSelectCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -90,8 +90,8 @@ object OperationType extends Enumeration {
       case "DescribeColumnCommand" | "DescribeTableCommand" => DESCTABLE
       case "DropDatabaseCommand" | "DropNamespace" => DROPDATABASE
       case "DropFunctionCommand" | "DropFunction" => DROPFUNCTION
-      case "DropTableCommand" | "DropTable" => DROPTABLE
-      case "DeleteFromTable" | "DropTable" => DROPTABLE
+      case "DropTableCommand" => DROPTABLE
+      case "DeleteFromTable" => DROPTABLE
       case "ExplainCommand" => EXPLAIN
       case "InsertIntoDataSourceCommand" |
           "InsertIntoDataSourceDirCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -70,7 +70,6 @@ object OperationType extends Enumeration {
           "AlterTableUnsetPropertiesCommand" => ALTERTABLE_PROPERTIES
       case ava if ava.contains("AlterViewAs") => ALTERVIEW_AS
       case ac if ac.startsWith("Analyze") => ANALYZE_TABLE
-      case "AppendData" => QUERY
       case "CreateDatabaseCommand" => CREATEDATABASE
       case "CreateFunctionCommand" | "CreateFunction" => CREATEFUNCTION
       case "CreateTableAsSelect" |
@@ -91,7 +90,6 @@ object OperationType extends Enumeration {
       case "DropDatabaseCommand" | "DropNamespace" => DROPDATABASE
       case "DropFunctionCommand" | "DropFunction" => DROPFUNCTION
       case "DropTableCommand" => DROPTABLE
-      case "DeleteFromTable" => DROPTABLE
       case "ExplainCommand" => EXPLAIN
       case "InsertIntoDataSourceCommand" |
           "InsertIntoDataSourceDirCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -17,8 +17,6 @@
 
 package org.apache.kyuubi.plugin.spark.authz
 
-import org.apache.kyuubi.plugin.spark.authz.v2Commands._
-
 object OperationType extends Enumeration {
 
   type OperationType = Value
@@ -82,8 +80,6 @@ object OperationType extends Enumeration {
       case "CreateTableCommand" |
           "CreateDataSourceTableCommand" |
           "CreateTableLikeCommand" |
-          "CreateTable" |
-          "CreateV2Table" |
           "CreateTableAsSelect" => CREATETABLE
       case "CreateViewCommand" |
           "CacheTableCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -49,8 +49,7 @@ object OperationType extends Enumeration {
       case "AlterDatabaseSetLocationCommand" |
           "SetNamespaceLocation" => ALTERDATABASE_LOCATION
       case "AlterTableAddColumnsCommand" |
-          "AlterHoodieTableAddColumnsCommand" |
-          "AlterTable" => ALTERTABLE_ADDCOLS
+          "AlterHoodieTableAddColumnsCommand" => ALTERTABLE_ADDCOLS
       case "AlterTableAddPartitionCommand" => ALTERTABLE_ADDPARTS
       case "AlterTableChangeColumnCommand" => ALTERTABLE_REPLACECOLS
       case "AlterTableDropPartitionCommand" => ALTERTABLE_DROPPARTS

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -48,7 +48,7 @@ object OperationType extends Enumeration {
           "SetNamespaceLocation" => ALTERDATABASE_LOCATION
       case "AlterTableAddColumnsCommand" |
           "AlterHoodieTableAddColumnsCommand" |
-          "AlterTable" | // todo identify add col for AlterTable
+          "AlterTable" |
           "AddColumns" |
           "AlterColumn" |
           "DropColumns" => ALTERTABLE_ADDCOLS

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -43,7 +43,6 @@ object OperationType extends Enumeration {
       case "AddArchivesCommand" => EXPLAIN
       case "AddFilesCommand" => EXPLAIN
       case "AddJarsCommand" => EXPLAIN
-      case "AddPartitions" => ALTERTABLE_ADDPARTS
       case "AlterDatabasePropertiesCommand" |
           "SetNamespaceProperties" => ALTERDATABASE
       case "AlterDatabaseSetLocationCommand" |
@@ -65,8 +64,7 @@ object OperationType extends Enumeration {
       case ac if ac.startsWith("Analyze") => ANALYZE_TABLE
       case "CreateDatabaseCommand" => CREATEDATABASE
       case "CreateFunctionCommand" | "CreateFunction" => CREATEFUNCTION
-      case "CreateTableAsSelect" |
-          "CreateDataSourceTableAsSelectCommand" |
+      case "CreateDataSourceTableAsSelectCommand" |
           "CreateHiveTableAsSelectCommand" |
           "OptimizedCreateHiveTableAsSelectCommand" => CREATETABLE_AS_SELECT
       case "CreateTableCommand" |
@@ -74,9 +72,7 @@ object OperationType extends Enumeration {
           "CreateTableLikeCommand" => CREATETABLE
       case "CreateViewCommand" |
           "CacheTableCommand" |
-          "CreateTempViewUsing" |
-          "CacheTable" |
-          "CacheTableAsSelect" => CREATEVIEW
+          "CreateTempViewUsing" => CREATEVIEW
       case "DescribeDatabaseCommand" | "DescribeNamespace" => DESCDATABASE
       case "DescribeFunctionCommand" => DESCFUNCTION
       case "DescribeColumnCommand" | "DescribeTableCommand" => DESCTABLE

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -432,22 +432,6 @@ object PrivilegesBuilder {
         outputObjs += v1TablePrivileges(table, actionType = actionType)
         buildQuery(getQuery, inputObjs)
 
-      case "AppendData" =>
-        val table = getPlanField[AnyRef]("table")
-        val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += v2TablePrivileges(tableIdent.get, actionType = INSERT)
-        buildQuery(getQuery, inputObjs)
-
-      case "UpdateTable" =>
-        val table = getPlanField[AnyRef]("table")
-        val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += v2TablePrivileges(tableIdent.get, actionType = UPDATE)
-
-      case "DeleteFromTable" =>
-        val table = getPlanField[AnyRef]("table")
-        val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += v2TablePrivileges(tableIdent.get, actionType = INSERT)
-
       case "LoadDataCommand" =>
         val table = getPlanField[TableIdentifier]("table")
         val overwrite = getPlanField[Boolean]("isOverwrite")

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -212,12 +212,6 @@ object PrivilegesBuilder {
         val database = getPlanField[String]("databaseName")
         outputObjs += databasePrivileges(database)
 
-      // v2AlterTableCommands of Spark 3.2+
-      case "AddColumns" | "AlterColumn" | "DropColumns" | "ReplaceColumns" | "RenameColumn" =>
-        val table = getPlanField[LogicalPlan]("table")
-        val tableIdent = getFieldVal[Identifier](table, "identifier")
-        outputObjs += v2TablePrivileges(tableIdent)
-
       case "AlterTableAddColumnsCommand" =>
         val table = getPlanField[TableIdentifier]("table")
         val cols = getPlanField[Seq[StructField]]("colsToAdd").map(_.name)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -260,11 +260,6 @@ object PrivilegesBuilder {
         val table = getTableName
         outputObjs += tablePrivileges(table)
 
-      case "AlterTable" =>
-        val table = getPlanField[Any]("table")
-        val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += v2TablePrivileges(tableIdent.get)
-
       case "AlterViewAsCommand" =>
         val view = getPlanField[TableIdentifier]("name")
         outputObjs += tablePrivileges(view)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -468,12 +468,14 @@ object PrivilegesBuilder {
         val table = getPlanField[AnyRef]("table")
         val tableIdentifier = getFieldVal[Option[Identifier]](table, "identifier")
         outputObjs += tablePrivilegesForDSV2(tableIdentifier.get, actionType = INSERT)
+      // todo INSERT ?
       // todo inputObjs
 
       case "DeleteFromTable" => // DsV2 update
         val table = getPlanField[AnyRef]("table")
         val tableIdentifier = getFieldVal[Option[Identifier]](table, "identifier")
         outputObjs += tablePrivilegesForDSV2(tableIdentifier.get, actionType = INSERT)
+      // todo INSERT ?
       // todo inputObjs
 
       case "LoadDataCommand" =>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -104,8 +104,7 @@ object PrivilegesBuilder {
     def mergeProjectionWithIdentifier(
         table: Identifier,
         cols: Seq[Attribute],
-        plan: LogicalPlan,
-        actionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER): Unit = {
+        plan: LogicalPlan): Unit = {
       if (projectionList.isEmpty) {
         privilegeObjects += tablePrivilegesWithIdentifier(
           table,
@@ -113,7 +112,7 @@ object PrivilegesBuilder {
       } else {
         val cols = (projectionList ++ conditionList).flatMap(collectLeaves)
           .filter(plan.outputSet.contains).map(_.name).distinct
-        privilegeObjects += tablePrivilegesWithIdentifier(table, cols, actionType)
+        privilegeObjects += tablePrivilegesWithIdentifier(table, cols)
       }
     }
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -475,15 +475,11 @@ object PrivilegesBuilder {
         val table = getPlanField[AnyRef]("table")
         val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
         outputObjs += v2TablePrivileges(tableIdent.get, actionType = UPDATE)
-      // todo INSERT ?
-      // todo inputObjs
 
       case "DeleteFromTable" =>
         val table = getPlanField[AnyRef]("table")
         val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
         outputObjs += v2TablePrivileges(tableIdent.get, actionType = INSERT)
-      // todo INSERT ?
-      // todo inputObjs
 
       case "LoadDataCommand" =>
         val table = getPlanField[TableIdentifier]("table")

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -402,11 +402,6 @@ object PrivilegesBuilder {
         val database = getFieldVal[Seq[String]](child, "namespace")
         outputObjs += databasePrivileges(quote(database))
 
-      case "DropTable" =>
-        val resolvedTable = getPlanField[LogicalPlan]("child")
-        val tableIdent = getFieldVal[Identifier](resolvedTable, "identifier")
-        outputObjs += v2TablePrivileges(tableIdent)
-
       case "DropTableCommand" =>
         outputObjs += v1TablePrivileges(getTableName)
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -41,14 +41,14 @@ object PrivilegesBuilder {
     PrivilegeObject(DATABASE, PrivilegeObjectActionType.OTHER, db, db)
   }
 
-  private def v1TablePrivileges(
+  def v1TablePrivileges(
       table: TableIdentifier,
       columns: Seq[String] = Nil,
       actionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER): PrivilegeObject = {
     PrivilegeObject(TABLE_OR_VIEW, actionType, table.database.orNull, table.table, columns)
   }
 
-  private def v2TablePrivileges(
+  def v2TablePrivileges(
       table: Identifier,
       columns: Seq[String] = Nil,
       actionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER): PrivilegeObject = {
@@ -341,10 +341,6 @@ object PrivilegesBuilder {
         val table = getPlanField[CatalogTable]("table").identifier
         // fixme: do we need to add columns to check?
         outputObjs += v1TablePrivileges(table)
-
-      case "CreateTable" | "CreateV2Table" =>
-        val table = invoke(plan, "tableName").asInstanceOf[Identifier]
-        outputObjs += v2TablePrivileges(table)
 
       case "CreateDataSourceTableAsSelectCommand" =>
         val table = getPlanField[CatalogTable]("table").identifier

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -83,7 +83,7 @@ object PrivilegesBuilder {
       projectionList: Seq[NamedExpression] = Nil,
       conditionList: Seq[NamedExpression] = Nil): Unit = {
 
-    def mergeProjectionV1Table(table: CatalogTable, plan: LogicalPlan): Unit = {
+    def mergeProjection(table: CatalogTable, plan: LogicalPlan): Unit = {
       if (projectionList.isEmpty) {
         privilegeObjects += tablePrivileges(
           table.identifier,
@@ -130,11 +130,11 @@ object PrivilegesBuilder {
         buildQuery(s.child, privilegeObjects, projectionList, cols)
 
       case hiveTableRelation if hasResolvedHiveTable(hiveTableRelation) =>
-        mergeProjectionV1Table(getHiveTable(hiveTableRelation), hiveTableRelation)
+        mergeProjection(getHiveTable(hiveTableRelation), hiveTableRelation)
 
       case logicalRelation if hasResolvedDatasourceTable(logicalRelation) =>
         getDatasourceTable(logicalRelation).foreach { t =>
-          mergeProjectionV1Table(t, plan)
+          mergeProjection(t, plan)
         }
 
       case datasourceV2Relation if hasResolvedDatasourceV2Table(datasourceV2Relation) =>
@@ -150,7 +150,7 @@ object PrivilegesBuilder {
         privilegeObjects += tablePrivileges(TableIdentifier(parts.last, Some(db)))
 
       case permanentViewMarker: PermanentViewMarker =>
-        mergeProjectionV1Table(permanentViewMarker.catalogTable, plan)
+        mergeProjection(permanentViewMarker.catalogTable, plan)
 
       case p =>
         for (child <- p.children) {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -197,7 +197,7 @@ object PrivilegesBuilder {
 
     plan.nodeName match {
       case v2Cmd if v2Commands.accept(v2Cmd) =>
-        v2Commands.withName(v2Cmd).buildCommand(plan, inputObjs, outputObjs)
+        v2Commands.withName(v2Cmd).buildPrivileges(plan, inputObjs, outputObjs)
 
       case "AlterDatabasePropertiesCommand" |
           "AlterDatabaseSetLocationCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -41,14 +41,14 @@ object PrivilegesBuilder {
     PrivilegeObject(DATABASE, PrivilegeObjectActionType.OTHER, db, db)
   }
 
-  private def tablePrivileges(
+  private def v1TablePrivileges(
       table: TableIdentifier,
       columns: Seq[String] = Nil,
       actionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER): PrivilegeObject = {
     PrivilegeObject(TABLE_OR_VIEW, actionType, table.database.orNull, table.table, columns)
   }
 
-  private def tablePrivilegesWithIdentifier(
+  private def v2TablePrivileges(
       table: Identifier,
       columns: Seq[String] = Nil,
       actionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER): PrivilegeObject = {
@@ -91,23 +91,23 @@ object PrivilegesBuilder {
 
     def mergeProjection(table: CatalogTable, plan: LogicalPlan): Unit = {
       if (projectionList.isEmpty) {
-        privilegeObjects += tablePrivileges(
+        privilegeObjects += v1TablePrivileges(
           table.identifier,
           table.schema.fieldNames)
       } else {
         val cols = (projectionList ++ conditionList).flatMap(collectLeaves)
           .filter(plan.outputSet.contains).map(_.name).distinct
-        privilegeObjects += tablePrivileges(table.identifier, cols)
+        privilegeObjects += v1TablePrivileges(table.identifier, cols)
       }
     }
 
     def mergeProjectionWithIdentifier(table: Identifier, plan: LogicalPlan): Unit = {
       if (projectionList.isEmpty) {
-        privilegeObjects += tablePrivilegesWithIdentifier(table, plan.output.map(_.name))
+        privilegeObjects += v2TablePrivileges(table, plan.output.map(_.name))
       } else {
         val cols = (projectionList ++ conditionList).flatMap(collectLeaves)
           .filter(plan.outputSet.contains).map(_.name).distinct
-        privilegeObjects += tablePrivilegesWithIdentifier(table, cols)
+        privilegeObjects += v2TablePrivileges(table, cols)
       }
     }
 
@@ -153,7 +153,7 @@ object PrivilegesBuilder {
         val tableNameM = u.getClass.getMethod("tableName")
         val parts = tableNameM.invoke(u).asInstanceOf[String].split("\\.")
         val db = quote(parts.init)
-        privilegeObjects += tablePrivileges(TableIdentifier(parts.last, Some(db)))
+        privilegeObjects += v1TablePrivileges(TableIdentifier(parts.last, Some(db)))
 
       case permanentViewMarker: PermanentViewMarker =>
         mergeProjection(permanentViewMarker.catalogTable, plan)
@@ -213,70 +213,70 @@ object PrivilegesBuilder {
       case "AddColumns" | "AlterColumn" | "DropColumns" | "ReplaceColumns" | "RenameColumn" =>
         val table = getPlanField[LogicalPlan]("table")
         val tableIdent = getFieldVal[Identifier](table, "identifier")
-        outputObjs += tablePrivilegesWithIdentifier(tableIdent)
+        outputObjs += v2TablePrivileges(tableIdent)
 
       case "AlterTableAddColumnsCommand" =>
         val table = getPlanField[TableIdentifier]("table")
         val cols = getPlanField[Seq[StructField]]("colsToAdd").map(_.name)
-        outputObjs += tablePrivileges(table, cols)
+        outputObjs += v1TablePrivileges(table, cols)
 
       case "AlterTableAddPartitionCommand" =>
         val table = getTableName
         val cols = getPlanField[Seq[(TablePartitionSpec, Option[String])]]("partitionSpecsAndLocs")
           .flatMap(_._1.keySet).distinct
-        outputObjs += tablePrivileges(table, cols)
+        outputObjs += v1TablePrivileges(table, cols)
 
       case "AlterTableChangeColumnCommand" =>
         val table = getTableName
         val cols = getPlanField[String]("columnName") :: Nil
-        outputObjs += tablePrivileges(table, cols)
+        outputObjs += v1TablePrivileges(table, cols)
 
       case "AlterTableDropPartitionCommand" =>
         val table = getTableName
         val cols = getPlanField[Seq[TablePartitionSpec]]("specs").flatMap(_.keySet).distinct
-        outputObjs += tablePrivileges(table, cols)
+        outputObjs += v1TablePrivileges(table, cols)
 
       case "AlterTableRenameCommand" =>
         val oldTable = getPlanField[TableIdentifier]("oldName")
         val newTable = getPlanField[TableIdentifier]("newName")
-        outputObjs += tablePrivileges(oldTable, actionType = PrivilegeObjectActionType.DELETE)
-        outputObjs += tablePrivileges(newTable)
+        outputObjs += v1TablePrivileges(oldTable, actionType = PrivilegeObjectActionType.DELETE)
+        outputObjs += v1TablePrivileges(newTable)
 
       // this is for spark 3.1 or below
       case "AlterTableRecoverPartitionsCommand" =>
         val table = getTableName
-        outputObjs += tablePrivileges(table)
+        outputObjs += v1TablePrivileges(table)
 
       case "AlterTableRenamePartitionCommand" =>
         val table = getTableName
         val cols = getPlanField[TablePartitionSpec]("oldPartition").keySet.toSeq
-        outputObjs += tablePrivileges(table, cols)
+        outputObjs += v1TablePrivileges(table, cols)
 
       case "AlterTableSerDePropertiesCommand" =>
         val table = getTableName
         val cols = getPlanField[Option[TablePartitionSpec]]("partSpec")
           .toSeq.flatMap(_.keySet)
-        outputObjs += tablePrivileges(table, cols)
+        outputObjs += v1TablePrivileges(table, cols)
 
       case "AlterTableSetLocationCommand" =>
         val table = getTableName
         val cols = getPlanField[Option[TablePartitionSpec]]("partitionSpec")
           .toSeq.flatMap(_.keySet)
-        outputObjs += tablePrivileges(table, cols)
+        outputObjs += v1TablePrivileges(table, cols)
 
       case "AlterTableSetPropertiesCommand" |
           "AlterTableUnsetPropertiesCommand" =>
         val table = getTableName
-        outputObjs += tablePrivileges(table)
+        outputObjs += v1TablePrivileges(table)
 
       case "AlterTable" =>
         val table = getPlanField[Any]("table")
         val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += tablePrivilegesWithIdentifier(tableIdent.get)
+        outputObjs += v2TablePrivileges(tableIdent.get)
 
       case "AlterViewAsCommand" =>
         val view = getPlanField[TableIdentifier]("name")
-        outputObjs += tablePrivileges(view)
+        outputObjs += v1TablePrivileges(view)
         buildQuery(getQuery, inputObjs)
 
       case "AlterViewAs" =>
@@ -289,18 +289,18 @@ object PrivilegesBuilder {
           } else {
             getPlanField[Seq[String]]("columnNames")
           }
-        inputObjs += tablePrivileges(table, cols)
+        inputObjs += v1TablePrivileges(table, cols)
 
       case "AnalyzePartitionCommand" =>
         val table = getTableIdent
         val cols = getPlanField[Map[String, Option[String]]]("partitionSpec")
           .keySet.toSeq
-        inputObjs += tablePrivileges(table, cols)
+        inputObjs += v1TablePrivileges(table, cols)
 
       case "AnalyzeTableCommand" |
           "RefreshTableCommand" |
           "RefreshTable" =>
-        inputObjs += tablePrivileges(getTableIdent)
+        inputObjs += v1TablePrivileges(getTableIdent)
 
       case "AnalyzeTablesCommand" =>
         val db = getPlanField[Option[String]]("databaseName")
@@ -332,7 +332,7 @@ object PrivilegesBuilder {
       case "CreateViewCommand" =>
         if (getPlanField[ViewType]("viewType") == PersistedView) {
           val view = getPlanField[TableIdentifier]("name")
-          outputObjs += tablePrivileges(view)
+          outputObjs += v1TablePrivileges(view)
         }
         val query =
           if (isSparkVersionAtMost("3.1")) {
@@ -347,22 +347,22 @@ object PrivilegesBuilder {
       case "CreateDataSourceTableCommand" | "CreateTableCommand" =>
         val table = getPlanField[CatalogTable]("table").identifier
         // fixme: do we need to add columns to check?
-        outputObjs += tablePrivileges(table)
+        outputObjs += v1TablePrivileges(table)
 
       case "CreateTable" | "CreateV2Table" =>
         val table = invoke(plan, "tableName").asInstanceOf[Identifier]
-        outputObjs += tablePrivilegesWithIdentifier(table)
+        outputObjs += v2TablePrivileges(table)
 
       case "CreateDataSourceTableAsSelectCommand" =>
         val table = getPlanField[CatalogTable]("table").identifier
-        outputObjs += tablePrivileges(table)
+        outputObjs += v1TablePrivileges(table)
         buildQuery(getQuery, inputObjs)
 
       case "CreateHiveTableAsSelectCommand" |
           "OptimizedCreateHiveTableAsSelectCommand" =>
         val table = getPlanField[CatalogTable]("tableDesc").identifier
         val cols = getPlanField[Seq[String]]("outputColumnNames")
-        outputObjs += tablePrivileges(table, cols)
+        outputObjs += v1TablePrivileges(table, cols)
         buildQuery(getQuery, inputObjs)
 
       case "CreateFunctionCommand" |
@@ -385,32 +385,32 @@ object PrivilegesBuilder {
             case "ResolvedDBObjectName" =>
               val nameParts = getFieldVal[Seq[String]](left, "nameParts")
               val db = Some(quote(nameParts.init))
-              outputObjs += tablePrivileges(TableIdentifier(nameParts.last, db))
+              outputObjs += v1TablePrivileges(TableIdentifier(nameParts.last, db))
             case _ =>
           }
         } else {
           val tableIdent = getPlanField[Identifier]("tableName")
-          outputObjs += tablePrivilegesWithIdentifier(tableIdent)
+          outputObjs += v2TablePrivileges(tableIdent)
         }
         buildQuery(getQuery, inputObjs)
 
       case "CreateTableLikeCommand" =>
         val target = setCurrentDBIfNecessary(getPlanField[TableIdentifier]("targetTable"), spark)
         val source = setCurrentDBIfNecessary(getPlanField[TableIdentifier]("sourceTable"), spark)
-        inputObjs += tablePrivileges(source)
-        outputObjs += tablePrivileges(target)
+        inputObjs += v1TablePrivileges(source)
+        outputObjs += v1TablePrivileges(target)
 
       case "CreateTempViewUsing" =>
-        outputObjs += tablePrivileges(getTableIdent)
+        outputObjs += v1TablePrivileges(getTableIdent)
 
       case "DescribeColumnCommand" =>
         val table = getPlanField[TableIdentifier]("table")
         val cols = getPlanField[Seq[String]]("colNameParts").takeRight(1)
-        inputObjs += tablePrivileges(table, cols)
+        inputObjs += v1TablePrivileges(table, cols)
 
       case "DescribeTableCommand" =>
         val table = setCurrentDBIfNecessary(getPlanField[TableIdentifier]("table"), spark)
-        inputObjs += tablePrivileges(table)
+        inputObjs += v1TablePrivileges(table)
 
       case "DescribeDatabaseCommand" | "SetDatabaseCommand" =>
         val database = getPlanField[String]("databaseName")
@@ -433,10 +433,10 @@ object PrivilegesBuilder {
       case "DropTable" =>
         val resolvedTable = getPlanField[LogicalPlan]("child")
         val tableIdent = getFieldVal[Identifier](resolvedTable, "identifier")
-        outputObjs += tablePrivilegesWithIdentifier(tableIdent)
+        outputObjs += v2TablePrivileges(tableIdent)
 
       case "DropTableCommand" =>
-        outputObjs += tablePrivileges(getTableName)
+        outputObjs += v1TablePrivileges(getTableName)
 
       case "ExplainCommand" =>
 
@@ -447,7 +447,7 @@ object PrivilegesBuilder {
         logicalRelation.catalogTable.foreach { t =>
           val overwrite = getPlanField[Boolean]("overwrite")
           val actionType = if (overwrite) INSERT_OVERWRITE else INSERT
-          outputObjs += tablePrivileges(t.identifier, actionType = actionType)
+          outputObjs += v1TablePrivileges(t.identifier, actionType = actionType)
         }
         buildQuery(getQuery, inputObjs)
 
@@ -462,26 +462,26 @@ object PrivilegesBuilder {
         val table = getPlanField[CatalogTable]("table").identifier
         val overwrite = getPlanField[Boolean]("overwrite")
         val actionType = if (overwrite) INSERT_OVERWRITE else INSERT
-        outputObjs += tablePrivileges(table, actionType = actionType)
+        outputObjs += v1TablePrivileges(table, actionType = actionType)
         buildQuery(getQuery, inputObjs)
 
       case "AppendData" =>
         val table = getPlanField[AnyRef]("table")
         val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += tablePrivilegesWithIdentifier(tableIdent.get, actionType = INSERT)
+        outputObjs += v2TablePrivileges(tableIdent.get, actionType = INSERT)
         buildQuery(getQuery, inputObjs)
 
       case "UpdateTable" =>
         val table = getPlanField[AnyRef]("table")
         val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += tablePrivilegesWithIdentifier(tableIdent.get, actionType = UPDATE)
+        outputObjs += v2TablePrivileges(tableIdent.get, actionType = UPDATE)
       // todo INSERT ?
       // todo inputObjs
 
       case "DeleteFromTable" =>
         val table = getPlanField[AnyRef]("table")
         val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += tablePrivilegesWithIdentifier(tableIdent.get, actionType = INSERT)
+        outputObjs += v2TablePrivileges(tableIdent.get, actionType = INSERT)
       // todo INSERT ?
       // todo inputObjs
 
@@ -491,24 +491,24 @@ object PrivilegesBuilder {
         val actionType = if (overwrite) INSERT_OVERWRITE else INSERT
         val cols = getPlanField[Option[TablePartitionSpec]]("partition")
           .map(_.keySet).getOrElse(Nil)
-        outputObjs += tablePrivileges(table, cols.toSeq, actionType = actionType)
+        outputObjs += v1TablePrivileges(table, cols.toSeq, actionType = actionType)
 
       case "MergeIntoTable" =>
 
       case "OverwriteByExpression" =>
         val table = getPlanField[AnyRef]("table")
         val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += tablePrivilegesWithIdentifier(tableIdent.get, actionType = UPDATE)
+        outputObjs += v2TablePrivileges(tableIdent.get, actionType = UPDATE)
         buildQuery(getQuery, inputObjs)
 
       case "RepairTableCommand" =>
         val enableAddPartitions = getPlanField[Boolean]("enableAddPartitions")
         if (enableAddPartitions) {
-          outputObjs += tablePrivileges(getTableName, actionType = INSERT)
+          outputObjs += v1TablePrivileges(getTableName, actionType = INSERT)
         } else if (getPlanField[Boolean]("enableDropPartitions")) {
-          outputObjs += tablePrivileges(getTableName, actionType = DELETE)
+          outputObjs += v1TablePrivileges(getTableName, actionType = DELETE)
         } else {
-          inputObjs += tablePrivileges(getTableName)
+          inputObjs += v1TablePrivileges(getTableName)
         }
 
       case "SetCatalogAndNamespace" =>
@@ -540,16 +540,16 @@ object PrivilegesBuilder {
         val table = getTableName
         val cols = getPlanField[Option[TablePartitionSpec]]("partitionSpec")
           .map(_.keySet).getOrElse(Nil)
-        outputObjs += tablePrivileges(table, cols.toSeq)
+        outputObjs += v1TablePrivileges(table, cols.toSeq)
 
       case "ShowColumnsCommand" =>
-        inputObjs += tablePrivileges(getTableName)
+        inputObjs += v1TablePrivileges(getTableName)
 
       case "ShowCreateTableCommand" |
           "ShowCreateTableAsSerdeCommand" |
           "ShowTablePropertiesCommand" =>
         val table = getPlanField[TableIdentifier]("table")
-        inputObjs += tablePrivileges(table)
+        inputObjs += v1TablePrivileges(table)
 
       case "ShowTableProperties" =>
         val resolvedTable = getPlanField[Any]("table")
@@ -580,7 +580,7 @@ object PrivilegesBuilder {
       case "ShowPartitionsCommand" =>
         val cols = getPlanField[Option[TablePartitionSpec]]("spec")
           .map(_.keySet.toSeq).getOrElse(Nil)
-        inputObjs += tablePrivileges(getTableName, cols)
+        inputObjs += v1TablePrivileges(getTableName, cols)
 
       case "SetNamespaceProperties" | "SetNamespaceLocation" =>
         val resolvedNamespace = getPlanField[Any]("namespace")

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -215,6 +215,12 @@ object PrivilegesBuilder {
         val database = getPlanField[String]("databaseName")
         outputObjs += databasePrivileges(database)
 
+      // v2AlterTableCommands of Spark 3.2+
+      case "AddColumns" | "AlterColumn" | "DropColumns" | "ReplaceColumns" | "RenameColumn" =>
+        val table = getPlanField[LogicalPlan]("table")
+        val tableIdentifier = getFieldVal[Identifier](table, "identifier")
+        outputObjs += tablePrivilegesWithIdentifier(tableIdentifier)
+
       case "AlterTableAddColumnsCommand" =>
         val table = getPlanField[TableIdentifier]("table")
         val cols = getPlanField[Seq[StructField]]("colsToAdd").map(_.name)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -417,12 +417,6 @@ object PrivilegesBuilder {
 
       case "MergeIntoTable" =>
 
-      case "OverwriteByExpression" =>
-        val table = getPlanField[AnyRef]("table")
-        val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-        outputObjs += v2TablePrivileges(tableIdent.get, actionType = UPDATE)
-        buildQuery(getQuery, inputObjs)
-
       case "RepairTableCommand" =>
         val enableAddPartitions = getPlanField[Boolean]("enableAddPartitions")
         if (enableAddPartitions) {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -34,6 +34,7 @@ import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType._
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 import org.apache.kyuubi.plugin.spark.authz.util.PermanentViewMarker
+import org.apache.kyuubi.plugin.spark.authz.v2Commands.v2TablePrivileges
 
 object PrivilegesBuilder {
 
@@ -46,13 +47,6 @@ object PrivilegesBuilder {
       columns: Seq[String] = Nil,
       actionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER): PrivilegeObject = {
     PrivilegeObject(TABLE_OR_VIEW, actionType, table.database.orNull, table.table, columns)
-  }
-
-  def v2TablePrivileges(
-      table: Identifier,
-      columns: Seq[String] = Nil,
-      actionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER): PrivilegeObject = {
-    PrivilegeObject(TABLE_OR_VIEW, actionType, quote(table.namespace()), table.name(), columns)
   }
 
   private def functionPrivileges(

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -311,16 +311,8 @@ object PrivilegesBuilder {
           inputObjs += databasePrivileges(db.get)
         }
 
-      case "CacheTable" =>
-        val query = getPlanField[LogicalPlan]("table") // table to cache
-        buildQuery(query, inputObjs)
-
       case "CacheTableCommand" =>
         getPlanField[Option[LogicalPlan]]("plan").foreach(buildQuery(_, inputObjs))
-
-      case "CacheTableAsSelect" =>
-        val query = getPlanField[LogicalPlan]("plan")
-        buildQuery(query, inputObjs)
 
       case "CreateViewCommand" =>
         if (getPlanField[ViewType]("viewType") == PersistedView) {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -42,7 +42,7 @@ object PrivilegesBuilder {
     PrivilegeObject(DATABASE, PrivilegeObjectActionType.OTHER, db, db)
   }
 
-  def tablePrivileges(
+  private def tablePrivileges(
       table: TableIdentifier,
       columns: Seq[String] = Nil,
       actionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER): PrivilegeObject = {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -197,7 +197,7 @@ object PrivilegesBuilder {
 
     plan.nodeName match {
       case v2Cmd if v2Commands.accept(v2Cmd) =>
-        v2Commands.withName(v2Cmd).handle(plan, inputObjs, outputObjs)
+        v2Commands.withName(v2Cmd).buildCommand(plan, inputObjs, outputObjs)
 
       case "AlterDatabasePropertiesCommand" |
           "AlterDatabaseSetLocationCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -49,7 +49,10 @@ class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[Logical
         if (tableIdentifier.isEmpty) {
           datasourceV2Relation
         } else {
-          applyFilterAndMasking(datasourceV2Relation, tableIdentifier.get, spark)
+          applyFilterAndMasking(
+            datasourceV2Relation,
+            getTableIdentifierFromIdentifier(tableIdentifier.get),
+            spark)
         }
       case other => apply(other)
     }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleApplyRowFilterAndDataMasking.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.expressions.Alias
 import org.apache.spark.sql.catalyst.plans.logical.{Filter, LogicalPlan, Project}
 import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.connector.catalog.Identifier
 
 import org.apache.kyuubi.plugin.spark.authz.{ObjectType, OperationType}
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
@@ -49,13 +50,17 @@ class RuleApplyRowFilterAndDataMasking(spark: SparkSession) extends Rule[Logical
         if (tableIdentifier.isEmpty) {
           datasourceV2Relation
         } else {
-          applyFilterAndMasking(
-            datasourceV2Relation,
-            getTableIdentifierFromIdentifier(tableIdentifier.get),
-            spark)
+          applyFilterAndMasking(datasourceV2Relation, tableIdentifier.get, spark)
         }
       case other => apply(other)
     }
+  }
+
+  private def applyFilterAndMasking(
+      plan: LogicalPlan,
+      identifier: Identifier,
+      spark: SparkSession): LogicalPlan = {
+    applyFilterAndMasking(plan, getTableIdentifierFromV2Identifier(identifier), spark)
   }
 
   private def applyFilterAndMasking(

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -103,7 +103,7 @@ private[authz] object AuthZUtils {
     getFieldVal[Option[Identifier]](plan, "identifier")
   }
 
-  def getTableIdentifierFromIdentifier(id: Identifier): TableIdentifier = {
+  def getTableIdentifierFromV2Identifier(id: Identifier): TableIdentifier = {
     TableIdentifier(id.name(), Some(quote(id.namespace())))
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -110,7 +110,6 @@ private[authz] object AuthZUtils {
   }
 
   def getDatasourceV2Identifier(plan: LogicalPlan): Option[Identifier] = {
-    // avoid importing DataSourceV2Relation for Spark version compatibility
     getFieldVal[Option[Identifier]](plan, "identifier")
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -99,17 +99,12 @@ private[authz] object AuthZUtils {
     plan.nodeName == "DataSourceV2Relation" && plan.resolved
   }
 
-  def getDatasourceV2Identifier(plan: LogicalPlan): Option[TableIdentifier] = {
+  def getDatasourceV2Identifier(plan: LogicalPlan): Option[Identifier] = {
     // avoid importing DataSourceV2Relation for Spark version compatibility
-    val identifier = getFieldVal[Option[Identifier]](plan, "identifier")
-    if (identifier.isEmpty) {
-      None
-    } else {
-      Some(getTableIdentifierFromIdentifier(identifier.get))
-    }
+    getFieldVal[Option[Identifier]](plan, "identifier")
   }
 
-  private def getTableIdentifierFromIdentifier(id: Identifier): TableIdentifier = {
+  def getTableIdentifierFromIdentifier(id: Identifier): TableIdentifier = {
     val namespaces = invoke(id, "namespace").asInstanceOf[Array[String]]
     val table = invoke(id, "name").asInstanceOf[String]
     TableIdentifier(table, Some(quote(namespaces)))

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -44,6 +44,16 @@ private[authz] object AuthZUtils {
     }
   }
 
+  def getFieldValOption[T](o: Any, name: String): Option[T] = {
+    Try {
+      getFieldVal[T](o, name)
+    } match {
+      case Success(value) => Some(value)
+      case Failure(_) =>
+        None
+    }
+  }
+
   def invoke(
       obj: AnyRef,
       methodName: String,

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -44,16 +44,6 @@ private[authz] object AuthZUtils {
     }
   }
 
-  def getFieldValOption[T](o: Any, name: String): Option[T] = {
-    Try {
-      getFieldVal[T](o, name)
-    } match {
-      case Success(value) => Some(value)
-      case Failure(_) =>
-        None
-    }
-  }
-
   def invoke(
       obj: AnyRef,
       methodName: String,

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/util/AuthZUtils.scala
@@ -104,9 +104,7 @@ private[authz] object AuthZUtils {
   }
 
   def getTableIdentifierFromIdentifier(id: Identifier): TableIdentifier = {
-    val namespaces = invoke(id, "namespace").asInstanceOf[Array[String]]
-    val table = invoke(id, "name").asInstanceOf[String]
-    TableIdentifier(table, Some(quote(namespaces)))
+    TableIdentifier(id.name(), Some(quote(id.namespace())))
   }
 
   def hasResolvedPermanentView(plan: LogicalPlan): Boolean = {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -120,7 +120,7 @@ object v2Commands extends Enumeration {
       enabled: Boolean = true)
     extends super.Val {
 
-    def handle(
+    def buildCommand(
         plan: LogicalPlan,
         inputObjs: ArrayBuffer[PrivilegeObject],
         outputObjs: ArrayBuffer[PrivilegeObject]): Unit = {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -186,4 +186,28 @@ object v2Commands extends Enumeration {
       outputObjs += v2TablePrivileges(tableIdent)
     })
 
+  // 3.3
+  val CacheTable: V2Command = V2Command(
+    leastVer = "3.2",
+    buildInput = (plan, inputObjs, _) => {
+      val query = getFieldVal[LogicalPlan](plan, "table") // table to cache
+      buildQuery(query, inputObjs)
+    })
+
+//  val CacheTableCommand: V2Command = V2Command(
+//    leastVer = "3.2",
+//    buildInput = (plan, inputObjs, _) => {
+//      val query = getFieldVal[Option[LogicalPlan]](plan, "plan")
+//      if (query.isDefined) {
+//        buildQuery(query.get, inputObjs)
+//      }
+//    })
+
+  val CacheTableAsSelect: V2Command = V2Command(
+    leastVer = "3.2",
+    buildInput = (plan, inputObjs, _) => {
+      val query = getFieldVal[LogicalPlan](plan, "plan")
+      buildQuery(query, inputObjs)
+    })
+
 }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -249,7 +249,6 @@ object v2Commands extends Enumeration {
       if (isSparkVersionAtLeast("3.2")) V2AlterTableCommand else V2DdlTableCommand))
 
   val TruncateTable: V2Command = V2Command(
-    operType = DROPDATABASE,
     leastVer = "3.2",
     buildOutput = (plan, outputObjs, _, _) => {
       val table = getFieldVal[Any](plan, "table")

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -28,7 +28,7 @@ import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType.PrivilegeO
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType.TABLE_OR_VIEW
 import org.apache.kyuubi.plugin.spark.authz.PrivilegesBuilder._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
-import org.apache.kyuubi.plugin.spark.authz.v2Commands.CommandType._
+import org.apache.kyuubi.plugin.spark.authz.v2Commands.CommandType.{CommandType, HasChildAsIdentifier, HasQueryAsLogicPlan, HasTableAsIdentifier, HasTableAsIdentifierOption, HasTableNameAsIdentifier}
 
 /**
  * Building privilege objects

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -215,6 +215,16 @@ object v2Commands extends Enumeration {
     })
 
   // v2AlterTableCommands with V2AlterTableCommand trait
+  val AlterTable: V2Command = V2Command(
+    operType = ALTERTABLE_ADDCOLS,
+    leastVer = "3.0",
+    mostVer = "3.1",
+    buildOutput = (plan, outputObjs, _, _) => {
+      val table = getFieldVal[Any](plan, "table")
+      val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
+      outputObjs += v2TablePrivileges(tableIdent.get)
+    })
+
   val AddColumns: V2Command = V2Command(
     operType = ALTERTABLE_ADDCOLS,
     leastVer = "3.2",

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -119,7 +119,7 @@ object v2Commands extends Enumeration {
           ArrayBuffer[PrivilegeObject],
           Seq[V2CommandType],
           PrivilegeObjectActionType) => Unit = defaultBuildOutput,
-      operType: OperationType = QUERY,
+      operationType: OperationType = QUERY,
       cmdTypes: Seq[V2CommandType] = Seq(),
       outputActionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER,
       enabled: Boolean = true)
@@ -141,12 +141,11 @@ object v2Commands extends Enumeration {
     PrivilegeObject(TABLE_OR_VIEW, actionType, quote(table.namespace()), table.name(), columns)
   }
 
-
   // /////////////////////////////////////////////////////////////////////////////////////////////
   // commands
 
   val CreateNamespace: V2Command = V2Command(
-    operType = CREATEDATABASE,
+    operationType = CREATEDATABASE,
     buildOutput = (plan, outputObjs, _, _) => {
       if (isSparkVersionAtLeast("3.3")) {
         val resolvedNamespace = getFieldVal[Any](plan, "name")
@@ -159,7 +158,7 @@ object v2Commands extends Enumeration {
     })
 
   val DropNamespace: V2Command = V2Command(
-    operType = DROPDATABASE,
+    operationType = DROPDATABASE,
     buildOutput = (plan, outputObjs, _, _) => {
       val resolvedNamespace = getFieldVal[LogicalPlan](plan, "namespace")
       val databases = getFieldVal[Seq[String]](resolvedNamespace, "namespace")
@@ -169,25 +168,25 @@ object v2Commands extends Enumeration {
   // with V2CreateTablePlan
 
   val CreateTable: V2Command = V2Command(
-    operType = CREATETABLE,
+    operationType = CREATETABLE,
     cmdTypes = Seq(V2CreateTablePlan),
     leastVer = Some("3.3"))
 
   val CreateV2Table: V2Command = V2Command(
-    operType = CREATETABLE,
+    operationType = CREATETABLE,
     cmdTypes = Seq(V2CreateTablePlan),
     mostVer = Some("3.2"))
 
   val CreateTableAsSelect: V2Command = V2Command(
-    operType = CREATETABLE,
+    operationType = CREATETABLE,
     cmdTypes = Seq(V2CreateTablePlan, HasQuery))
 
   val ReplaceTable: V2Command = V2Command(
-    operType = CREATETABLE,
+    operationType = CREATETABLE,
     cmdTypes = Seq(V2CreateTablePlan))
 
   val ReplaceTableAsSelect: V2Command = V2Command(
-    operType = CREATETABLE,
+    operationType = CREATETABLE,
     cmdTypes = Seq(V2CreateTablePlan, HasQuery))
 
   // with V2WriteCommand
@@ -215,29 +214,29 @@ object v2Commands extends Enumeration {
   // with V2PartitionCommand
 
   val AddPartitions: V2Command = V2Command(
-    operType = OperationType.ALTERTABLE_ADDPARTS,
+    operationType = OperationType.ALTERTABLE_ADDPARTS,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2PartitionCommand))
 
   val DropPartitions: V2Command = V2Command(
-    operType = OperationType.ALTERTABLE_DROPPARTS,
+    operationType = OperationType.ALTERTABLE_DROPPARTS,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2PartitionCommand))
 
   val RenamePartitions: V2Command = V2Command(
-    operType = OperationType.ALTERTABLE_ADDPARTS,
+    operationType = OperationType.ALTERTABLE_ADDPARTS,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2PartitionCommand))
 
   val TruncatePartition: V2Command = V2Command(
-    operType = OperationType.ALTERTABLE_DROPPARTS,
+    operationType = OperationType.ALTERTABLE_DROPPARTS,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2PartitionCommand))
 
   // other table commands
 
   val DropTable: V2Command = V2Command(
-    operType = DROPTABLE,
+    operationType = DROPTABLE,
     buildOutput = (plan, outputObjs, _, _) => {
       val tableIdent =
         if (isSparkVersionAtLeast("3.1")) {
@@ -250,7 +249,7 @@ object v2Commands extends Enumeration {
     })
 
   val CacheTable: V2Command = V2Command(
-    operType = CREATEVIEW,
+    operationType = CREATEVIEW,
     leastVer = Some("3.2"),
     buildInput = (plan, inputObjs, _) => {
       val query = getFieldVal[LogicalPlan](plan, "table") // table to cache
@@ -258,7 +257,7 @@ object v2Commands extends Enumeration {
     })
 
   val CacheTableAsSelect: V2Command = V2Command(
-    operType = CREATEVIEW,
+    operationType = CREATEVIEW,
     leastVer = Some("3.2"),
     buildInput = (plan, inputObjs, _) => {
       val query = getFieldVal[LogicalPlan](plan, "plan")
@@ -266,7 +265,7 @@ object v2Commands extends Enumeration {
     })
 
   val CommentOnNamespace: V2Command = V2Command(
-    operType = ALTERDATABASE,
+    operationType = ALTERDATABASE,
     buildOutput = (plan, outputObjs, _, _) => {
       val resolvedNamespace = getFieldVal[AnyRef](plan, "child")
       val namespace = getFieldVal[Seq[String]](resolvedNamespace, "namespace")
@@ -274,7 +273,7 @@ object v2Commands extends Enumeration {
     })
 
   val CommentOnTable: V2Command = V2Command(
-    operType = ALTERTABLE_PROPERTIES,
+    operationType = ALTERTABLE_PROPERTIES,
     cmdTypes = Seq(
       if (isSparkVersionAtLeast("3.2")) V2AlterTableCommand else V2DdlTableCommand))
 
@@ -293,7 +292,7 @@ object v2Commands extends Enumeration {
     })
 
   val RepairTable: V2Command = V2Command(
-    operType = ALTERTABLE_ADDPARTS,
+    operationType = ALTERTABLE_ADDPARTS,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2DdlTableCommand))
 
@@ -308,7 +307,7 @@ object v2Commands extends Enumeration {
   // with V2AlterTableCommand
 
   val AlterTable: V2Command = V2Command(
-    operType = ALTERTABLE_ADDCOLS,
+    operationType = ALTERTABLE_ADDCOLS,
     mostVer = Some("3.1"),
     buildOutput = (plan, outputObjs, _, _) => {
       val table = getFieldVal[Any](plan, "table")
@@ -319,27 +318,27 @@ object v2Commands extends Enumeration {
     })
 
   val AddColumns: V2Command = V2Command(
-    operType = ALTERTABLE_ADDCOLS,
+    operationType = ALTERTABLE_ADDCOLS,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2AlterTableCommand))
 
   val AlterColumn: V2Command = V2Command(
-    operType = ALTERTABLE_ADDCOLS,
+    operationType = ALTERTABLE_ADDCOLS,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2AlterTableCommand))
 
   val DropColumns: V2Command = V2Command(
-    operType = ALTERTABLE_ADDCOLS,
+    operationType = ALTERTABLE_ADDCOLS,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2AlterTableCommand))
 
   val ReplaceColumns: V2Command = V2Command(
-    operType = ALTERTABLE_REPLACECOLS,
+    operationType = ALTERTABLE_REPLACECOLS,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2AlterTableCommand))
 
   val RenameColumn: V2Command = V2Command(
-    operType = ALTERTABLE_RENAMECOL,
+    operationType = ALTERTABLE_RENAMECOL,
     leastVer = Some("3.2"),
     cmdTypes = Seq(V2AlterTableCommand))
 }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -230,6 +230,15 @@ object v2Commands extends Enumeration {
       buildQuery(query, inputObjs)
     })
 
+  val TruncateTable: V2Command = V2Command(
+    operType = DROPDATABASE,
+    leastVer = "3.2",
+    buildOutput = (plan, outputObjs, _, _) => {
+      val table = getFieldVal[Any](plan, "table")
+      val tableIdent = getFieldVal[Identifier](table, "identifier")
+      outputObjs += v2TablePrivileges(tableIdent, actionType = PrivilegeObjectActionType.UPDATE)
+    })
+
   // v2AlterTableCommands with V2AlterTableCommand trait
   val AlterTable: V2Command = V2Command(
     operType = ALTERTABLE_ADDCOLS,
@@ -238,7 +247,9 @@ object v2Commands extends Enumeration {
     buildOutput = (plan, outputObjs, _, _) => {
       val table = getFieldVal[Any](plan, "table")
       val tableIdent = getFieldVal[Option[Identifier]](table, "identifier")
-      outputObjs += v2TablePrivileges(tableIdent.get)
+      if (tableIdent.isDefined) {
+        outputObjs += v2TablePrivileges(tableIdent.get)
+      }
     })
 
   val AddColumns: V2Command = V2Command(

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -209,29 +209,28 @@ object v2Commands extends Enumeration {
       buildQuery(query, inputObjs)
     })
 
-
   // v2AlterTableCommands with V2AlterTableCommand trait
   val AddColumns: V2Command = V2Command(
     operType = ALTERTABLE_ADDCOLS,
     leastVer = "3.2",
     cmdTypes = Seq(V2AlterTableCommand))
 
-  val AlterColumn : V2Command = V2Command(
+  val AlterColumn: V2Command = V2Command(
     operType = ALTERTABLE_ADDCOLS,
     leastVer = "3.2",
     cmdTypes = Seq(V2AlterTableCommand))
 
-  val DropColumns : V2Command = V2Command(
+  val DropColumns: V2Command = V2Command(
     operType = ALTERTABLE_ADDCOLS,
     leastVer = "3.2",
     cmdTypes = Seq(V2AlterTableCommand))
 
-  val ReplaceColumns : V2Command = V2Command(
+  val ReplaceColumns: V2Command = V2Command(
     operType = ALTERTABLE_REPLACECOLS,
     leastVer = "3.2",
     cmdTypes = Seq(V2AlterTableCommand))
 
-  val RenameColumn : V2Command = V2Command(
+  val RenameColumn: V2Command = V2Command(
     operType = ALTERTABLE_RENAMECOL,
     leastVer = "3.2",
     cmdTypes = Seq(V2AlterTableCommand))

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -23,12 +23,12 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog.Identifier
 
-import org.apache.kyuubi.plugin.spark.authz.OperationType.{ALTERDATABASE, ALTERTABLE_ADDCOLS, ALTERTABLE_PROPERTIES, ALTERTABLE_RENAMECOL, ALTERTABLE_REPLACECOLS, CREATEDATABASE, CREATETABLE, CREATEVIEW, DROPDATABASE, DROPTABLE, OperationType, QUERY}
+import org.apache.kyuubi.plugin.spark.authz.OperationType._
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType.PrivilegeObjectActionType
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType.TABLE_OR_VIEW
 import org.apache.kyuubi.plugin.spark.authz.PrivilegesBuilder._
 import org.apache.kyuubi.plugin.spark.authz.V2CommandType.{HasQuery, V2AlterTableCommand, V2CommandType, V2CreateTablePlan, V2DdlTableCommand, V2WriteCommand}
-import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.{getFieldVal, invoke, isSparkVersionAtLeast, isSparkVersionAtMost, quote}
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
 
 object V2CommandType extends Enumeration {
   type V2CommandType = Value

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog.Identifier
 
-import org.apache.kyuubi.plugin.spark.authz.OperationType.{ALTERTABLE_ADDCOLS, ALTERTABLE_RENAMECOL, ALTERTABLE_REPLACECOLS, CREATEDATABASE, CREATETABLE, CREATEVIEW, DROPTABLE, OperationType, QUERY}
+import org.apache.kyuubi.plugin.spark.authz.OperationType.{ALTERTABLE_ADDCOLS, ALTERTABLE_RENAMECOL, ALTERTABLE_REPLACECOLS, CREATEDATABASE, CREATETABLE, CREATEVIEW, DROPDATABASE, DROPTABLE, OperationType, QUERY}
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType.PrivilegeObjectActionType
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType.TABLE_OR_VIEW
 import org.apache.kyuubi.plugin.spark.authz.PrivilegesBuilder._
@@ -145,6 +145,14 @@ object v2Commands extends Enumeration {
         val namespace = getFieldVal[Seq[String]](plan, "namespace")
         outputObjs += databasePrivileges(quote(namespace))
       }
+    })
+
+  val DropNamespace: V2Command = V2Command(
+    operType = DROPDATABASE,
+    buildOutput = (plan, outputObjs, _, _) => {
+      val resolvedNamespace = getFieldVal[LogicalPlan](plan, "namespace")
+      val databases = getFieldVal[Seq[String]](resolvedNamespace, "namespace")
+      outputObjs += databasePrivileges(quote(databases))
     })
 
   // with V2CreateTablePlan

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -122,8 +122,7 @@ object v2Commands extends Enumeration {
       operationType: OperationType = QUERY,
       cmdTypes: Seq[V2CommandType] = Seq(),
       outputActionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER,
-      enabled: Boolean = true)
-    extends super.Val {
+      enabled: Boolean = true) {
 
     def buildCommand(
         plan: LogicalPlan,

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -248,6 +248,11 @@ object v2Commands extends Enumeration {
     cmdTypes = Seq(
       if (isSparkVersionAtLeast("3.2")) V2AlterTableCommand else V2DdlTableCommand))
 
+  val RepairTable: V2Command = V2Command(
+    operType = ALTERTABLE_ADDPARTS,
+    leastVer = "3.2",
+    cmdTypes = Seq(V2DdlTableCommand))
+
   val TruncateTable: V2Command = V2Command(
     leastVer = "3.2",
     buildOutput = (plan, outputObjs, _, _) => {

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -257,7 +257,8 @@ object v2Commands extends Enumeration {
     buildOutput = (plan, outputObjs, _, _) => {
       val table = getFieldVal[DataSourceV2Relation](plan, "targetTable")
       if (table.identifier.isDefined) {
-        outputObjs += v2TablePrivileges(table.identifier.get,
+        outputObjs += v2TablePrivileges(
+          table.identifier.get,
           actionType = PrivilegeObjectActionType.UPDATE)
       }
     })

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -184,6 +184,14 @@ object v2Commands extends Enumeration {
     cmdTypes = Seq(V2WriteCommand),
     outputActionType = PrivilegeObjectActionType.UPDATE)
 
+  val OverwriteByExpression: V2Command = V2Command(
+    cmdTypes = Seq(V2WriteCommand, HasQuery),
+    outputActionType = PrivilegeObjectActionType.UPDATE)
+
+  val OverwritePartitionsDynamic: V2Command = V2Command(
+    cmdTypes = Seq(V2WriteCommand, HasQuery),
+    outputActionType = PrivilegeObjectActionType.UPDATE)
+
   // other table commands
   val DropTable: V2Command = V2Command(
     operType = DROPTABLE,

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -28,7 +28,7 @@ import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType.PrivilegeO
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType.TABLE_OR_VIEW
 import org.apache.kyuubi.plugin.spark.authz.PrivilegesBuilder._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
-import org.apache.kyuubi.plugin.spark.authz.v2Commands.CommandType.{CommandType, HasChildAsIdentifier, HasQueryAsLogicPlan, HasTableAsIdentifier, HasTableAsIdentifierOption, HasTableNameAsIdentifier}
+import org.apache.kyuubi.plugin.spark.authz.v2Commands.CommandType.{CommandType, HasChildAsIdentifier, HasQueryAsLogicalPlan, HasTableAsIdentifier, HasTableAsIdentifierOption, HasTableNameAsIdentifier}
 
 /**
  * Building privilege objects
@@ -37,13 +37,14 @@ import org.apache.kyuubi.plugin.spark.authz.v2Commands.CommandType.{CommandType,
 object v2Commands extends Enumeration {
 
   /**
-   * Command types
+   * Command type enum
+   * with naming rule as `HasFieldAsReturnType`
    * for hinting privileges building of inputObjs or outputObjs
    */
   object CommandType extends Enumeration {
     type CommandType = Value
-    val HasChildAsIdentifier, HasQueryAsLogicPlan, HasTableAsIdentifier, HasTableAsIdentifierOption,
-        HasTableNameAsIdentifier = Value
+    val HasChildAsIdentifier, HasQueryAsLogicalPlan, HasTableAsIdentifier,
+        HasTableAsIdentifierOption, HasTableNameAsIdentifier = Value
   }
 
   import scala.language.implicitConversions
@@ -76,7 +77,7 @@ object v2Commands extends Enumeration {
   val defaultBuildInput: (LogicalPlan, ArrayBuffer[PrivilegeObject], Seq[CommandType]) => Unit =
     (plan, inputObjs, commandTypes) => {
       commandTypes.foreach {
-        case HasQueryAsLogicPlan =>
+        case HasQueryAsLogicalPlan =>
           val query = getFieldVal[LogicalPlan](plan, "query")
           buildQuery(query, inputObjs)
         case _ =>
@@ -194,7 +195,7 @@ object v2Commands extends Enumeration {
 
   val CreateTableAsSelect: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
     operationType = CREATETABLE,
-    commandTypes = Seq(HasTableNameAsIdentifier, HasQueryAsLogicPlan))
+    commandTypes = Seq(HasTableNameAsIdentifier, HasQueryAsLogicalPlan))
 
   val ReplaceTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
     operationType = CREATETABLE,
@@ -202,12 +203,12 @@ object v2Commands extends Enumeration {
 
   val ReplaceTableAsSelect: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
     operationType = CREATETABLE,
-    commandTypes = Seq(HasTableNameAsIdentifier, HasQueryAsLogicPlan))
+    commandTypes = Seq(HasTableNameAsIdentifier, HasQueryAsLogicalPlan))
 
   // with V2WriteCommand
 
   val AppendData: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
-    commandTypes = Seq(HasTableAsIdentifierOption, HasQueryAsLogicPlan),
+    commandTypes = Seq(HasTableAsIdentifierOption, HasQueryAsLogicalPlan),
     outputActionType = PrivilegeObjectActionType.INSERT)
 
   val UpdateTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
@@ -219,11 +220,11 @@ object v2Commands extends Enumeration {
     outputActionType = PrivilegeObjectActionType.UPDATE)
 
   val OverwriteByExpression: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
-    commandTypes = Seq(HasTableAsIdentifierOption, HasQueryAsLogicPlan),
+    commandTypes = Seq(HasTableAsIdentifierOption, HasQueryAsLogicalPlan),
     outputActionType = PrivilegeObjectActionType.UPDATE)
 
   val OverwritePartitionsDynamic: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
-    commandTypes = Seq(HasTableAsIdentifierOption, HasQueryAsLogicPlan),
+    commandTypes = Seq(HasTableAsIdentifierOption, HasQueryAsLogicalPlan),
     outputActionType = PrivilegeObjectActionType.UPDATE)
 
   // with V2PartitionCommand

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -23,7 +23,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
 import org.apache.spark.sql.connector.catalog.Identifier
 
-import org.apache.kyuubi.plugin.spark.authz.OperationType.{CREATEDATABASE, CREATETABLE, DROPTABLE, OperationType, QUERY}
+import org.apache.kyuubi.plugin.spark.authz.OperationType.{CREATEDATABASE, CREATETABLE, CREATEVIEW, DROPTABLE, OperationType, QUERY}
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType.PrivilegeObjectActionType
 import org.apache.kyuubi.plugin.spark.authz.PrivilegesBuilder._
 import org.apache.kyuubi.plugin.spark.authz.V2CommandType.{HasQuery, V2CommandType, V2CreateTablePlan, V2WriteCommand}
@@ -186,24 +186,16 @@ object v2Commands extends Enumeration {
       outputObjs += v2TablePrivileges(tableIdent)
     })
 
-  // 3.3
   val CacheTable: V2Command = V2Command(
+    operType = CREATEVIEW,
     leastVer = "3.2",
     buildInput = (plan, inputObjs, _) => {
       val query = getFieldVal[LogicalPlan](plan, "table") // table to cache
       buildQuery(query, inputObjs)
     })
 
-//  val CacheTableCommand: V2Command = V2Command(
-//    leastVer = "3.2",
-//    buildInput = (plan, inputObjs, _) => {
-//      val query = getFieldVal[Option[LogicalPlan]](plan, "plan")
-//      if (query.isDefined) {
-//        buildQuery(query.get, inputObjs)
-//      }
-//    })
-
   val CacheTableAsSelect: V2Command = V2Command(
+    operType = CREATEVIEW,
     leastVer = "3.2",
     buildInput = (plan, inputObjs, _) => {
       val query = getFieldVal[LogicalPlan](plan, "plan")

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.apache.commons.lang3.StringUtils
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+
+import org.apache.kyuubi.plugin.spark.authz.OperationType.{CREATEDATABASE, OperationType, QUERY}
+import org.apache.kyuubi.plugin.spark.authz.PrivilegesBuilder.databasePrivileges
+import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils.{getFieldVal, isSparkVersionAtLeast, isSparkVersionAtMost, quote}
+
+object v2Commands extends Enumeration {
+  import scala.language.implicitConversions
+
+  implicit def valueToV2CommandBuilder(x: Value): V2Command =
+    x.asInstanceOf[V2Command]
+
+  def accept(commandName: String): Boolean = {
+    try {
+      val cmd = v2Commands.withName(commandName)
+
+      !(StringUtils.isNotBlank(cmd.mostVer) && isSparkVersionAtMost(cmd.mostVer)) &&
+      !(StringUtils.isNotBlank(cmd.leastVer) && isSparkVersionAtLeast(cmd.leastVer))
+    } catch {
+      case e: NoSuchElementException => false
+    }
+  }
+
+  private val defaultBuildInput: (
+      LogicalPlan,
+      ArrayBuffer[PrivilegeObject]) => Unit = (p, inputObjs) => {}
+
+  private val defaultBuildOutput: (LogicalPlan, ArrayBuffer[PrivilegeObject]) => Unit =
+    (p, outputObjs) => {}
+
+  case class V2Command(
+      leastVer: String = "",
+      mostVer: String = "",
+      buildInput: (LogicalPlan, ArrayBuffer[PrivilegeObject]) => Unit = defaultBuildInput,
+      buildOutput: (LogicalPlan, ArrayBuffer[PrivilegeObject]) => Unit = defaultBuildOutput,
+      operType: OperationType = QUERY)
+    extends super.Val {
+
+    def handle(
+        plan: LogicalPlan,
+        inputObjs: ArrayBuffer[PrivilegeObject],
+        outputObjs: ArrayBuffer[PrivilegeObject]): Unit = {
+      this.buildInput(plan, inputObjs)
+      this.buildOutput(plan, outputObjs)
+    }
+  }
+
+  // commands
+
+  val CreateNamespace: V2Command = V2Command(
+    operType = CREATEDATABASE,
+    buildOutput = (plan, outputObjs) => {
+      if (isSparkVersionAtLeast("3.3")) {
+        val resolvedNamespace = getFieldVal[Any](plan, "name")
+        val databases = getFieldVal[Seq[String]](resolvedNamespace, "nameParts")
+        outputObjs += databasePrivileges(quote(databases))
+      } else {
+        val namespace = getFieldVal[Seq[String]](plan, "namespace")
+        outputObjs += databasePrivileges(quote(namespace))
+      }
+    })
+
+}

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -110,8 +110,10 @@ object v2Commands extends Enumeration {
     }
 
   case class V2Command(
+      operationType: OperationType = QUERY,
       leastVer: Option[String] = None,
       mostVer: Option[String] = None,
+      cmdTypes: Seq[V2CommandType] = Seq(),
       buildInput: (LogicalPlan, ArrayBuffer[PrivilegeObject], Seq[V2CommandType]) => Unit =
         defaultBuildInput,
       buildOutput: (
@@ -119,8 +121,6 @@ object v2Commands extends Enumeration {
           ArrayBuffer[PrivilegeObject],
           Seq[V2CommandType],
           PrivilegeObjectActionType) => Unit = defaultBuildOutput,
-      operationType: OperationType = QUERY,
-      cmdTypes: Seq[V2CommandType] = Seq(),
       outputActionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER,
       enabled: Boolean = true) {
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -112,7 +112,8 @@ object v2Commands extends Enumeration {
           ArrayBuffer[PrivilegeObject],
           Seq[CommandType],
           PrivilegeObjectActionType) => Unit = defaultBuildOutput,
-      outputActionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER) {
+      outputActionType: PrivilegeObjectActionType = PrivilegeObjectActionType.OTHER)
+    extends super.Val {
 
     def buildPrivileges(
         plan: LogicalPlan,

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -464,23 +464,23 @@ class InMemoryV2TableCatalogRangerSparkExtensionSuite extends RangerSparkExtensi
   val cacheTable1 = "cacheTable1"
 
   override def beforeAll(): Unit = {
-   if (isSparkV32OrGreater) {
+    if (isSparkV32OrGreater) {
 
-    spark.conf.set(
-      s"spark.sql.catalog.$catalogV2",
-      "org.apache.spark.sql.connector.catalog.InMemoryCatalog")
+      spark.conf.set(
+        s"spark.sql.catalog.$catalogV2",
+        "org.apache.spark.sql.connector.catalog.InMemoryCatalog")
 
-    super.beforeAll()
+      super.beforeAll()
 
-    doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
-    doAs(
-      "admin",
-      sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
-        " (id int, name string, city string)"))
-    doAs(
-      "admin",
-      sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
-        " (id int, name string, city string)"))
+      doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
+      doAs(
+        "admin",
+        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
+          " (id int, name string, city string)"))
+      doAs(
+        "admin",
+        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
+          " (id int, name string, city string)"))
     }
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -475,6 +475,7 @@ class InMemoryV2TableCatalogRangerSparkExtensionSuite extends RangerSparkExtensi
     val namespace1 = "ns1"
     val table1 = "table1"
     val table2 = "table2"
+    val cacheTable1 = "cacheTable1"
 
     withCleanTmpResources(
       Seq((s"$catalogV2.$namespace1.$table1", "table"))) {
@@ -534,6 +535,15 @@ class InMemoryV2TableCatalogRangerSparkExtensionSuite extends RangerSparkExtensi
         doAs("someone", sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1")))
       assert(e6.getMessage.contains(s"does not have [update] privilege" +
         s" on [$namespace1/$table1]"))
+
+      // CacheTable
+      val e7 = intercept[AccessControlException](
+        doAs(
+          "someone",
+          sql(s"CACHE TABLE $cacheTable1" +
+            s" AS select * from $catalogV2.$namespace1.$table1")))
+      assert(e7.getMessage.contains(s"does not have [select] privilege" +
+        s" on [$namespace1/$table1/id]"))
     }
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -26,8 +26,8 @@ import org.apache.commons.codec.digest.DigestUtils
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
+import org.apache.spark.sql.catalyst.catalog.InMemoryCatalog
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
-import org.apache.spark.sql.connector.catalog.InMemoryCatalog
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.scalatest.BeforeAndAfterAll

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -34,7 +34,6 @@ import org.scalatest.BeforeAndAfterAll
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
 
-import org.apache.kyuubi.Utils
 import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 import org.apache.kyuubi.plugin.spark.authz.SparkSessionProvider
 import org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization.KYUUBI_AUTHZ_TAG

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -26,8 +26,8 @@ import org.apache.commons.codec.digest.DigestUtils
 import org.apache.hadoop.security.UserGroupInformation
 import org.apache.spark.sql.{Row, SparkSessionExtensions}
 import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
-import org.apache.spark.sql.catalyst.catalog.InMemoryCatalog
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
+import org.apache.spark.sql.connector.catalog.InMemoryCatalog
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.datasources.LogicalRelation
 import org.scalatest.BeforeAndAfterAll

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -29,7 +29,6 @@ import org.apache.spark.sql.catalyst.catalog.HiveTableRelation
 import org.apache.spark.sql.catalyst.plans.logical.Statistics
 import org.apache.spark.sql.execution.columnar.InMemoryRelation
 import org.apache.spark.sql.execution.datasources.LogicalRelation
-import org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog
 import org.scalatest.BeforeAndAfterAll
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
@@ -470,7 +469,9 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
 
   override def beforeAll(): Unit = {
     if (isSparkV31OrGreater) {
-      spark.conf.set(s"spark.sql.catalog.$catalogV2", classOf[JDBCTableCatalog].getName)
+      spark.conf.set(
+        s"spark.sql.catalog.$catalogV2",
+        "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
       spark.conf.set(s"spark.sql.catalog.$catalogV2.url", jdbcUrl)
       spark.conf.set(
         s"spark.sql.catalog.$catalogV2.driver",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -496,7 +496,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     spark.sessionState.conf.clear()
 
     // cleanup db
-    try {
+    Try {
       DriverManager.getConnection(s"$dbUrl;shutdown=true")
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -147,16 +147,8 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
     val e = intercept[AccessControlException](sql(create))
     assert(e.getMessage === errorMessage("create", "mydb"))
     withCleanTmpResources(Seq((testDb, "database"))) {
-      doAs(
-        "admin",
-        assert(Try {
-          sql(create)
-        }.isSuccess))
-      doAs(
-        "admin",
-        assert(Try {
-          sql(alter)
-        }.isSuccess))
+      doAs("admin", assert(Try { sql(create) }.isSuccess))
+      doAs("admin", assert(Try { sql(alter) }.isSuccess))
       val e1 = intercept[AccessControlException](sql(alter))
       assert(e1.getMessage === errorMessage("alter", "mydb"))
       val e2 = intercept[AccessControlException](sql(drop))
@@ -178,34 +170,14 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
     assert(e.getMessage === errorMessage("create"))
 
     withCleanTmpResources(Seq((s"$db.$table", "table"))) {
-      doAs(
-        "bob",
-        assert(Try {
-          sql(create0)
-        }.isSuccess))
-      doAs(
-        "bob",
-        assert(Try {
-          sql(alter0)
-        }.isSuccess))
+      doAs("bob", assert(Try { sql(create0) }.isSuccess))
+      doAs("bob", assert(Try { sql(alter0) }.isSuccess))
 
       val e1 = intercept[AccessControlException](sql(drop0))
       assert(e1.getMessage === errorMessage("drop"))
-      doAs(
-        "bob",
-        assert(Try {
-          sql(alter0)
-        }.isSuccess))
-      doAs(
-        "bob",
-        assert(Try {
-          sql(select).collect()
-        }.isSuccess))
-      doAs(
-        "kent",
-        assert(Try {
-          sql(s"SELECT key FROM $db.$table").collect()
-        }.isSuccess))
+      doAs("bob", assert(Try { sql(alter0) }.isSuccess))
+      doAs("bob", assert(Try { sql(select).collect() }.isSuccess))
+      doAs("kent", assert(Try { sql(s"SELECT key FROM $db.$table").collect() }.isSuccess))
 
       Seq(
         select,
@@ -245,11 +217,7 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
     val create = s"CREATE TABLE IF NOT EXISTS $db.$table ($col int, value int) USING $format"
 
     withCleanTmpResources(Seq((s"$db.${table}2", "table"), (s"$db.$table", "table"))) {
-      doAs(
-        "admin",
-        assert(Try {
-          sql(create)
-        }.isSuccess))
+      doAs("admin", assert(Try { sql(create) }.isSuccess))
       doAs("admin", sql(s"INSERT INTO $db.$table SELECT 1, 1"))
       doAs("admin", sql(s"INSERT INTO $db.$table SELECT 20, 2"))
       doAs("admin", sql(s"INSERT INTO $db.$table SELECT 30, 3"))
@@ -293,11 +261,7 @@ abstract class RangerSparkExtensionSuite extends AnyFunSuite
     withCleanTmpResources(Seq(
       (s"$db.${table}2", "table"),
       (s"$db.$table", "table"))) {
-      doAs(
-        "admin",
-        assert(Try {
-          sql(create)
-        }.isSuccess))
+      doAs("admin", assert(Try { sql(create) }.isSuccess))
       doAs(
         "admin",
         sql(

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -217,6 +217,18 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     }
   }
 
+  test("[KYUUBI #3424] TRUNCATE TABLE") {
+    assume(isSparkV31OrGreater)
+
+    // CreateView with select
+    val e1 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"TRUNCATE TABLE $catalogV2.$namespace1.$table1")))
+    assert(e1.getMessage.contains(s"does not have [update] privilege" +
+      s" on [$catalogV2.$namespace1/$table1]"))
+  }
+
   test("[KYUUBI #3424] ALTER TABLE") {
     assume(isSparkV31OrGreater)
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -229,6 +229,18 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
       s" on [$namespace1/$table1]"))
   }
 
+  test("[KYUUBI #3424] MSCK REPAIR TABLE") {
+    assume(isSparkV32OrGreater)
+
+    // CreateView with select
+    val e1 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"MSCK REPAIR TABLE $catalogV2.$namespace1.$table1")))
+    assert(e1.getMessage.contains(s"does not have [alter] privilege" +
+      s" on [$namespace1/$table1]"))
+  }
+
   test("[KYUUBI #3424] ALTER TABLE") {
     assume(isSparkV31OrGreater)
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -265,4 +265,33 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     assert(e64.getMessage.contains(s"does not have [alter] privilege" +
       s" on [$namespace1/$table1]"))
   }
+
+  test("[KYUUBI #3424] COMMENT ON") {
+    assume(isSparkV31OrGreater)
+
+    // CommentOnNamespace
+    val e1 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"COMMENT ON DATABASE $catalogV2.$namespace1 IS 'xYz' ").explain()))
+    assert(e1.getMessage.contains(s"does not have [alter] privilege" +
+      s" on [$namespace1]"))
+
+    // CommentOnNamespace
+    val e2 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"COMMENT ON NAMESPACE $catalogV2.$namespace1 IS 'xYz' ").explain()))
+    assert(e2.getMessage.contains(s"does not have [alter] privilege" +
+      s" on [$namespace1]"))
+
+    // CommentOnTable
+    val e3 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"COMMENT ON TABLE $catalogV2.$namespace1.$table1 IS 'xYz' ").explain()))
+    assert(e3.getMessage.contains(s"does not have [alter] privilege" +
+      s" on [$namespace1/$table1]"))
+
+  }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -192,8 +192,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     val e1 = intercept[AccessControlException](
       doAs(
         "someone",
-        sql(mergeIntoSql
-        )))
+        sql(mergeIntoSql)))
     assert(e1.getMessage.contains(s"does not have [select] privilege" +
       s" on [$namespace1/$table1/id]"))
 
@@ -201,13 +200,10 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
       SparkRangerAdminPlugin.getRangerConf.setBoolean(
         s"ranger.plugin.${SparkRangerAdminPlugin.getServiceType}.authorize.in.single.call",
         true)
-
-      // MergeIntoTable:  Using a MERGE INTO Statement
       val e2 = intercept[AccessControlException](
         doAs(
           "someone",
-          sql(mergeIntoSql
-          )))
+          sql(mergeIntoSql)))
       assert(e2.getMessage.contains(s"does not have" +
         s" [select] privilege" +
         s" on [$namespace1/$table1/id,$namespace1/table1/name,$namespace1/$table1/city]," +

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -191,7 +191,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
       assert(e7.getMessage.contains(s"does not have [select] privilege" +
         s" on [$namespace1/$table1/id]"))
     } else {
-      // todo catalog
       assert(e7.getMessage.contains(s"does not have [select] privilege" +
         s" on [$catalogV2.$namespace1/$table1]"))
     }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -30,9 +30,6 @@ import org.apache.kyuubi.plugin.spark.authz.AccessControlException
 class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
   override protected val catalogImpl: String = "in-memory"
 
-  private val dbUrl = s"jdbc:derby:memory:$catalogV2"
-  private val jdbcUrl: String = s"$dbUrl;create=true"
-
   val catalogV2 = "testcat"
   val jdbcCatalogV2 = "jdbc2"
   val namespace1 = "ns1"
@@ -40,6 +37,9 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   val table2 = "table2"
   val outputTable1 = "outputTable1"
   val cacheTable1 = "cacheTable1"
+
+  val dbUrl = s"jdbc:derby:memory:$catalogV2"
+  val jdbcUrl: String = s"$dbUrl;create=true"
 
   override def beforeAll(): Unit = {
     if (isSparkV31OrGreater) {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -102,7 +102,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
         sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2" +
           s" AS select * from $catalogV2.$namespace1.$table1")))
     assert(e21.getMessage.contains(s"does not have [select] privilege" +
-      s" on [$namespace1/$table1/city]"))
+      s" on [$namespace1/$table1/id]"))
   }
 
   test("[KYUUBI #3424] DROP TABLE") {
@@ -134,7 +134,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
         sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
           s" TABLE $catalogV2.$namespace1.$table1")))
     assert(e42.getMessage.contains(s"does not have [select] privilege" +
-      s" on [$namespace1/$table1/city]"))
+      s" on [$namespace1/$table1/id]"))
 
     // AppendData: Insert Using a SELECT Statement
     val e43 = intercept[AccessControlException](
@@ -143,7 +143,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
         sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
           s" SELECT * from $catalogV2.$namespace1.$table1")))
     assert(e43.getMessage.contains(s"does not have [select] privilege" +
-      s" on [$namespace1/$table1/city]"))
+      s" on [$namespace1/$table1/id]"))
 
     // OverwriteByExpression: Insert Overwrite
     val e44 = intercept[AccessControlException](

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -95,7 +95,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     assert(e2.getMessage.contains(s"does not have [create] privilege" +
       s" on [$namespace1/$table2]"))
 
-    // CreateAsSelect
+    // CreateTableAsSelect
     val e21 = intercept[AccessControlException](
       doAs(
         "someone",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -218,7 +218,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   }
 
   test("[KYUUBI #3424] TRUNCATE TABLE") {
-    assume(isSparkV31OrGreater)
+    assume(isSparkV32OrGreater)
 
     // CreateView with select
     val e1 = intercept[AccessControlException](
@@ -226,7 +226,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
         "someone",
         sql(s"TRUNCATE TABLE $catalogV2.$namespace1.$table1")))
     assert(e1.getMessage.contains(s"does not have [update] privilege" +
-      s" on [$catalogV2.$namespace1/$table1]"))
+      s" on [$namespace1/$table1]"))
   }
 
   test("[KYUUBI #3424] ALTER TABLE") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -33,6 +33,7 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   val catalogV2 = "testcat"
   val jdbcCatalogV2 = "jdbc2"
   val namespace1 = "ns1"
+  val namespace2 = "ns2"
   val table1 = "table1"
   val table2 = "table2"
   val outputTable1 = "outputTable1"
@@ -74,6 +75,26 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     Try {
       DriverManager.getConnection(s"$dbUrl;shutdown=true")
     }
+  }
+
+  test("[KYUUBI #3424] CREATE DATABASE") {
+    assume(isSparkV31OrGreater)
+
+    // create database
+    val e1 = intercept[AccessControlException](
+      doAs("someone", sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace2").explain()))
+    assert(e1.getMessage.contains(s"does not have [create] privilege" +
+      s" on [$namespace2]"))
+  }
+
+  test("[KYUUBI #3424] DROP DATABASE") {
+    assume(isSparkV31OrGreater)
+
+    // create database
+    val e1 = intercept[AccessControlException](
+      doAs("someone", sql(s"DROP DATABASE IF EXISTS $catalogV2.$namespace2").explain()))
+    assert(e1.getMessage.contains(s"does not have [drop] privilege" +
+      s" on [$namespace2]"))
   }
 
   test("[KYUUBI #3424] SELECT TABLE") {

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -1,0 +1,236 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.plugin.spark.authz.ranger
+
+import java.sql.DriverManager
+
+import scala.util.Try
+
+// scalastyle:off
+import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+
+/**
+ * Tests for RangerSparkExtensionSuite
+ * on JdbcTableCatalog with DataSource V2 API.
+ */
+class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
+  override protected val catalogImpl: String = "in-memory"
+
+  private val dbUrl = s"jdbc:derby:memory:$catalogV2"
+  private val jdbcUrl: String = s"$dbUrl;create=true"
+
+  val catalogV2 = "testcat"
+  val jdbcCatalogV2 = "jdbc2"
+  val namespace1 = "ns1"
+  val table1 = "table1"
+  val table2 = "table2"
+  val outputTable1 = "outputTable1"
+  val cacheTable1 = "cacheTable1"
+
+  override def beforeAll(): Unit = {
+    if (isSparkV31OrGreater) {
+      spark.conf.set(
+        s"spark.sql.catalog.$catalogV2",
+        "org.apache.spark.sql.execution.datasources.v2.jdbc.JDBCTableCatalog")
+      spark.conf.set(s"spark.sql.catalog.$catalogV2.url", jdbcUrl)
+      spark.conf.set(
+        s"spark.sql.catalog.$catalogV2.driver",
+        "org.apache.derby.jdbc.AutoloadedDriver")
+
+      super.beforeAll()
+
+      doAs("admin", sql(s"CREATE DATABASE IF NOT EXISTS $catalogV2.$namespace1"))
+      doAs(
+        "admin",
+        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table1" +
+          " (id int, name string, city string)"))
+      doAs(
+        "admin",
+        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$outputTable1" +
+          " (id int, name string, city string)"))
+    }
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    spark.sessionState.catalog.reset()
+    spark.sessionState.conf.clear()
+
+    // cleanup db
+    Try {
+      DriverManager.getConnection(s"$dbUrl;shutdown=true")
+    }
+  }
+
+  test("[KYUUBI #3424] SELECT TABLE") {
+    assume(isSparkV31OrGreater)
+
+    // select
+    val e1 = intercept[AccessControlException](
+      doAs("someone", sql(s"select city, id from $catalogV2.$namespace1.$table1").explain()))
+    assert(e1.getMessage.contains(s"does not have [select] privilege" +
+      s" on [$namespace1/$table1/id]"))
+  }
+
+  test("[KYUUBI #3424] CREATE TABLE") {
+    assume(isSparkV31OrGreater)
+
+    // CreateTable
+    val e2 = intercept[AccessControlException](
+      doAs("someone", sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2")))
+    assert(e2.getMessage.contains(s"does not have [create] privilege" +
+      s" on [$namespace1/$table2]"))
+
+    // CreateAsSelect
+    val e21 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"CREATE TABLE IF NOT EXISTS $catalogV2.$namespace1.$table2" +
+          s" AS select * from $catalogV2.$namespace1.$table1")))
+    assert(e21.getMessage.contains(s"does not have [select] privilege" +
+      s" on [$namespace1/$table1/city]"))
+  }
+
+  test("[KYUUBI #3424] DROP TABLE") {
+    assume(isSparkV31OrGreater)
+
+    // DropTable
+    val e3 = intercept[AccessControlException](
+      doAs("someone", sql(s"DROP TABLE $catalogV2.$namespace1.$table1")))
+    assert(e3.getMessage.contains(s"does not have [drop] privilege" +
+      s" on [$namespace1/$table1]"))
+  }
+
+  test("[KYUUBI #3424] INSERT TABLE") {
+    assume(isSparkV31OrGreater)
+
+    // AppendData: Insert Using a VALUES Clause
+    val e4 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+          s" VALUES (1, 'bowenliang123', 'Guangzhou')")))
+    assert(e4.getMessage.contains(s"does not have [update] privilege" +
+      s" on [$namespace1/$outputTable1]"))
+
+    // AppendData: Insert Using a TABLE Statement
+    val e42 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+          s" TABLE $catalogV2.$namespace1.$table1")))
+    assert(e42.getMessage.contains(s"does not have [select] privilege" +
+      s" on [$namespace1/$table1/city]"))
+
+    // AppendData: Insert Using a SELECT Statement
+    val e43 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"INSERT INTO $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+          s" SELECT * from $catalogV2.$namespace1.$table1")))
+    assert(e43.getMessage.contains(s"does not have [select] privilege" +
+      s" on [$namespace1/$table1/city]"))
+
+    // OverwriteByExpression: Insert Overwrite
+    val e44 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"INSERT OVERWRITE $catalogV2.$namespace1.$outputTable1 (id, name, city)" +
+          s" VALUES (1, 'bowenliang123', 'Guangzhou')")))
+    assert(e44.getMessage.contains(s"does not have [update] privilege" +
+      s" on [$namespace1/$outputTable1]"))
+  }
+
+  test("[KYUUBI #3424] UPDATE TABLE") {
+    assume(isSparkV31OrGreater)
+
+    // UpdateTable
+    val e5 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"UPDATE $catalogV2.$namespace1.$table1 SET city='Hangzhou' " +
+          " WHERE id=1")))
+    assert(e5.getMessage.contains(s"does not have [update] privilege" +
+      s" on [$namespace1/$table1]"))
+  }
+
+  test("[KYUUBI #3424] DELETE FROM TABLE") {
+    assume(isSparkV31OrGreater)
+
+    // DeleteFromTable
+    val e6 = intercept[AccessControlException](
+      doAs("someone", sql(s"DELETE FROM $catalogV2.$namespace1.$table1 WHERE id=1")))
+    assert(e6.getMessage.contains(s"does not have [update] privilege" +
+      s" on [$namespace1/$table1]"))
+  }
+
+  test("[KYUUBI #3424] CACHE TABLE") {
+    assume(isSparkV31OrGreater)
+
+    // CacheTable
+    val e7 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"CACHE TABLE $cacheTable1" +
+          s" AS select * from $catalogV2.$namespace1.$table1")))
+    if (isSparkV32OrGreater) {
+      assert(e7.getMessage.contains(s"does not have [select] privilege" +
+        s" on [$namespace1/$table1/id]"))
+    } else {
+      // todo catalog
+      assert(e7.getMessage.contains(s"does not have [select] privilege" +
+        s" on [$catalogV2.$namespace1/$table1]"))
+    }
+  }
+
+  test("[KYUUBI #3424] ALTER TABLE") {
+    assume(isSparkV31OrGreater)
+
+    // AddColumns
+    val e61 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 ADD COLUMNS (age int) ").explain()))
+    assert(e61.getMessage.contains(s"does not have [alter] privilege" +
+      s" on [$namespace1/$table1]"))
+
+    // DropColumns
+    val e62 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 DROP COLUMNS city ").explain()))
+    assert(e62.getMessage.contains(s"does not have [alter] privilege" +
+      s" on [$namespace1/$table1]"))
+
+    // RenameColumn
+    val e63 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 RENAME COLUMN city TO city2 ").explain()))
+    assert(e63.getMessage.contains(s"does not have [alter] privilege" +
+      s" on [$namespace1/$table1]"))
+
+    // AlterColumn
+    val e64 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"ALTER TABLE $catalogV2.$namespace1.$table1 " +
+          s"ALTER COLUMN city COMMENT 'city' ")))
+    assert(e64.getMessage.contains(s"does not have [alter] privilege" +
+      s" on [$namespace1/$table1]"))
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
close #3424.

Covering the following V2 commands,
- v2Commands
  - CreateNamespace: CREATE DATABASE
  - DropNamespace: DROP DATABASE
  - CommentOnNamespace
  - CreateTable
  - CreateV2Table
  - CreateAsSelect
  - UpdateTable
  - AppendData: Insert Using a SELECT Statement /  VALUES / TABLE
  - OverwriteByExpression: Insert Overwrite
  - OverwritePartitionsDynamic
  - CacheTable
  - DropTable
  - TruncateTable
  - AlterTable
  - MergeIntoTable
  - RepairTable

- v2AlterTableCommands
  - CommentOnTable
  - AddColumns
  - DropColumns
  - RenameColumn
  - AlterColumn
  - ReplaceColumns

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
