### PR TITLE
[SUBTASK] [KYUUBI #3420] Spark SQL Engine register zk with ui info

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -416,6 +416,13 @@ kyuubi.operation.spark.listener.enabled|true|When set to true, Spark engine regi
 kyuubi.operation.status.polling.timeout|PT5S|Timeout(ms) for long polling asynchronous running sql query's status|duration|1.0.0
 
 
+### Proxy
+
+Key | Default | Meaning | Type | Since
+--- | --- | --- | --- | ---
+kyuubi.proxy.spark.ui.enabled|false|Whether to enabled kyuubi help proxy spark ui|boolean|1.7.0
+
+
 ### Server
 
 Key | Default | Meaning | Type | Since

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
@@ -94,7 +94,13 @@ class SparkTBinaryFrontendService(
   }
 
   override def extraConfs: Map[String, String] = {
-    super.extraConfs ++ Map("ui" -> sc.uiWebUrl.get)
+    val extraConfs =
+      if (sc.uiWebUrl.nonEmpty) {
+        Map("ui" -> sc.uiWebUrl.get)
+      } else {
+        Map.empty
+      }
+    super.extraConfs ++ extraConfs
   }
 }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
@@ -93,7 +93,9 @@ class SparkTBinaryFrontendService(
     }
   }
 
-  override def ui: Option[String] = sc.uiWebUrl
+  override def extraConfs: Map[String, String] = {
+    super.extraConfs ++ Map("ui" -> sc.uiWebUrl.get)
+  }
 }
 
 object SparkTBinaryFrontendService extends Logging {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkTBinaryFrontendService.scala
@@ -92,6 +92,8 @@ class SparkTBinaryFrontendService(
       None
     }
   }
