### PR TITLE
Fix GetTables operation in Flink

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/java/org/apache/kyuubi/engine/flink/result/Constants.java
+++ b/externals/kyuubi-flink-sql-engine/src/main/java/org/apache/kyuubi/engine/flink/result/Constants.java
@@ -21,8 +21,6 @@ package org.apache.kyuubi.engine.flink.result;
 /** Constant column names. */
 public class Constants {
 
-  public static final String SHOW_TABLES_RESULT = "tables";
-
   public static final String TABLE_TYPE = "TABLE";
   public static final String VIEW_TYPE = "VIEW";
 

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/FlinkSQLOperationManager.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/FlinkSQLOperationManager.scala
@@ -128,9 +128,9 @@ class FlinkSQLOperationManager extends OperationManager("FlinkSQLOperationManage
 
     val op = new GetTables(
       session = session,
-      catalog = catalogName,
-      schema = schemaName,
-      tableName = tableName,
+      catalogNameOrEmpty = catalogName,
+      schemaNamePattern = schemaName,
+      tableNamePattern = tableName,
       tableTypes = tTypes)
 
     addOperation(op)

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTables.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTables.scala
@@ -48,7 +48,7 @@ class GetTables(
       val schemaNameRegex = toJavaRegex(schemaNamePattern).r
       val tableNameRegex = toJavaRegex(tableNamePattern).r
 
-      val tables = tableEnv.getCatalog(catalogName).asScala.toSeq.flatMap { flinkCatalog =>
+      val tables = tableEnv.getCatalog(catalogName).asScala.toArray.flatMap { flinkCatalog =>
         flinkCatalog.listDatabases().asScala
           .filter { schemaName => schemaNameRegex.pattern.matcher(schemaName).matches() }
           .flatMap { schemaName =>
@@ -78,7 +78,7 @@ class GetTables(
                   null)
               }
           }
-      }.toArray
+      }
 
       resultSet = ResultSet.builder.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
         .columns(

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTables.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTables.scala
@@ -64,13 +64,13 @@ class GetTables(
               .filter {
                 case (_, None) => false
                 case (_, Some(flinkTable)) => tableTypes.contains(flinkTable.getTableKind.name)
-              }.map { case (tableName, Some(flinkTable)) =>
+              }.map { case (tableName, flinkTable) =>
                 Row.of(
                   catalogName,
                   schemaName,
                   tableName,
-                  flinkTable.getTableKind.name,
-                  flinkTable.getComment,
+                  flinkTable.map(_.getTableKind.name).getOrElse(""),
+                  flinkTable.map(_.getComment).getOrElse(""),
                   null,
                   null,
                   null,

--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTables.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTables.scala
@@ -21,9 +21,13 @@ import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 import org.apache.commons.lang3.StringUtils
+import org.apache.flink.table.api.{DataTypes, ResultKind}
+import org.apache.flink.table.catalog.Column
 import org.apache.flink.table.catalog.ObjectIdentifier
+import org.apache.flink.types.Row
 
-import org.apache.kyuubi.engine.flink.result.{Constants, ResultSetUtil}
+import org.apache.kyuubi.engine.flink.result.ResultSet
+import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
 import org.apache.kyuubi.session.Session
 
 class GetTables(
@@ -49,22 +53,46 @@ class GetTables(
           .flatMap { _schema =>
             flinkCatalog.listTables(_schema).asScala
               .filter { _table => tableNamePattern.pattern.matcher(_table).matches() }
-              .filter { _table =>
-                // skip check type of every table if request all types
-                if (Set(Constants.TABLE_TYPE, Constants.VIEW_TYPE) subsetOf tableTypes) {
-                  true
-                } else {
-                  val objPath = ObjectIdentifier.of(catalogName, _schema, _table).toObjectPath
-                  Try(flinkCatalog.getTable(objPath)) match {
-                    case Success(table) => tableTypes.contains(table.getTableKind.name)
-                    case Failure(_) => false
-                  }
+              .map { _table =>
+                val objPath = ObjectIdentifier.of(catalogName, _schema, _table).toObjectPath
+                Try(flinkCatalog.getTable(objPath)) match {
+                  case Success(table) => (_table, Some(table))
+                  case Failure(_) => (_table, None)
                 }
               }
+              .filter(_._2.isDefined)
+              .filter { _table =>
+                tableTypes.contains(_table._2.get.getTableKind.name)
+              }.map { _table =>
+                Row.of(
+                  catalogName,
+                  _schema,
+                  _table._1,
+                  _table._2.get.getTableKind.name(),
+                  _table._2.get.getComment,
+                  null,
+                  null,
+                  null,
+                  null,
+                  null)
+              }
           }
-      }
+      }.toArray
 
-      resultSet = ResultSetUtil.stringListToResultSet(tables.toList, Constants.SHOW_TABLES_RESULT)
+      resultSet = ResultSet.builder.resultKind(ResultKind.SUCCESS_WITH_CONTENT)
+        .columns(
+          Column.physical(TABLE_CAT, DataTypes.STRING()),
+          Column.physical(TABLE_SCHEM, DataTypes.STRING()),
+          Column.physical(TABLE_NAME, DataTypes.STRING()),
+          Column.physical(TABLE_TYPE, DataTypes.STRING()),
+          Column.physical(REMARKS, DataTypes.STRING()),
+          Column.physical("TYPE_CAT", DataTypes.STRING()),
+          Column.physical("TYPE_SCHEM", DataTypes.STRING()),
+          Column.physical("TYPE_NAME", DataTypes.STRING()),
+          Column.physical("SELF_REFERENCING_COL_NAME", DataTypes.STRING()),
+          Column.physical("REF_GENERATION", DataTypes.STRING()))
+        .data(tables)
+        .build
     } catch onError()
   }
 }

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
@@ -389,7 +389,9 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
            |  id int,
            |  name string,
            |  price double
-           | ) with (
+           | )
+           | comment 'table_comment'
+           | with (
            |   'connector' = 'filesystem'
            | )
        """.stripMargin)
@@ -403,25 +405,37 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
       val metaData = statement.getConnection.getMetaData
       val rs1 = metaData.getTables(null, null, null, null)
       assert(rs1.next())
-      assert(rs1.getString(1) == table)
+      assert(rs1.getString(1) == "default_catalog")
+      assert(rs1.getString(2) == "default_database")
+      assert(rs1.getString(3) == table)
+      assert(rs1.getString(4) == "TABLE")
+      assert(rs1.getString(5) == "table_comment")
       assert(rs1.next())
-      assert(rs1.getString(1) == table_view)
+      assert(rs1.getString(1) == "default_catalog")
+      assert(rs1.getString(2) == "default_database")
+      assert(rs1.getString(3) == table_view)
+      assert(rs1.getString(4) == "VIEW")
+      assert(rs1.getString(5) == "")
 
       // get table , table name like table%
       val rs2 = metaData.getTables(null, null, "table%", Array("TABLE"))
       assert(rs2.next())
-      assert(rs2.getString(1) == table)
+      assert(rs2.getString(1) == "default_catalog")
+      assert(rs2.getString(2) == "default_database")
+      assert(rs2.getString(3) == table)
       assert(!rs2.next())
 
       // get view , view name like *
       val rs3 = metaData.getTables(null, "default_database", "*", Array("VIEW"))
       assert(rs3.next())
-      assert(rs3.getString(1) == table_view)
+      assert(rs3.getString(1) == "default_catalog")
+      assert(rs3.getString(2) == "default_database")
+      assert(rs3.getString(3) == table_view)
 
       // get view , view name like *, schema pattern like default_%
       val rs4 = metaData.getTables(null, "default_%", "*", Array("VIEW"))
       assert(rs4.next())
-      assert(rs4.getString(1) == table_view)
+      assert(rs4.getString(3) == table_view)
 
       // get view , view name like *, schema pattern like no_exists_%
       val rs5 = metaData.getTables(null, "no_exists_%", "*", Array("VIEW"))


### PR DESCRIPTION
### _Why are the changes needed?_
#1646

In Flink, the schema returned by `GetTables` is incorrect, causing some database management tools to not see the table.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
