### PR TITLE
[KYUUBI #3449] Change default server info provider to ENGINE

### DIFF
--- a/docs/deployment/index.rst
+++ b/docs/deployment/index.rst
@@ -29,6 +29,7 @@ Basics
     kyuubi_on_kubernetes
     hive_metastore
     high_availability_guide
+    migration-guide
 
 Configurations
 --------------

--- a/docs/deployment/migration-guide.md
+++ b/docs/deployment/migration-guide.md
@@ -1,0 +1,22 @@
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+
+# Kyuubi Migration Guide
+
+## Upgrading from Kyuubi 1.6.0 to 1.7.0
+* In Kyuubi 1.6.0, Kyuubi provides the `kyuubi.server.info.provider` option to control get the server or the engine information, in Kyuubi 1.6.0, it defaults to the `SERVER`, after Kyuubi 1.7.0, it defaults to the `ENGINE`, which means that information about engine is returned by default, Setting the option as "SERVER" restores the previous behavior.

--- a/docs/deployment/migration-guide.md
+++ b/docs/deployment/migration-guide.md
@@ -18,5 +18,6 @@
 
 # Kyuubi Migration Guide
 
-## Upgrading from Kyuubi 1.6.0 to 1.7.0
-* In Kyuubi 1.6.0, Kyuubi provides the `kyuubi.server.info.provider` option to control get the server or the engine information, in Kyuubi 1.6.0, it defaults to the `SERVER`, after Kyuubi 1.7.0, it defaults to the `ENGINE`, which means that information about engine is returned by default, Setting the option as "SERVER" restores the previous behavior.
+## Upgrading from Kyuubi 1.6 to 1.7
+
+* Since Kyuubi 1.7, Kyuubi returns engine's information for `GetInfo` request instead of server. To restore the previous behavior, set `kyuubi.server.info.provider` to `SERVER`.

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -420,7 +420,7 @@ kyuubi.operation.status.polling.timeout|PT5S|Timeout(ms) for long polling asynch
 
 Key | Default | Meaning | Type | Since
 --- | --- | --- | --- | ---
-kyuubi.server.info.provider|SERVER|The server information provider name, some clients may rely on this information to check the server compatibilities and functionalities. <li>SERVER: Return Kyuubi server information.</li> <li>ENGINE: Return Kyuubi engine information.</li>|string|1.6.1
+kyuubi.server.info.provider|ENGINE|The server information provider name, some clients may rely on this information to check the server compatibilities and functionalities. <li>SERVER: Return Kyuubi server information.</li> <li>ENGINE: Return Kyuubi engine information.</li>|string|1.6.1
 kyuubi.server.limit.connections.per.ipaddress|&lt;undefined&gt;|Maximum kyuubi server connections per ipaddress. Any user exceeding this limit will not be allowed to connect.|int|1.6.0
 kyuubi.server.limit.connections.per.user|&lt;undefined&gt;|Maximum kyuubi server connections per user. Any user exceeding this limit will not be allowed to connect.|int|1.6.0
 kyuubi.server.limit.connections.per.user.ipaddress|&lt;undefined&gt;|Maximum kyuubi server connections per user:ipaddress combination. Any user-ipaddress exceeding this limit will not be allowed to connect.|int|1.6.0

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1719,7 +1719,7 @@ object KyuubiConf {
         " <li>ENGINE: Return Kyuubi engine information.</li>")
       .version("1.6.1")
       .stringConf
-      .createWithDefault("SERVER")
+      .createWithDefault("ENGINE")
 
   val ENGINE_SPARK_SHOW_PROGRESS: ConfigEntry[Boolean] =
     buildConf("kyuubi.session.engine.spark.showProgress")

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiOperationPerUserSuite.scala
@@ -45,13 +45,15 @@ class KyuubiOperationPerUserSuite
   }
 
   test("audit Kyuubi server MetaData") {
-    withJdbcStatement() { statement =>
-      val metaData = statement.getConnection.getMetaData
-      assert(metaData.getDatabaseProductName === "Apache Kyuubi (Incubating)")
-      assert(metaData.getDatabaseProductVersion === KYUUBI_VERSION)
-      val ver = SemanticVersion(KYUUBI_VERSION)
-      assert(metaData.getDatabaseMajorVersion === ver.majorVersion)
-      assert(metaData.getDatabaseMinorVersion === ver.minorVersion)
+    withSessionConf()(Map(KyuubiConf.SERVER_INFO_PROVIDER.key -> "SERVER"))(Map.empty) {
+      withJdbcStatement() { statement =>
+        val metaData = statement.getConnection.getMetaData
+        assert(metaData.getDatabaseProductName === "Apache Kyuubi (Incubating)")
+        assert(metaData.getDatabaseProductVersion === KYUUBI_VERSION)
+        val ver = SemanticVersion(KYUUBI_VERSION)
+        assert(metaData.getDatabaseMajorVersion === ver.majorVersion)
+        assert(metaData.getDatabaseMinorVersion === ver.minorVersion)
+      }
     }
   }
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -27,6 +27,7 @@ import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
 
 import org.apache.kyuubi.{KyuubiFunSuite, RestFrontendTestHelper}
 import org.apache.kyuubi.client.api.v1.dto._
+import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.events.KyuubiSessionEvent
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.OperationHandle
@@ -147,7 +148,7 @@ class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
       "admin",
       "123456",
       "localhost",
-      Map("testConfig" -> "testValue").asJava)
+      Map("testConfig" -> "testValue", KyuubiConf.SERVER_INFO_PROVIDER.key -> "SERVER").asJava)
 
     var response: Response = webTarget.path("api/v1/sessions")
       .request(MediaType.APPLICATION_JSON_TYPE)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
close https://github.com/apache/incubator-kyuubi/issues/3449, this pr aims to change `kyuubi.server.info.provider` default value to "ENGINE", and modify corresponding tests.



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
