### PR TITLE
[KYUUBI #3543][FOLLOWUP][1.6] Handle zookeeper watch events

### DIFF
--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
@@ -33,7 +33,7 @@ import org.apache.kyuubi.service.Service
 import org.apache.kyuubi.service.ServiceState
 
 trait DiscoveryClientTests extends KyuubiFunSuite {
-  protected val conf: KyuubiConf
+  protected var conf: KyuubiConf
 
   protected def getConnectString: String
 

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClientSuite.scala
@@ -38,7 +38,7 @@ class EtcdDiscoveryClientSuite extends DiscoveryClientTests {
 
   override def getConnectString: String = _connectString
 
-  val conf: KyuubiConf = {
+  var conf: KyuubiConf = {
     KyuubiConf()
       .set(HA_CLIENT_CLASS, classOf[EtcdDiscoveryClient].getName)
   }

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClientSuite.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClientSuite.scala
@@ -42,24 +42,23 @@ import org.apache.kyuubi.zookeeper.{EmbeddedZookeeper, ZookeeperConf}
 
 class ZookeeperDiscoveryClientSuite extends DiscoveryClientTests with KerberizedTestHelper {
 
-  val zkServer = new EmbeddedZookeeper()
-  override val conf: KyuubiConf = KyuubiConf()
+  private var zkServer: EmbeddedZookeeper = _
+  override var conf: KyuubiConf = KyuubiConf()
 
   override def getConnectString: String = zkServer.getConnectString
 
-  override def beforeAll(): Unit = {
+  override def beforeEach(): Unit = {
     conf.set(ZookeeperConf.ZK_CLIENT_PORT, 0)
+    zkServer = new EmbeddedZookeeper()
     zkServer.initialize(conf)
     zkServer.start()
-    super.beforeAll()
+    conf = new KyuubiConf().set(HA_ADDRESSES, getConnectString)
+    super.beforeEach()
   }
 
-  override def afterAll(): Unit = {
-    conf.unset(KyuubiConf.SERVER_KEYTAB)
-    conf.unset(KyuubiConf.SERVER_PRINCIPAL)
-    conf.unset(HA_ADDRESSES)
+  override def afterEach(): Unit = {
+    super.afterEach()
     zkServer.stop()
-    super.afterAll()
   }
 
   test("acl for zookeeper") {


### PR DESCRIPTION
### _Why are the changes needed?_
`ZookeeperDiscoveryClientSuite` used `beforeAll` and `afterAll` in 1.6, which caused some values to be set in conf and not cleaned up in test, resulting in UT failure.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