+
+  override def ui: Option[String] = sc.uiWebUrl
 }
 
 object SparkTBinaryFrontendService extends Logging {

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
@@ -20,14 +20,14 @@ package org.apache.kyuubi.engine.spark
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 
-import org.apache.kyuubi.config.KyuubiConf.PROXY_KUBERNETES_SPARK_UI_ENABLED
+import org.apache.kyuubi.config.KyuubiConf.PROXY_SPARK_UI_ENABLED
 import org.apache.kyuubi.ha.client.zookeeper.ZookeeperClientProvider
 
 class ZookeeperSparkEngineRegisterSuite extends WithDiscoverySparkSQLEngine
   with WithEmbeddedZookeeper {
   override def withKyuubiConf: Map[String, String] =
     super.withKyuubiConf ++ zookeeperConf ++ Map(
-      PROXY_KUBERNETES_SPARK_UI_ENABLED.key -> "true",
+      PROXY_SPARK_UI_ENABLED.key -> "true",
       "spark.ui.enabled" -> "true")
 
   override val namespace: String = s"/kyuubi/deregister_test/${UUID.randomUUID().toString}"

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark
+
+import java.nio.charset.StandardCharsets
+import java.util.UUID
+
+import org.apache.kyuubi.config.KyuubiConf.PROXY_KUBERNETES_SPARK_UI_ENABLED
+import org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient
+
+class ZookeeperSparkEngineRegisterSuite extends WithDiscoverySparkSQLEngine
+  with WithEmbeddedZookeeper {
+  override def withKyuubiConf: Map[String, String] =
+    super.withKyuubiConf ++ zookeeperConf ++ Map(PROXY_KUBERNETES_SPARK_UI_ENABLED.key -> "true")
+
+  override val namespace: String = s"/kyuubi/deregister_test/${UUID.randomUUID().toString}"
+
+  test("") {
+    zookeeperConf.foreach(entry => kyuubiConf.set(entry._1, entry._2))
+    val client = new ZookeeperDiscoveryClient(kyuubiConf)
+    val bytes = client.getData(namespace)
+    val data = new String(bytes, StandardCharsets.UTF_8)
+    assert(data.contains("spark.ui"))
+  }
+}

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import org.apache.kyuubi.config.KyuubiConf.PROXY_KUBERNETES_SPARK_UI_ENABLED
-import org.apache.kyuubi.ha.client.zookeeper.{ZookeeperClientProvider, ZookeeperDiscoveryClient}
+import org.apache.kyuubi.ha.client.zookeeper.ZookeeperClientProvider
 
 class ZookeeperSparkEngineRegisterSuite extends WithDiscoverySparkSQLEngine
   with WithEmbeddedZookeeper {

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/ZookeeperSparkEngineRegisterSuite.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 import java.util.UUID
 
 import org.apache.kyuubi.config.KyuubiConf.PROXY_KUBERNETES_SPARK_UI_ENABLED
-import org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient
+import org.apache.kyuubi.ha.client.zookeeper.{ZookeeperClientProvider, ZookeeperDiscoveryClient}
 
 class ZookeeperSparkEngineRegisterSuite extends WithDiscoverySparkSQLEngine
   with WithEmbeddedZookeeper {
@@ -30,10 +30,11 @@ class ZookeeperSparkEngineRegisterSuite extends WithDiscoverySparkSQLEngine
 
   override val namespace: String = s"/kyuubi/deregister_test/${UUID.randomUUID().toString}"
 
-  test("") {
+  test("Spark Engine Register Zookeeper with spark ui info") {
     zookeeperConf.foreach(entry => kyuubiConf.set(entry._1, entry._2))
-    val client = new ZookeeperDiscoveryClient(kyuubiConf)
-    val bytes = client.getData(namespace)
+    val client = ZookeeperClientProvider.buildZookeeperClient(kyuubiConf)
+    client.start()
+    val bytes = client.getData.forPath(namespace)
     val data = new String(bytes, StandardCharsets.UTF_8)
     assert(data.contains("spark.ui"))
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -305,9 +305,9 @@ object KyuubiConf {
       .booleanConf
       .createWithDefault(true)
 
-  val PROXY_KUBERNETES_SPARK_UI_ENABLED: ConfigEntry[Boolean] =
-    buildConf("kyuubi.proxy.kubernetes.spark.ui.enabled")
-      .doc("")
+  val PROXY_SPARK_UI_ENABLED: ConfigEntry[Boolean] =
+    buildConf("kyuubi.proxy.spark.ui.enabled")
+      .doc("Whether to enabled kyuubi help proxy spark ui")
       .version("1.7.0")
       .booleanConf
       .createWithDefault(false)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -305,6 +305,13 @@ object KyuubiConf {
       .booleanConf
       .createWithDefault(true)
 
+  val PROXY_KUBERNETES_SPARK_UI_ENABLED: ConfigEntry[Boolean] =
+    buildConf("kyuubi.proxy.kubernetes.spark.ui.enabled")
+      .doc("")
+      .version("1.7.0")
+      .booleanConf
+      .createWithDefault(false)
+
   // ///////////////////////////////////////////////////////////////////////////////////////////////
   //                              Frontend Service Configuration                                 //
   // ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
@@ -41,4 +41,9 @@ trait FrontendService {
    * An optional `ServiceDiscovery` for [[FrontendService]] to expose itself
    */
   val discoveryService: Option[Service]
+
+  /**
+   * An optional `UI`for each engine expose it's ui
+   */
+  def ui: Option[String] = None
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
@@ -43,7 +43,7 @@ trait FrontendService {
   val discoveryService: Option[Service]
 
   /**
-   * An optional `UI`for each engine expose it's ui
+   * An empty map for [[FrontendService]] to expose it's extra configurations
    */
-  def ui: Option[String] = None
+  def extraConfs: Map[String, String] = Map.empty
 }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceNodeInfo.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/ServiceNodeInfo.scala
@@ -23,6 +23,7 @@ case class ServiceNodeInfo(
     host: String,
     port: Int,
     version: Option[String],
-    engineRefId: Option[String]) {
+    engineRefId: Option[String],
+    ui: Option[String] = None) {
   def instance: String = s"$host:$port"
 }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -235,7 +235,7 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
       version: Option[String] = None,
       external: Boolean = false): Unit = {
     val instance = serviceDiscovery.fe.connectionUrl
-    val ui = serviceDiscovery.fe.ui
+    val ui = serviceDiscovery.fe.extraConfs.get("ui")
     val watcher = new DeRegisterWatcher(instance, serviceDiscovery)
     serviceNode = createPersistentNode(conf, namespace, instance, version, ui, external)
     // Set a watch on the serviceNode

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -40,6 +40,7 @@ import org.apache.zookeeper.KeeperException
 import org.apache.zookeeper.KeeperException.NodeExistsException
 import org.apache.zookeeper.WatchedEvent
 import org.apache.zookeeper.Watcher
+
 import org.apache.kyuubi.KYUUBI_VERSION
 import org.apache.kyuubi.KyuubiException
 import org.apache.kyuubi.KyuubiSQLException

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -46,7 +46,7 @@ import org.apache.kyuubi.KyuubiException
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
-import org.apache.kyuubi.config.KyuubiConf.PROXY_KUBERNETES_SPARK_UI_ENABLED
+import org.apache.kyuubi.config.KyuubiConf.PROXY_SPARK_UI_ENABLED
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ENGINE_REF_ID
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_NODE_TIMEOUT
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_PUBLISH_CONFIGS
@@ -363,7 +363,7 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
         instance
       }
     znodeData =
-      if (conf.get(PROXY_KUBERNETES_SPARK_UI_ENABLED) && ui.nonEmpty) {
+      if (conf.get(PROXY_SPARK_UI_ENABLED) && ui.nonEmpty) {
         znodeData + ";spark.ui=" + ui.get
       } else {
         znodeData

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -362,11 +362,12 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
       } else {
         instance
       }
-    znodeData = if (conf.get(PROXY_KUBERNETES_SPARK_UI_ENABLED) && ui.nonEmpty) {
+    znodeData =
+      if (conf.get(PROXY_KUBERNETES_SPARK_UI_ENABLED) && ui.nonEmpty) {
         znodeData + ";spark.ui=" + ui.get
-    } else {
-      znodeData
-    }
+      } else {
+        znodeData
+      }
     try {
       localServiceNode = new PersistentNode(
         zkClient,


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See more in #3420 
This pr aim to improve spark sql engine register zookeeper with spark ui info

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
