### PR TITLE
[KYUUBI #3598] Beeline doesn't work with -e option when started in background

### DIFF
--- a/bin/beeline
+++ b/bin/beeline
@@ -32,7 +32,7 @@ RUNNER="${JAVA_HOME}/bin/java"
 
 # Append jline option to enable the Beeline process to run in background.
 if [[ ( ! $(ps -o stat= -p $$) =~ "+" ) && ! ( -p /dev/stdin ) ]]; then
-    export KYUUBI_BEELINE_OPTS="$KYUUBI_BEELINE_OPTS -Djline.terminal=jline.UnsupportedTerminal"
+  export KYUUBI_BEELINE_OPTS="$KYUUBI_BEELINE_OPTS -Djline.terminal=jline.UnsupportedTerminal"
 fi
 
 ## Find the Kyuubi beeline Jar

--- a/bin/beeline
+++ b/bin/beeline
@@ -30,6 +30,11 @@ fi
 
 RUNNER="${JAVA_HOME}/bin/java"
 
+# Append jline option to enable the Beeline process to run in background.
+if [[ ( ! $(ps -o stat= -p $$) =~ "+" ) && ! ( -p /dev/stdin ) ]]; then
+    export KYUUBI_BEELINE_OPTS="$KYUUBI_BEELINE_OPTS -Djline.terminal=jline.UnsupportedTerminal"
+fi
+
 ## Find the Kyuubi beeline Jar
 if [[ -z "$KYUUBI_BEELINE_JARS" ]]; then
   KYUUBI_BEELINE_JARS="$KYUUBI_HOME/beeline-jars"


### PR DESCRIPTION
### _Why are the changes needed?_
Fix #3598

Hive Beeline has the same issue: https://issues.apache.org/jira/browse/HIVE-6758 and was fixed by append jline option "-Djline.termial=jline.UnsupportedTerminal".

We do the same in this PR.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="1043" alt="image" src="https://user-images.githubusercontent.com/88070094/194760564-04258a46-646f-4f76-ab19-b3e305b0ef69.png">


- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
