### PR TITLE
[SPARK][K8S] Respect default static port for web UI on Spark K8s cluster mode

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -168,9 +168,11 @@ object SparkSQLEngine extends Logging {
 
     if (Utils.isOnK8s) {
       kyuubiConf.setIfMissing(FRONTEND_CONNECTION_URL_USE_HOSTNAME, false)
-    } else {
-      _sparkConf.setIfMissing("spark.ui.port", "0")
+      sys.env.get("SPARK_APPLICATION_ID").foreach(_ =>
+        _sparkConf.setIfMissing("spark.ui.port", "4040"))
     }
+    // set web ui port 0 when no deploy k8s cluster mode
+    _sparkConf.setIfMissing("spark.ui.port", "0")
 
     // Pass kyuubi config from spark with `spark.kyuubi`
     val sparkToKyuubiPrefix = "spark.kyuubi."

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -147,7 +147,6 @@ object SparkSQLEngine extends Logging {
     _sparkConf.setIfMissing("spark.sql.execution.topKSortFallbackThreshold", "10000")
     _sparkConf.setIfMissing("spark.sql.legacy.castComplexTypesToString.enabled", "true")
     _sparkConf.setIfMissing("spark.master", "local")
-    _sparkConf.setIfMissing("spark.ui.port", "0")
     _sparkConf.set(
       "spark.redaction.regex",
       _sparkConf.get("spark.redaction.regex", "(?i)secret|password|token|access[.]key")
@@ -169,6 +168,8 @@ object SparkSQLEngine extends Logging {
 
     if (Utils.isOnK8s) {
       kyuubiConf.setIfMissing(FRONTEND_CONNECTION_URL_USE_HOSTNAME, false)
+    } else {
+      _sparkConf.setIfMissing("spark.ui.port", "0")
     }
 
     // Pass kyuubi config from spark with `spark.kyuubi`

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -168,11 +168,12 @@ object SparkSQLEngine extends Logging {
 
     if (Utils.isOnK8s) {
       kyuubiConf.setIfMissing(FRONTEND_CONNECTION_URL_USE_HOSTNAME, false)
-      sys.env.get("SPARK_APPLICATION_ID").foreach(_ =>
-        _sparkConf.setIfMissing("spark.ui.port", "4040"))
     }
+
     // set web ui port 0 when no deploy k8s cluster mode
-    _sparkConf.setIfMissing("spark.ui.port", "0")
+    if (!isOnKubernetesUsingClusterMode) {
+      _sparkConf.setIfMissing("spark.ui.port", "0")
+    }
 
     // Pass kyuubi config from spark with `spark.kyuubi`
     val sparkToKyuubiPrefix = "spark.kyuubi."
@@ -312,4 +313,7 @@ object SparkSQLEngine extends Logging {
       },
       "CreateSparkTimeoutChecker").start()
   }
+
+  private def isOnKubernetesUsingClusterMode: Boolean =
+    Utils.isOnK8s && sys.env.contains("SPARK_APPLICATION_ID")
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -170,8 +170,8 @@ object SparkSQLEngine extends Logging {
       kyuubiConf.setIfMissing(FRONTEND_CONNECTION_URL_USE_HOSTNAME, false)
     }
 
-    // set web ui port 0 when no deploy k8s cluster mode
-    if (!isOnKubernetesUsingClusterMode) {
+    // Set web ui port 0 to avoid port conflicts during non-k8s cluster mode
+    if (!isOnK8sClusterMode) {
       _sparkConf.setIfMissing("spark.ui.port", "0")
     }
 
@@ -314,6 +314,8 @@ object SparkSQLEngine extends Logging {
       "CreateSparkTimeoutChecker").start()
   }
 
-  private def isOnKubernetesUsingClusterMode: Boolean =
+  private def isOnK8sClusterMode: Boolean = {
+    // only spark driver pod will build with `SPARK_APPLICATION_ID` env.
     Utils.isOnK8s && sys.env.contains("SPARK_APPLICATION_ID")
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Now kyuubi will help set web ui port to 0 while scalaing up spark sql engine, which is good for the general situation, help avoid port conflicts.

But on k8s case, kyuubi should respect the user's default settings, here means web ui should be `4040`.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
