### PR TITLE
Revert "[KYUUBI #3454] [CI] Check Kyuubi modules available only when `**/pom.xml` is changed"

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -38,12 +38,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: dorny/paths-filter@v2
-        id: filter
-        with:
-          filters: |
-            is-pom-changed:
-              - '**/pom.xml'
       - name: Setup JDK 8
         uses: actions/setup-java@v2
         with:
@@ -53,7 +47,6 @@ jobs:
           check-latest: false
       - name: Check kyuubi modules avaliable
         id: modules-check
-        if: steps.filter.outputs.is-pom-changed == 'true'
         run: build/mvn dependency:resolve -DincludeGroupIds="org.apache.kyuubi" -DincludeScope="compile" -DexcludeTransitive=true ${{ matrix.profiles }}
         continue-on-error: true
 


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR revert #3454 

Since publishing snapshots is a scheduler job, added submodules may not be available after merging into the master.


### _How was this patch tested?_

Pass CI.
