### PR TITLE
[KYUUBI #3527][SPARK][FOLLOWUP] spark.kubernetes.executorEnv should be spark.executorEnv

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -98,7 +98,7 @@ class SparkProcessBuilder(
           buffer += CONF
           buffer += s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$userName"
           buffer += CONF
-          buffer += s"spark.kubernetes.executorEnv.SPARK_USER_NAME=$userName"
+          buffer += s"spark.executorEnv.SPARK_USER_NAME=$userName"
         }
       })
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilderSuite.scala
@@ -277,7 +277,7 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
     val b1 = new SparkProcessBuilder(proxyName, conf1)
     val c1 = b1.toString.split(' ')
     assert(c1.contains(s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$proxyName"))
-    assert(c1.contains(s"spark.kubernetes.executorEnv.SPARK_USER_NAME=$proxyName"))
+    assert(c1.contains(s"spark.executorEnv.SPARK_USER_NAME=$proxyName"))
 
     tryWithSecurityEnabled {
       val conf2 = conf.set("spark.master", "k8s://test:12345")
@@ -287,7 +287,7 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
       val b2 = new SparkProcessBuilder(name, conf2)
       val c2 = b2.toString.split(' ')
       assert(c2.contains(s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$name"))
-      assert(c2.contains(s"spark.kubernetes.executorEnv.SPARK_USER_NAME=$name"))
+      assert(c2.contains(s"spark.executorEnv.SPARK_USER_NAME=$name"))
       assert(!c2.contains(s"--proxy-user $name"))
     }
 
@@ -296,7 +296,7 @@ class SparkProcessBuilderSuite extends KerberizedTestHelper with MockitoSugar {
     val b3 = new SparkProcessBuilder(proxyName, conf3)
     val c3 = b3.toString.split(' ')
     assert(!c3.contains(s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$proxyName"))
-    assert(!c3.contains(s"spark.kubernetes.executorEnv.SPARK_USER_NAME=$proxyName"))
+    assert(!c3.contains(s"spark.executorEnv.SPARK_USER_NAME=$proxyName"))
   }
 }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix bug in #3527
Modify `spark.kubernetes.executorEnv` to `spark.executorEnv`

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
- [x] Unit Test
