### PR TITLE
[KYUUBI #3490] Improve the KyuubiConf#kyuubiConfEntries code logic

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -52,6 +52,9 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
   }
 
   def set[T](entry: ConfigEntry[T], value: T): KyuubiConf = {
+    require(entry != null, "entry cannot be null")
+    require(value != null, s"value cannot be null for key: ${entry.key}")
+    require(containsConfigEntry(entry), s"$entry is not registered")
     if (settings.put(entry.key, entry.strConverter(value)) == null) {
       logDeprecationWarning(entry.key)
     }
@@ -59,13 +62,14 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
   }
 
   def set[T](entry: OptionalConfigEntry[T], value: T): KyuubiConf = {
+    require(containsConfigEntry(entry), s"$entry is not registered")
     set(entry.key, entry.strConverter(Option(value)))
     this
   }
 
   def set(key: String, value: String): KyuubiConf = {
-    require(key != null)
-    require(value != null)
+    require(key != null, "key cannot be null")
+    require(value != null, s"value cannot be null for key: $key")
     if (settings.put(key, value) == null) {
       logDeprecationWarning(key)
     }
@@ -73,6 +77,7 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
   }
 
   def setIfMissing[T](entry: ConfigEntry[T], value: T): KyuubiConf = {
+    require(containsConfigEntry(entry), s"$entry is not registered")
     if (settings.putIfAbsent(entry.key, entry.strConverter(value)) == null) {
       logDeprecationWarning(entry.key)
     }
@@ -89,6 +94,7 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
   }
 
   def get[T](config: ConfigEntry[T]): T = {
+    require(containsConfigEntry(config), s"$config is not registered")
     config.readFrom(reader)
   }
 
@@ -102,6 +108,7 @@ case class KyuubiConf(loadSysDefault: Boolean = true) extends Logging {
   }
 
   def unset(entry: ConfigEntry[_]): KyuubiConf = {
+    require(containsConfigEntry(entry), s"$entry is not registered")
     unset(entry.key)
   }
 
@@ -184,14 +191,40 @@ object KyuubiConf {
   final val KYUUBI_ENGINE_ENV_PREFIX = "kyuubi.engineEnv"
   final val KYUUBI_BATCH_CONF_PREFIX = "kyuubi.batchConf"
 
-  val kyuubiConfEntries: java.util.Map[String, ConfigEntry[_]] =
-    java.util.Collections.synchronizedMap(new java.util.HashMap[String, ConfigEntry[_]]())
+  private[this] val kyuubiConfEntriesUpdateLock = new Object
 
-  private def register(entry: ConfigEntry[_]): Unit = kyuubiConfEntries.synchronized {
-    require(
-      !kyuubiConfEntries.containsKey(entry.key),
-      s"Duplicate ConfigEntry. ${entry.key} has been registered")
-    kyuubiConfEntries.put(entry.key, entry)
+  @volatile
+  private[this] var kyuubiConfEntries: java.util.Map[String, ConfigEntry[_]] =
+    java.util.Collections.emptyMap()
+
+  private[config] def register(entry: ConfigEntry[_]): Unit =
+    kyuubiConfEntriesUpdateLock.synchronized {
+      require(
+        !kyuubiConfEntries.containsKey(entry.key),
+        s"Duplicate ConfigEntry. ${entry.key} has been registered")
+      val updatedMap = new java.util.HashMap[String, ConfigEntry[_]](kyuubiConfEntries)
+      updatedMap.put(entry.key, entry)
+      kyuubiConfEntries = updatedMap
+    }
+
+  // For testing only
+  private[config] def unregister(entry: ConfigEntry[_]): Unit =
+    kyuubiConfEntriesUpdateLock.synchronized {
+      val updatedMap = new java.util.HashMap[String, ConfigEntry[_]](kyuubiConfEntries)
+      updatedMap.remove(entry.key)
+      kyuubiConfEntries = updatedMap
+    }
+
+  private[config] def getConfigEntry(key: String): ConfigEntry[_] = {
+    kyuubiConfEntries.get(key)
+  }
+
+  private[config] def getConfigEntries(): java.util.Collection[ConfigEntry[_]] = {
+    kyuubiConfEntries.values()
+  }
+
+  private[config] def containsConfigEntry(entry: ConfigEntry[_]): Boolean = {
+    getConfigEntry(entry.key) == entry
   }
 
   def buildConf(key: String): ConfigBuilder = {

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/config/ConfigBuilderSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/config/ConfigBuilderSuite.scala
@@ -51,6 +51,8 @@ class ConfigBuilderSuite extends KyuubiFunSuite {
       .createWithDefault(false)
     assert(booleanConf.key === "kyuubi.boolean.conf")
     assert(!booleanConf.defaultVal.get)
+
+    KyuubiConf.register(booleanConf)
     val kyuubiConf = KyuubiConf().set(booleanConf.key, "invalid conf")
     val e = intercept[IllegalArgumentException](kyuubiConf.get(booleanConf))
     assert(e.getMessage === "kyuubi.boolean.conf should be boolean, but was invalid conf")
@@ -67,6 +69,7 @@ class ConfigBuilderSuite extends KyuubiFunSuite {
       .toSequence()
       .createWithDefault(Nil)
     assert(sequenceConf.defaultVal.get.isEmpty)
+    KyuubiConf.register(sequenceConf)
     val kyuubiConf = KyuubiConf().set(sequenceConf.key, "kyuubi,kent")
     assert(kyuubiConf.get(sequenceConf) === Seq("kyuubi", "kent"))
   }
@@ -78,6 +81,7 @@ class ConfigBuilderSuite extends KyuubiFunSuite {
     assert(timeConf.key === "kyuubi.time.config")
     assert(timeConf.defaultVal.get === 3)
     val kyuubiConf = KyuubiConf().set(timeConf.key, "invalid")
+    KyuubiConf.register(timeConf)
     val e = intercept[IllegalArgumentException](kyuubiConf.get(timeConf))
     assert(e.getMessage startsWith "The formats accepted are 1) based on the ISO-8601")
   }
@@ -90,6 +94,7 @@ class ConfigBuilderSuite extends KyuubiFunSuite {
     assert(intConf.key === "kyuubi.invalid.config")
     assert(intConf.defaultVal.get === 3)
     val kyuubiConf = KyuubiConf().set(intConf.key, "-1")
+    KyuubiConf.register(intConf)
     val e = intercept[IllegalArgumentException](kyuubiConf.get(intConf))
     assert(e.getMessage equals "'-1' in kyuubi.invalid.config is invalid. must be positive integer")
   }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/config/AllKyuubiConfiguration.scala
@@ -131,7 +131,7 @@ class AllKyuubiConfiguration extends KyuubiFunSuite {
 
     rewriteToConf(Paths.get(kyuubiHome, "conf", "kyuubi-defaults.conf.template"), newOutput)
 
-    KyuubiConf.kyuubiConfEntries.values().asScala
+    KyuubiConf.getConfigEntries().asScala
       .toSeq
       .filterNot(_.internal)
       .groupBy(_.key.split("\\.")(1))


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix https://github.com/apache/incubator-kyuubi/issues/3490
Currently, when Kyuubi get or set conf by `ConfigEntry`, it does not check whether `ConfigEntry` have been registered, so this pr aims to two points as follow:

- Require ConfigEntry has been registered;
- Using copy-on-write for Kyuubi#kyuubiConfEntries to reduce contention in concurrent workloads.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
