### PR TITLE
[KYUUBI #3547] Fix Flink statements results validation

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
@@ -703,13 +703,18 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
 
   test("execute statement - create/drop catalog") {
     withJdbcStatement()({ statement =>
-      val createResult =
+      val createResult = {
         statement.executeQuery("create catalog cat_a with ('type'='generic_in_memory')")
-      assert(createResult.next())
-      assert(createResult.getString(1) === "OK")
+      }
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(createResult.next())
+        assert(createResult.getString(1) === "OK")
+      }
       val dropResult = statement.executeQuery("drop catalog cat_a")
-      assert(dropResult.next())
-      assert(dropResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(dropResult.next())
+        assert(dropResult.getString(1) === "OK")
+      }
     })
   }
 
@@ -732,14 +737,20 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
   test("execute statement - create/alter/drop database") {
     withJdbcStatement()({ statement =>
       val createResult = statement.executeQuery("create database db_a")
-      assert(createResult.next())
-      assert(createResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(createResult.next())
+        assert(createResult.getString(1) === "OK")
+      }
       val alterResult = statement.executeQuery("alter database db_a set ('k1' = 'v1')")
-      assert(alterResult.next())
-      assert(alterResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(alterResult.next())
+        assert(alterResult.getString(1) === "OK")
+      }
       val dropResult = statement.executeQuery("drop database db_a")
-      assert(dropResult.next())
-      assert(dropResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(dropResult.next())
+        assert(dropResult.getString(1) === "OK")
+      }
     })
   }
 
@@ -764,28 +775,40 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
       val createResult = {
         statement.executeQuery("create table tbl_a (a string) with ('connector' = 'blackhole')")
       }
-      assert(createResult.next())
-      assert(createResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(createResult.next())
+        assert(createResult.getString(1) === "OK")
+      }
       val alterResult = statement.executeQuery("alter table tbl_a rename to tbl_b")
-      assert(alterResult.next())
-      assert(alterResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(alterResult.next())
+        assert(alterResult.getString(1) === "OK")
+      }
       val dropResult = statement.executeQuery("drop table tbl_b")
-      assert(dropResult.next())
-      assert(dropResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(dropResult.next())
+        assert(dropResult.getString(1) === "OK")
+      }
     })
   }
 
   test("execute statement - create/alter/drop view") {
     withMultipleConnectionJdbcStatement()({ statement =>
       val createResult = statement.executeQuery("create view view_a as select 1")
-      assert(createResult.next())
-      assert(createResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(createResult.next())
+        assert(createResult.getString(1) === "OK")
+      }
       val alterResult = statement.executeQuery("alter view view_a rename to view_b")
-      assert(alterResult.next())
-      assert(alterResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(alterResult.next())
+        assert(alterResult.getString(1) === "OK")
+      }
       val dropResult = statement.executeQuery("drop view view_b")
-      assert(dropResult.next())
-      assert(dropResult.getString(1) === "OK")
+      if (isFlinkVersionAtLeast("1.15")) {
+        assert(dropResult.next())
+        assert(dropResult.getString(1) === "OK")
+      }
     })
   }
 

--- a/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
+++ b/externals/kyuubi-flink-sql-engine/src/test/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperationSuite.scala
@@ -701,11 +701,15 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
     }
   }
 
-  test("execute statement - create/alter/drop catalog") {
-    // TODO: validate table results after FLINK-25558 is resolved
+  test("execute statement - create/drop catalog") {
     withJdbcStatement()({ statement =>
-      statement.executeQuery("create catalog cat_a with ('type'='generic_in_memory')")
-      assert(statement.execute("drop catalog cat_a"))
+      val createResult =
+        statement.executeQuery("create catalog cat_a with ('type'='generic_in_memory')")
+      assert(createResult.next())
+      assert(createResult.getString(1) === "OK")
+      val dropResult = statement.executeQuery("drop catalog cat_a")
+      assert(dropResult.next())
+      assert(dropResult.getString(1) === "OK")
     })
   }
 
@@ -726,11 +730,16 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
   }
 
   test("execute statement - create/alter/drop database") {
-    // TODO: validate table results after FLINK-25558 is resolved
     withJdbcStatement()({ statement =>
-      statement.executeQuery("create database db_a")
-      assert(statement.execute("alter database db_a set ('k1' = 'v1')"))
-      assert(statement.execute("drop database db_a"))
+      val createResult = statement.executeQuery("create database db_a")
+      assert(createResult.next())
+      assert(createResult.getString(1) === "OK")
+      val alterResult = statement.executeQuery("alter database db_a set ('k1' = 'v1')")
+      assert(alterResult.next())
+      assert(alterResult.getString(1) === "OK")
+      val dropResult = statement.executeQuery("drop database db_a")
+      assert(dropResult.next())
+      assert(dropResult.getString(1) === "OK")
     })
   }
 
@@ -751,20 +760,32 @@ class FlinkOperationSuite extends WithFlinkSQLEngine with HiveJDBCTestHelper {
   }
 
   test("execute statement - create/alter/drop table") {
-    // TODO: validate table results after FLINK-25558 is resolved
     withJdbcStatement()({ statement =>
-      statement.executeQuery("create table tbl_a (a string) with ('connector' = 'blackhole')")
-      assert(statement.execute("alter table tbl_a rename to tbl_b"))
-      assert(statement.execute("drop table tbl_b"))
+      val createResult = {
+        statement.executeQuery("create table tbl_a (a string) with ('connector' = 'blackhole')")
+      }
+      assert(createResult.next())
+      assert(createResult.getString(1) === "OK")
+      val alterResult = statement.executeQuery("alter table tbl_a rename to tbl_b")
+      assert(alterResult.next())
+      assert(alterResult.getString(1) === "OK")
+      val dropResult = statement.executeQuery("drop table tbl_b")
+      assert(dropResult.next())
+      assert(dropResult.getString(1) === "OK")
     })
   }
 
   test("execute statement - create/alter/drop view") {
-    // TODO: validate table results after FLINK-25558 is resolved
     withMultipleConnectionJdbcStatement()({ statement =>
-      statement.executeQuery("create view view_a as select 1")
-      assert(statement.execute("alter view view_a rename to view_b"))
-      assert(statement.execute("drop view view_b"))
+      val createResult = statement.executeQuery("create view view_a as select 1")
+      assert(createResult.next())
+      assert(createResult.getString(1) === "OK")
+      val alterResult = statement.executeQuery("alter view view_a rename to view_b")
+      assert(alterResult.next())
+      assert(alterResult.getString(1) === "OK")
+      val dropResult = statement.executeQuery("drop view view_b")
+      assert(dropResult.next())
+      assert(dropResult.getString(1) === "OK")
     })
   }
 


### PR DESCRIPTION

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The statement results were not available with Flink 1.14 because of a bug, but as we upgraded to Flink 1.15, now we could validate the result sets.


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
