### PR TITLE
[KYUUBI #3464] Support for pooling external catalog

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/ExternalCatalogManager.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/ExternalCatalogManager.scala
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.spark.connector.hive
+
+import java.util.concurrent.ConcurrentHashMap
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.SparkConf
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.hive.kyuubi.connector.HiveBridgeHelper.HiveExternalCatalog
+
+import org.apache.kyuubi.spark.connector.hive.KyuubiHiveConnectorConf.EXTERNAL_CATALOG_SHARE_POLICY
+
+object ExternalCatalogManager {
+  private var manager: ExternalCatalogManager = _
+
+  def getOrCreate(sparkSession: SparkSession): ExternalCatalogManager = {
+    if (manager == null) {
+      synchronized {
+        if (manager == null) {
+          val conf = sparkSession.sessionState.conf
+          manager = ExternalCatalogSharePolicy.fromString(
+            conf.getConf(EXTERNAL_CATALOG_SHARE_POLICY)) match {
+            case OneForAllPolicy => new OneForAllPolicyManager()
+            case OneForOnePolicy => OneForOnePolicyManager
+          }
+        }
+      }
+    }
+    manager
+  }
+
+  private[kyuubi] def reset(): Unit = {
+    if (manager != null) {
+      manager.invalidateAll()
+      manager = null
+    }
+  }
+}
+
+abstract class ExternalCatalogManager {
+
+  def take(ticket: Ticket): HiveExternalCatalog
+
+  def invalidateAll(): Unit = {}
+}
+
+/**
+ * A [[OneForAllPolicy]] policy for the externalCatalog manager, which caches the externalCatalog
+ * according to the catalogName, aiming for only one of each catalog globally.
+ */
+class OneForAllPolicyManager() extends ExternalCatalogManager {
+  private val catalogCache = new ConcurrentHashMap[String, HiveExternalCatalog]()
+
+  override def take(ticket: Ticket): HiveExternalCatalog = {
+    catalogCache.computeIfAbsent(
+      ticket.catalogName,
+      _ => {
+        new HiveExternalCatalog(ticket.sparkConf, ticket.hadoopConf)
+      })
+  }
+}
+
+/**
+ * A [[OneForOnePolicy]] policy for the externalCatalog manager, It doesn't actually cache any
+ * externalCatalog, each session will have its own externalCatalog.
+ */
+object OneForOnePolicyManager extends ExternalCatalogManager {
+
+  override def take(ticket: Ticket): HiveExternalCatalog = {
+    new HiveExternalCatalog(ticket.sparkConf, ticket.hadoopConf)
+  }
+}
+
+case class Ticket(catalogName: String, sparkConf: SparkConf, hadoopConf: Configuration)

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/ExternalCatalogSharePolicy.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/ExternalCatalogSharePolicy.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.spark.connector.hive
+
+import java.util.Locale
+
+sealed trait ExternalCatalogSharePolicy {
+
+  /**
+   * String name of the share policy
+   */
+  def name: String
+}
+
+/**
+ * Indicate to an external catalog is shared globally with the HiveCatalogs
+ * with the same catalogName.
+ */
+case object OneForAllPolicy extends ExternalCatalogSharePolicy { val name = "ONE_FOR_ALL" }
+
+/**
+ * Indicate to an external catalog is used by only one HiveCatalog.
+ */
+case object OneForOnePolicy extends ExternalCatalogSharePolicy { val name = "ONE_FOR_ONE" }
+
+object ExternalCatalogSharePolicy {
+
+  /**
+   * Returns the share policy from the given string.
+   */
+  def fromString(policy: String): ExternalCatalogSharePolicy =
+    policy.toUpperCase(Locale.ROOT) match {
+      case OneForAllPolicy.name => OneForAllPolicy
+      case OneForOnePolicy.name => OneForOnePolicy
+      case _ => throw new IllegalArgumentException(s"Unknown share policy: $policy. Accepted " +
+          "policies are 'ONE_FOR_ONE', 'ONE_FOR_ALL'.")
+    }
+}

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveConnectorConf.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/KyuubiHiveConnectorConf.scala
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.spark.connector.hive
+
+import java.util.Locale
+
+object KyuubiHiveConnectorConf {
+
+  import org.apache.spark.sql.internal.SQLConf.buildStaticConf
+
+  val EXTERNAL_CATALOG_SHARE_POLICY =
+    buildStaticConf("spark.sql.kyuubi.hive.connector.externalCatalog.share.policy")
+      .internal()
+      .doc(s"Indicates the share policy for the externalCatalog in the Kyuubi Connector, we use" +
+        "'all' by default. " +
+        "<li>ONE_FOR_ONE: Indicate to an external catalog is used by only one HiveCatalog. </li> " +
+        "<li>ONE_FOR_ALL: Indicate to an external catalog is shared globally with the " +
+        "HiveCatalogs with the same catalogName. </li> ")
+      .version("1.7.0")
+      .stringConf
+      .transform(policy => policy.toUpperCase(Locale.ROOT))
+      .checkValue(
+        policy => Set("ONE_FOR_ONE", "ONE_FOR_ALL").contains(policy),
+        "Invalid value for 'spark.sql.kyuubi.hive.connector.externalCatalog.share.policy'." +
+          "Valid values are 'ONE_FOR_ONE', 'ONE_FOR_ALL'.")
+      .createWithDefault(OneForAllPolicy.name)
+}

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/ExternalCatalogPoolSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/ExternalCatalogPoolSuite.scala
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.spark.connector.hive
+
+import org.apache.kyuubi.spark.connector.hive.KyuubiHiveConnectorConf.EXTERNAL_CATALOG_SHARE_POLICY
+
+class ExternalCatalogPoolSuite extends KyuubiHiveTest {
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    ExternalCatalogManager.reset()
+  }
+
+  test("test configuration for externalCatalog share policy") {
+    withSparkSession() { spark =>
+      val pool1 = ExternalCatalogManager.getOrCreate(spark)
+      val pool2 = ExternalCatalogManager.getOrCreate(spark)
+      assert(pool1.isInstanceOf[OneForAllPolicyManager])
+      assert(pool1 == pool2)
+    }
+
+    ExternalCatalogManager.reset()
+    withSparkSession(Map(EXTERNAL_CATALOG_SHARE_POLICY.key -> "ONE_FOR_ONE")) { spark =>
+      val pool1 = ExternalCatalogManager.getOrCreate(spark)
+      val pool2 = ExternalCatalogManager.getOrCreate(spark)
+      assert(pool1.isInstanceOf[OneForOnePolicyManager.type])
+      assert(pool1 == pool2)
+    }
+  }
+
+  test("ALL policy: external catalog is shared globally " +
+    "with the HiveCatalogs with the same catalogName") {
+    withSparkSession(Map(
+      EXTERNAL_CATALOG_SHARE_POLICY.key -> "ONE_FOR_ALL")) { spark =>
+      val catalog1 =
+        Ticket("catalog1", spark.sparkContext.getConf, spark.sessionState.newHadoopConf())
+      val catalog2 =
+        Ticket("catalog2", spark.sparkContext.getConf, spark.sessionState.newHadoopConf())
+      val pool = ExternalCatalogManager.getOrCreate(spark)
+      val externalCatalog1 = pool.take(catalog1)
+      val externalCatalog2 = pool.take(catalog2)
+
+      assert(externalCatalog1 != externalCatalog2)
+      (1 to 10).foreach { id =>
+        assert(pool.take(catalog1) == externalCatalog1)
+      }
+
+      (1 to 10).foreach { id =>
+        assert(pool.take(catalog2) == externalCatalog2)
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix https://github.com/apache/incubator-kyuubi/issues/3464, currently, Kyuubi supports hive connector for read/write hive table, it is implemented based on the [Apache Spark DataSource V2](https://www.databricks.com/session/apache-spark-data-source-v2), but there's a potential issue;

Kyuubi use `kyuubi.engine.single.spark.session`=[false](https://kyuubi.apache.org/docs/latest/deployment/settings.html#:~:text=kyuubi.engine.single.spark.session) to provide concurrency sql execution in context isolation, this cause spark.newSession invoked for each transaction, in spark v1 catalog, externalCatalog is shared in the mutiple session, but in catalog v2 architecture, it's big different with v1, v2 catalogs are managed by `CatalogManager` which is [session level](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/internal/SessionState.scala#L97), this means that each session will have a separate catalogManager, so in the case of multiple sessions, hivecatalog will be initialized multiple times. this causes two problems: 1  multiple sessions may be wasted initializing multiple HiveExternalCatalog, which may cause the JVM namespace to swell. 2  multiple HiveClient connections may be initialized;

This issue aims to pool externalCatalog to address the potential issues mentioned above.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
