### PR TITLE
[KYUUBI #3545] Forbid running the set statement to disable the AUTHZ rules

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/pom.xml
+++ b/extensions/spark/kyuubi-spark-authz/pom.xml
@@ -294,6 +294,26 @@
                 <directory>${project.basedir}/src/test/resources</directory>
             </testResource>
         </testResources>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>add-sources</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>src/main/spark-${spark.binary.version}</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
 </project>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtension.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtension.scala
@@ -39,6 +39,7 @@ class RangerSparkExtension extends (SparkSessionExtensions => Unit) {
   SparkRangerAdminPlugin.init()
 
   override def apply(v1: SparkSessionExtensions): Unit = {
+    v1.injectParser { case (_, parser) => new DisabledExcludeAuthzParser(parser) }
     v1.injectResolutionRule(_ => new RuleReplaceShowObjectCommands())
     v1.injectResolutionRule(_ => new RuleApplyPermanentViewMarker())
     v1.injectResolutionRule(new RuleApplyRowFilterAndDataMasking(_))

--- a/extensions/spark/kyuubi-spark-authz/src/main/spark-3.0/org/apache/kyuubi/plugin/spark/authz/ranger/DisabledExcludeAuthzParser.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/spark-3.0/org/apache/kyuubi/plugin/spark/authz/ranger/DisabledExcludeAuthzParser.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz.ranger
+
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.command.SetCommand
+import org.apache.spark.sql.types.{DataType, StructType}
+
+import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+
+/**
+ * A parser for disabled the set statement that contains authz rules.
+ */
+class DisabledExcludeAuthzParser(delegate: ParserInterface) extends ParserInterface {
+  override def parsePlan(sqlText: String): LogicalPlan = {
+    delegate.parsePlan(sqlText) match {
+      case SetCommand(Some((key, Some(value))))
+          if key.equalsIgnoreCase("spark.sql.optimizer.excludedRules") &&
+            value.contains("org.apache.kyuubi.plugin.spark.authz.ranger") =>
+        throw new AccessControlException("Authz rules cannot be disabled by a set statement.")
+      case p => p
+    }
+  }
+
+  override def parseExpression(sqlText: String): Expression = {
+    delegate.parseExpression(sqlText)
+  }
+
+  override def parseTableIdentifier(sqlText: String): TableIdentifier = {
+    delegate.parseTableIdentifier(sqlText)
+  }
+
+  override def parseFunctionIdentifier(sqlText: String): FunctionIdentifier = {
+    delegate.parseFunctionIdentifier(sqlText)
+  }
+
+  override def parseMultipartIdentifier(sqlText: String): Seq[String] = {
+    delegate.parseMultipartIdentifier(sqlText)
+  }
+
+  override def parseTableSchema(sqlText: String): StructType = {
+    delegate.parseTableSchema(sqlText)
+  }
+
+  override def parseDataType(sqlText: String): DataType = {
+    delegate.parseDataType(sqlText)
+  }
+
+  override def parseRawDataType(sqlText: String): DataType = {
+    delegate.parseRawDataType(sqlText)
+  }
+}

--- a/extensions/spark/kyuubi-spark-authz/src/main/spark-3.1/org/apache/kyuubi/plugin/spark/authz/ranger/DisabledExcludeAuthzParser.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/spark-3.1/org/apache/kyuubi/plugin/spark/authz/ranger/DisabledExcludeAuthzParser.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz.ranger
+
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.command.SetCommand
+import org.apache.spark.sql.types.{DataType, StructType}
+
+import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+
+/**
+ * A parser for disabled the set statement that contains authz rules.
+ */
+class DisabledExcludeAuthzParser(delegate: ParserInterface) extends ParserInterface {
+  override def parsePlan(sqlText: String): LogicalPlan = {
+    delegate.parsePlan(sqlText) match {
+      case SetCommand(Some((key, Some(value))))
+          if key.equalsIgnoreCase("spark.sql.optimizer.excludedRules") &&
+            value.contains("org.apache.kyuubi.plugin.spark.authz.ranger") =>
+        throw new AccessControlException("Authz rules cannot be disabled by a set statement.")
+      case p => p
+    }
+  }
+
+  override def parseExpression(sqlText: String): Expression = {
+    delegate.parseExpression(sqlText)
+  }
+
+  override def parseTableIdentifier(sqlText: String): TableIdentifier = {
+    delegate.parseTableIdentifier(sqlText)
+  }
+
+  override def parseFunctionIdentifier(sqlText: String): FunctionIdentifier = {
+    delegate.parseFunctionIdentifier(sqlText)
+  }
+
+  override def parseMultipartIdentifier(sqlText: String): Seq[String] = {
+    delegate.parseMultipartIdentifier(sqlText)
+  }
+
+  override def parseTableSchema(sqlText: String): StructType = {
+    delegate.parseTableSchema(sqlText)
+  }
+
+  override def parseDataType(sqlText: String): DataType = {
+    delegate.parseDataType(sqlText)
+  }
+}

--- a/extensions/spark/kyuubi-spark-authz/src/main/spark-3.2/org/apache/kyuubi/plugin/spark/authz/ranger/DisabledExcludeAuthzParser.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/spark-3.2/org/apache/kyuubi/plugin/spark/authz/ranger/DisabledExcludeAuthzParser.scala
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz.ranger
+
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.command.SetCommand
+import org.apache.spark.sql.types.{DataType, StructType}
+
+import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+
+/**
+ * A parser for disabled the set statement that contains authz rules.
+ */
+class DisabledExcludeAuthzParser(delegate: ParserInterface) extends ParserInterface {
+  override def parsePlan(sqlText: String): LogicalPlan = {
+    delegate.parsePlan(sqlText) match {
+      case SetCommand(Some((key, Some(value))))
+          if key.equalsIgnoreCase("spark.sql.optimizer.excludedRules") &&
+            value.contains("org.apache.kyuubi.plugin.spark.authz.ranger") =>
+        throw new AccessControlException("Authz rules cannot be disabled by a set statement.")
+      case p => p
+    }
+  }
+
+  override def parseExpression(sqlText: String): Expression = {
+    delegate.parseExpression(sqlText)
+  }
+
+  override def parseTableIdentifier(sqlText: String): TableIdentifier = {
+    delegate.parseTableIdentifier(sqlText)
+  }
+
+  override def parseFunctionIdentifier(sqlText: String): FunctionIdentifier = {
+    delegate.parseFunctionIdentifier(sqlText)
+  }
+
+  override def parseMultipartIdentifier(sqlText: String): Seq[String] = {
+    delegate.parseMultipartIdentifier(sqlText)
+  }
+
+  override def parseTableSchema(sqlText: String): StructType = {
+    delegate.parseTableSchema(sqlText)
+  }
+
+  override def parseDataType(sqlText: String): DataType = {
+    delegate.parseDataType(sqlText)
+  }
+}

--- a/extensions/spark/kyuubi-spark-authz/src/main/spark-3.3/org/apache/kyuubi/plugin/spark/authz/ranger/DisabledExcludeAuthzParser.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/spark-3.3/org/apache/kyuubi/plugin/spark/authz/ranger/DisabledExcludeAuthzParser.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.plugin.spark.authz.ranger
+
+import org.apache.spark.sql.catalyst.{FunctionIdentifier, TableIdentifier}
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.execution.command.SetCommand
+import org.apache.spark.sql.types.{DataType, StructType}
+
+import org.apache.kyuubi.plugin.spark.authz.AccessControlException
+
+/**
+ * A parser for disabled the set statement that contains authz rules.
+ */
+class DisabledExcludeAuthzParser(delegate: ParserInterface) extends ParserInterface {
+  override def parsePlan(sqlText: String): LogicalPlan = {
+    delegate.parsePlan(sqlText) match {
+      case SetCommand(Some((key, Some(value))))
+          if key.equalsIgnoreCase("spark.sql.optimizer.excludedRules") &&
+            value.contains("org.apache.kyuubi.plugin.spark.authz.ranger") =>
+        throw new AccessControlException("Authz rules cannot be disabled by a set statement.")
+      case p => p
+    }
+  }
+
+  override def parseExpression(sqlText: String): Expression = {
+    delegate.parseExpression(sqlText)
+  }
+
+  override def parseTableIdentifier(sqlText: String): TableIdentifier = {
+    delegate.parseTableIdentifier(sqlText)
+  }
+
+  override def parseFunctionIdentifier(sqlText: String): FunctionIdentifier = {
+    delegate.parseFunctionIdentifier(sqlText)
+  }
+
+  override def parseMultipartIdentifier(sqlText: String): Seq[String] = {
+    delegate.parseMultipartIdentifier(sqlText)
+  }
+
+  override def parseTableSchema(sqlText: String): StructType = {
+    delegate.parseTableSchema(sqlText)
+  }
+
+  override def parseDataType(sqlText: String): DataType = {
+    delegate.parseDataType(sqlText)
+  }
+
+  /**
+   * This functions was introduced since spark-3.3, for more details, please see
+   * https://github.com/apache/spark/pull/34543
+   */
+  override def parseQuery(sqlText: String): LogicalPlan = {
+    delegate.parseQuery(sqlText)
+  }
+}

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -794,5 +794,4 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     assert(e.getMessage.contains("Authz rules cannot be disabled by a set statement."))
     intercept[AccessControlException](sql(stmt))
   }
-
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -789,7 +789,8 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
     val stmt = s"CREATE TABLE IF NOT EXISTS default.my_table (key int, value int) USING $format"
     intercept[AccessControlException](sql(stmt))
     val e = intercept[AccessControlException] {
-      spark.sql("set spark.sql.optimizer.excludedRules=org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization")
+      spark.sql("set spark.sql.optimizer.excludedRules = " +
+        "org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization")
     }
     assert(e.getMessage.contains("Authz rules cannot be disabled by a set statement."))
     intercept[AccessControlException](sql(stmt))

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RangerSparkExtensionSuite.scala
@@ -784,4 +784,15 @@ class HiveCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSuite {
       }
     }
   }
+
+  test("Authz rules should not be disabled by a set statement") {
+    val stmt = s"CREATE TABLE IF NOT EXISTS default.my_table (key int, value int) USING $format"
+    intercept[AccessControlException](sql(stmt))
+    val e = intercept[AccessControlException] {
+      spark.sql("set spark.sql.optimizer.excludedRules=org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization")
+    }
+    assert(e.getMessage.contains("Authz rules cannot be disabled by a set statement."))
+    intercept[AccessControlException](sql(stmt))
+  }
+
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The PR injected a new Spark parser to disable the set statement that the key equals `spark.sql.optimizer.excludedRules` and the value contains `org.apache.kyuubi.plugin.spark.authz.ranger.*`.

```
set spark.sql.optimizer.excludedRules=org.apache.kyuubi.plugin.spark.authz.ranger.RuleAuthorization
```

```
Authz rules cannot be disabled by a set statement.
org.apache.kyuubi.plugin.spark.authz.AccessControlException: Authz rules cannot be disabled by a set statement.
	at org.apache.kyuubi.plugin.spark.authz.ranger.DisabledExcludeAuthzParser.parsePlan(DisabledExcludeAuthzParser.scala:38)
```


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
