### PR TITLE
[SPARK] Kyuubi should set env SPARK_USER_NAME for K8s deployment

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -93,10 +93,14 @@ class SparkProcessBuilder(
 
     // For spark on kubernetes, spark pod using env SPARK_USER_NAME as current user
     def setSparkUserName(userName: String): Unit = {
-      buffer += CONF
-      buffer += s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$userName"
-      buffer += CONF
-      buffer += s"spark.kubernetes.executorEnv.SPARK_USER_NAME=$userName"
+      clusterManager().foreach(cm => {
+        if (cm.startsWith("k8s://")) {
+          buffer += CONF
+          buffer += s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$userName"
+          buffer += CONF
+          buffer += s"spark.kubernetes.executorEnv.SPARK_USER_NAME=$userName"
+        }
+      })
     }
 
     // if the keytab is specified, PROXY_USER is not supported


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
On case spark on kubernetes, spark using env `SPARK_USER_NAME` as user name.
So kyuubi should build spark engine with this env when proxy user or using keytab.
This conf only affect on kubernetes case.

Ref: https://github.com/apache/spark/pull/23017

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
