### PR TITLE
[BUILD] Share jars to reduce binary release tarball size

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -236,10 +236,9 @@ cp -r "$KYUUBI_HOME/kyuubi-assembly/target/scala-$SCALA_VERSION/jars/" "$DISTDIR
 cp "$KYUUBI_HOME"/kyuubi-hive-beeline/target/*.jar "$DISTDIR/beeline-jars/"
 
 # Share the jars w/ server to reduce binary size
-cd $DISTDIR/beeline-jars
 for jar in $(ls "$DISTDIR/jars/"); do
   if [[ -f "$DISTDIR/beeline-jars/$jar" ]]; then
-    ln -snf "../jars/$jar" "$DISTDIR/beeline-jars/$jar"
+    (cd $DISTDIR/beeline-jars; ln -snf "../jars/$jar" "$DISTDIR/beeline-jars/$jar")
   fi
 done
 
@@ -254,10 +253,9 @@ cp "$KYUUBI_HOME/externals/kyuubi-trino-engine/target/kyuubi-trino-engine_${SCAL
 cp -r "$KYUUBI_HOME/externals/kyuubi-trino-engine/target/scala-$SCALA_VERSION/jars/" "$DISTDIR/externals/engines/trino"
 
 # Share the jars w/ server to reduce binary size
-cd $DISTDIR/externals/engines/trino
 for jar in $(ls "$DISTDIR/jars/"); do
   if [[ -f "$DISTDIR/externals/engines/trino/$jar" ]]; then
-    ln -snf "../jars/$jar" "$DISTDIR/externals/engines/trino/$jar"
+    (cd $DISTDIR/externals/engines/trino; ln -snf "../../../jars/$jar" "$DISTDIR/externals/engines/trino/$jar")
   fi
 done
 
@@ -269,10 +267,9 @@ cp "$KYUUBI_HOME/externals/kyuubi-jdbc-engine/target/kyuubi-jdbc-engine_${SCALA_
 cp -r "$KYUUBI_HOME/externals/kyuubi-jdbc-engine/target/scala-$SCALA_VERSION/jars/" "$DISTDIR/externals/engines/jdbc"
 
 # Share the jars w/ server to reduce binary size
-cd $DISTDIR/externals/engines/jdbc
 for jar in $(ls "$DISTDIR/jars/"); do
   if [[ -f "$DISTDIR/externals/engines/jdbc/$jar" ]]; then
-    ln -snf "../jars/$jar" "$DISTDIR/externals/engines/jdbc/$jar"
+    (cd $DISTDIR/externals/engines/jdbc; ln -snf "../../../jars/$jar" "$DISTDIR/externals/engines/jdbc/$jar")
   fi
 done
 
@@ -328,7 +325,7 @@ if [[ "$MAKE_TGZ" == "true" ]]; then
   TARDIR="$KYUUBI_HOME/$TARDIR_NAME"
   rm -rf "$TARDIR"
   cp -R "$DISTDIR" "$TARDIR"
-  tar czf "$TARDIR.tgz" -C "$KYUUBI_HOME" "$TARDIR_NAME"
+  tar czf "$TARDIR_NAME.tgz" -C "$KYUUBI_HOME" "$TARDIR_NAME"
   rm -rf "$TARDIR"
   echo "The Kyuubi tarball $TARDIR_NAME.tgz is successfully generated in $KYUUBI_HOME."
 fi

--- a/build/dist
+++ b/build/dist
@@ -235,15 +235,13 @@ cp -r "$KYUUBI_HOME/kyuubi-assembly/target/scala-$SCALA_VERSION/jars/" "$DISTDIR
 # Copy kyuubi beeline jars
 cp "$KYUUBI_HOME"/kyuubi-hive-beeline/target/*.jar "$DISTDIR/beeline-jars/"
 
-# Share the jars between server and beeline to reduce binary size
+# Share the jars w/ server to reduce binary size
 cd $DISTDIR/beeline-jars
 for jar in $(ls "$DISTDIR/jars/"); do
   if [[ -f "$DISTDIR/beeline-jars/$jar" ]]; then
-    rm "$DISTDIR/beeline-jars/$jar"
-    ln -sn "../jars/$jar" "$DISTDIR/beeline-jars/$jar"
+    ln -snf "../jars/$jar" "$DISTDIR/beeline-jars/$jar"
   fi
 done
-cd -
 
 # Copy flink engines
 cp "$KYUUBI_HOME/externals/kyuubi-flink-sql-engine/target/kyuubi-flink-sql-engine_${SCALA_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/flink"
@@ -255,12 +253,28 @@ cp "$KYUUBI_HOME/externals/kyuubi-spark-sql-engine/target/kyuubi-spark-sql-engin
 cp "$KYUUBI_HOME/externals/kyuubi-trino-engine/target/kyuubi-trino-engine_${SCALA_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/trino"
 cp -r "$KYUUBI_HOME/externals/kyuubi-trino-engine/target/scala-$SCALA_VERSION/jars/" "$DISTDIR/externals/engines/trino"
 
+# Share the jars w/ server to reduce binary size
+cd $DISTDIR/externals/engines/trino
+for jar in $(ls "$DISTDIR/jars/"); do
+  if [[ -f "$DISTDIR/externals/engines/trino/$jar" ]]; then
+    ln -snf "../jars/$jar" "$DISTDIR/externals/engines/trino/$jar"
+  fi
+done
+
 # Copy hive engines
 cp "$KYUUBI_HOME/externals/kyuubi-hive-sql-engine/target/kyuubi-hive-sql-engine_${SCALA_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/hive"
 
 # Copy jdbc engines
 cp "$KYUUBI_HOME/externals/kyuubi-jdbc-engine/target/kyuubi-jdbc-engine_${SCALA_VERSION}-${VERSION}.jar" "$DISTDIR/externals/engines/jdbc"
 cp -r "$KYUUBI_HOME/externals/kyuubi-jdbc-engine/target/scala-$SCALA_VERSION/jars/" "$DISTDIR/externals/engines/jdbc"
+
+# Share the jars w/ server to reduce binary size
+cd $DISTDIR/externals/engines/jdbc
+for jar in $(ls "$DISTDIR/jars/"); do
+  if [[ -f "$DISTDIR/externals/engines/jdbc/$jar" ]]; then
+    ln -snf "../jars/$jar" "$DISTDIR/externals/engines/jdbc/$jar"
+  fi
+done
 
 # Copy kyuubi tools
 if [[ -f "$KYUUBI_HOME/tools/spark-block-cleaner/target/spark-block-cleaner_${SCALA_VERSION}-${VERSION}.jar" ]]; then
@@ -314,7 +328,7 @@ if [[ "$MAKE_TGZ" == "true" ]]; then
   TARDIR="$KYUUBI_HOME/$TARDIR_NAME"
   rm -rf "$TARDIR"
   cp -R "$DISTDIR" "$TARDIR"
-  tar czf "$TARDIR_NAME.tgz" -C "$KYUUBI_HOME" "$TARDIR_NAME"
+  tar czf "$TARDIR.tgz" -C "$KYUUBI_HOME" "$TARDIR_NAME"
   rm -rf "$TARDIR"
   echo "The Kyuubi tarball $TARDIR_NAME.tgz is successfully generated in $KYUUBI_HOME."
 fi


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
The 1.6.0 binary tarball is nearly 300MB, we can reduce the size by sharing jars between engine and server, as beeline does.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

```
-rw-r--r--   1 chengpan  staff   155M Sep  9 14:21 apache-kyuubi-1.7.0-SNAPSHOT-bin.tgz
```

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
