### PR TITLE
Enhance JAVA_HOME detection to support RPM

### DIFF
--- a/build/dist
+++ b/build/dist
@@ -103,6 +103,15 @@ while (( "$#" )); do
 done
 # Setup java
 if [[ -z "$JAVA_HOME" ]]; then
+  # Fallback on JAVA_HOME from rpm, if found
+  if [ $(command -v rpm) ]; then
+    RPM_JAVA_HOME="$(rpm -E %java_home 2>/dev/null)"
+    if [ "$RPM_JAVA_HOME" != "%java_home" ]; then
+      JAVA_HOME="$RPM_JAVA_HOME"
+      echo "No JAVA_HOME set, proceeding with '$JAVA_HOME' learned from rpm"
+    fi
+  fi
+
   if [[ `command -v java` ]]; then
     # If java is in /usr/bin/java, we want /usr
     JAVA_HOME="$(dirname $(dirname $(which java)))"

--- a/build/dist
+++ b/build/dist
@@ -101,6 +101,7 @@ while (( "$#" )); do
   esac
   shift
 done
+
 # Setup java
 if [[ -z "$JAVA_HOME" ]]; then
   # Fallback on JAVA_HOME from rpm, if found
@@ -112,9 +113,11 @@ if [[ -z "$JAVA_HOME" ]]; then
     fi
   fi
 
-  if [[ `command -v java` ]]; then
-    # If java is in /usr/bin/java, we want /usr
-    JAVA_HOME="$(dirname $(dirname $(which java)))"
+  if [ -z "$JAVA_HOME" ]; then
+    if [[ `command -v java` ]]; then
+      # If java is in /usr/bin/java, we want /usr
+      JAVA_HOME="$(dirname $(dirname $(which java)))"
+    fi
   fi
 fi
 
@@ -123,6 +126,7 @@ if [[ -z "$JAVA_HOME" ]]; then
   exit -1
 fi
 
+export JAVA_HOME="$JAVA_HOME"
 echo "JAVA_HOME is set to $JAVA_HOME"
 
 if [[ $(command -v git) ]]; then
@@ -141,7 +145,6 @@ if [ ! "$(command -v "$MVN")" ] ; then
 fi
 
 echo "MVN is set to $MVN"
-
 
 VERSION=$("$MVN" help:evaluate -Dexpression=project.version $@ 2>/dev/null\
     | grep -v "INFO"\


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

By default, on CentOS 7 w/ openJDK 8 installed via YUM/RPM, the `/usr/bin/java` links to `/usr/lib/jvm/java-1.8.0-openjdk/jre/bin/java`, the current detection logic will think the `JAVA_HOME` is `/usr/lib/jvm/java-1.8.0-openjdk/jre`, and then cause the issue.
 
```
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.6.1:compile (scala-compile-first) on project kyuubi-common_2.12: wrap: java.io.IOException: Cannot run program "/usr/lib/jvm/java-1.8.0-openjdk-1.8.0.322.b06-1.el7_9.x86_64/jre/bin/javac" (in directory "/home/pancheng/apache-kyuubi"): error=2, No such file or directory -> [Help 1]
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

w/ this patch, the `build/dist` works expected on CentOS w/ openJDK 8 installed via `yum`, the debug info shows it detected the right `JAVA_HOME`
```
+ [[ -z '' ]]
++ command -v rpm
+ '[' /usr/bin/rpm ']'
++ rpm -E %java_home
+ RPM_JAVA_HOME=/usr/lib/jvm/java
+ '[' /usr/lib/jvm/java '!=' %java_home ']'
+ JAVA_HOME=/usr/lib/jvm/java
+ echo 'No JAVA_HOME set, proceeding with '\''/usr/lib/jvm/java'\'' learned from rpm'
No JAVA_HOME set, proceeding with '/usr/lib/jvm/java' learned from rpm
+ '[' -z /usr/lib/jvm/java ']'
+ [[ -z /usr/lib/jvm/java ]]
+ echo 'JAVA_HOME is set to /usr/lib/jvm/java'
JAVA_HOME is set to /usr/lib/jvm/java
```

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
