### PR TITLE
[KYUUBI #3484] Implement isSigned method of ResultSetMetaData for Kyuubi JDBC driver 

### DIFF
--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiResultSetMetaData.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiResultSetMetaData.java
@@ -132,4 +132,38 @@ public class KyuubiResultSetMetaData implements SQLResultSetMetaData {
     }
     return column - 1;
   }
+
+  @Override
+  public boolean isSigned(int column) throws SQLException {
+    TTypeId typeId = columnTypes.get(toZeroIndex(column));
+    switch (typeId) {
+      case TINYINT_TYPE:
+      case SMALLINT_TYPE:
+      case INT_TYPE:
+      case BIGINT_TYPE:
+      case FLOAT_TYPE:
+      case DOUBLE_TYPE:
+      case DECIMAL_TYPE:
+      case TIMESTAMP_TYPE:
+      case DATE_TYPE:
+      case INTERVAL_YEAR_MONTH_TYPE:
+      case INTERVAL_DAY_TIME_TYPE:
+      case TIMESTAMPLOCALTZ_TYPE:
+        return true;
+
+      case BOOLEAN_TYPE:
+      case STRING_TYPE:
+      case VARCHAR_TYPE:
+      case CHAR_TYPE:
+      case NULL_TYPE:
+      case BINARY_TYPE:
+      case ARRAY_TYPE:
+      case MAP_TYPE:
+      case STRUCT_TYPE:
+      case UNION_TYPE:
+      case USER_DEFINED_TYPE:
+      default:
+        return false;
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Implement isSigned method of ResultSetMetaData for KyuubiHiveDriver.

isSigned is required in getSchema of Spark JDBC source. Without Implementing it, blue part is workaround for HiveDriver , but for KyuubiHiveDriver it will fail.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
