### PR TITLE
[KYUUBI #3624][REST] Fix description typo of session REST open api

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
@@ -353,7 +353,7 @@ private[v1] class SessionsResource extends ApiRequestContext with Logging {
     content = Array(new Content(
       mediaType = MediaType.APPLICATION_JSON,
       schema = new Schema(implementation = classOf[OperationHandle]))),
-    description = "Create an operation with GET_FUNCTIONS type")
+    description = "Create an operation with GET_PRIMARY_KEY type")
   @POST
   @Path("{sessionHandle}/operations/primaryKeys")
   def getPrimaryKeys(
@@ -378,7 +378,7 @@ private[v1] class SessionsResource extends ApiRequestContext with Logging {
     content = Array(new Content(
       mediaType = MediaType.APPLICATION_JSON,
       schema = new Schema(implementation = classOf[OperationHandle]))),
-    description = "Create an operation with GET_FUNCTIONS type")
+    description = "Create an operation with GET_CROSS_REFERENCE type")
   @POST
   @Path("{sessionHandle}/operations/crossReference")
   def getCrossReference(


### PR DESCRIPTION
### _Why are the changes needed?_
Fix `getPrimaryKeys` and `getCrossReference` descriptions typo of session REST open API


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
