### PR TITLE
 [KYUUBI #3424][FOLLOWUP] move ShowCreateTable/ShowTableProperties to v2Command and remove duplicate DropNamespace/MergeIntoTable

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -88,7 +88,7 @@ object OperationType extends Enumeration {
       case "LoadDataCommand" => LOAD
       case "SetCommand" => SHOWCONF
       case "RefreshFunctionCommand" | "RefreshFunction" => RELOADFUNCTION
-      case "RefreshTableCommand" => QUERY
+      case "RefreshTableCommand" | "RefreshTable" => QUERY
       case "SetCatalogCommand" |
           "SetCatalogAndNamespace" |
           "SetNamespaceCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -100,8 +100,7 @@ object OperationType extends Enumeration {
           "ShowTables" => SHOWTABLES
       case "ShowColumnsCommand" => SHOWCOLUMNS
       case "ShowCreateTableAsSerdeCommand" |
-          "ShowCreateTableCommand" |
-          "ShowCreateTable" => SHOW_CREATETABLE
+          "ShowCreateTableCommand" => SHOW_CREATETABLE
       case "ShowFunctionsCommand" => SHOWFUNCTIONS
       case "ShowPartitionsCommand" => SHOWPARTITIONS
       case "ShowTablePropertiesCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -103,8 +103,7 @@ object OperationType extends Enumeration {
           "ShowCreateTableCommand" => SHOW_CREATETABLE
       case "ShowFunctionsCommand" => SHOWFUNCTIONS
       case "ShowPartitionsCommand" => SHOWPARTITIONS
-      case "ShowTablePropertiesCommand" |
-          "ShowTableProperties" => SHOW_TBLPROPERTIES
+      case "ShowTablePropertiesCommand" => SHOW_TBLPROPERTIES
       case "TruncateTableCommand" => TRUNCATETABLE
       case "UncacheTableCommand" => DROPVIEW
       case _ => QUERY

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/OperationType.scala
@@ -88,7 +88,7 @@ object OperationType extends Enumeration {
       case "LoadDataCommand" => LOAD
       case "SetCommand" => SHOWCONF
       case "RefreshFunctionCommand" | "RefreshFunction" => RELOADFUNCTION
-      case "RefreshTableCommand" | "RefreshTable" => QUERY
+      case "RefreshTableCommand" => QUERY
       case "SetCatalogCommand" |
           "SetCatalogAndNamespace" |
           "SetNamespaceCommand" |

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -304,8 +304,7 @@ object PrivilegesBuilder {
         inputObjs += tablePrivileges(table, cols)
 
       case "AnalyzeTableCommand" |
-          "RefreshTableCommand" |
-          "RefreshTable" =>
+          "RefreshTableCommand" =>
         inputObjs += tablePrivileges(getTableIdent)
 
       case "AnalyzeTablesCommand" =>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -481,18 +481,6 @@ object PrivilegesBuilder {
         val table = getPlanField[TableIdentifier]("table")
         inputObjs += tablePrivileges(table)
 
-      case "ShowTableProperties" =>
-        val resolvedTable = getPlanField[Any]("table")
-        val identifier = getFieldVal[AnyRef](resolvedTable, "identifier")
-        val namespace = invoke(identifier, "namespace").asInstanceOf[Array[String]]
-        val table = invoke(identifier, "name").asInstanceOf[String]
-        inputObjs += PrivilegeObject(
-          TABLE_OR_VIEW,
-          PrivilegeObjectActionType.OTHER,
-          quote(namespace),
-          table,
-          Nil)
-
       case "ShowFunctionsCommand" =>
 
       case "ShowPartitionsCommand" =>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -304,7 +304,8 @@ object PrivilegesBuilder {
         inputObjs += tablePrivileges(table, cols)
 
       case "AnalyzeTableCommand" |
-          "RefreshTableCommand" =>
+          "RefreshTableCommand" |
+          "RefreshTable" =>
         inputObjs += tablePrivileges(getTableIdent)
 
       case "AnalyzeTablesCommand" =>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -493,18 +493,6 @@ object PrivilegesBuilder {
           table,
           Nil)
 
-      case "ShowCreateTable" =>
-        val resolvedTable = getPlanField[Any]("child")
-        val identifier = getFieldVal[AnyRef](resolvedTable, "identifier")
-        val namespace = invoke(identifier, "namespace").asInstanceOf[Array[String]]
-        val table = invoke(identifier, "name").asInstanceOf[String]
-        inputObjs += PrivilegeObject(
-          TABLE_OR_VIEW,
-          PrivilegeObjectActionType.OTHER,
-          quote(namespace),
-          table,
-          Nil)
-
       case "ShowFunctionsCommand" =>
 
       case "ShowPartitionsCommand" =>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -391,11 +391,6 @@ object PrivilegesBuilder {
         val func = getPlanField[FunctionIdentifier]("functionName")
         inputObjs += functionPrivileges(func.database.orNull, func.funcName)
 
-      case "DropNamespace" =>
-        val child = getPlanField[Any]("namespace")
-        val database = getFieldVal[Seq[String]](child, "namespace")
-        outputObjs += databasePrivileges(quote(database))
-
       case "DropTableCommand" =>
         if (!isTempView(getPlanField[TableIdentifier]("tableName"), spark)) {
           outputObjs += tablePrivileges(getTableName)
@@ -435,8 +430,6 @@ object PrivilegesBuilder {
         val cols = getPlanField[Option[TablePartitionSpec]]("partition")
           .map(_.keySet).getOrElse(Nil)
         outputObjs += tablePrivileges(table, cols.toSeq, actionType = actionType)
-
-      case "MergeIntoTable" =>
 
       case "RepairTableCommand" =>
         val enableAddPartitions = getPlanField[Boolean]("enableAddPartitions")

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -28,7 +28,7 @@ import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType.PrivilegeO
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType.TABLE_OR_VIEW
 import org.apache.kyuubi.plugin.spark.authz.PrivilegesBuilder._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
-import org.apache.kyuubi.plugin.spark.authz.v2Commands.CommandType.{CommandType, HasChildAsIdentifier, HasQueryAsLogicalPlan, HasTableAsIdentifier, HasTableAsIdentifierOption, HasTableNameAsIdentifier}
+import org.apache.kyuubi.plugin.spark.authz.v2Commands.CommandType._
 
 /**
  * Building privilege objects
@@ -314,7 +314,7 @@ object v2Commands extends Enumeration {
     commandTypes = Seq(HasChildAsIdentifier))
 
   val ShowTableProperties: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
-    operationType = SHOW_CREATETABLE,
+    operationType = SHOW_TBLPROPERTIES,
     commandTypes = Seq(HasTableAsIdentifier))
 
   val TruncateTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -74,11 +74,6 @@ object v2Commands extends Enumeration {
   val defaultBuildInput: (LogicalPlan, ArrayBuffer[PrivilegeObject], Seq[CommandType]) => Unit =
     (plan, inputObjs, commandTypes) => {
       commandTypes.foreach {
-        case HasChildAsIdentifier =>
-          val table = getFieldVal[LogicalPlan](plan, "child")
-          val tableIdent = getFieldVal[Identifier](table, "identifier")
-          inputObjs += v2TablePrivileges(tableIdent)
-
         case HasQueryAsLogicalPlan =>
           val query = getFieldVal[LogicalPlan](plan, "query")
           buildQuery(query, inputObjs)
@@ -308,10 +303,6 @@ object v2Commands extends Enumeration {
           actionType = PrivilegeObjectActionType.UPDATE)
       }
     })
-
-  val RefreshTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
-    operationType = QUERY,
-    commandTypes = Seq(HasChildAsIdentifier))
 
   val RepairTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
     operationType = ALTERTABLE_ADDPARTS,

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -28,7 +28,7 @@ import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectActionType.PrivilegeO
 import org.apache.kyuubi.plugin.spark.authz.PrivilegeObjectType.TABLE_OR_VIEW
 import org.apache.kyuubi.plugin.spark.authz.PrivilegesBuilder._
 import org.apache.kyuubi.plugin.spark.authz.util.AuthZUtils._
-import org.apache.kyuubi.plugin.spark.authz.v2Commands.CommandType._
+import org.apache.kyuubi.plugin.spark.authz.v2Commands.CommandType.{CommandType, HasChildAsIdentifier, HasQueryAsLogicalPlan, HasTableAsIdentifier, HasTableAsIdentifierOption, HasTableNameAsIdentifier}
 
 /**
  * Building privilege objects

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -74,6 +74,11 @@ object v2Commands extends Enumeration {
   val defaultBuildInput: (LogicalPlan, ArrayBuffer[PrivilegeObject], Seq[CommandType]) => Unit =
     (plan, inputObjs, commandTypes) => {
       commandTypes.foreach {
+        case HasChildAsIdentifier =>
+          val table = getFieldVal[LogicalPlan](plan, "child")
+          val tableIdent = getFieldVal[Identifier](table, "identifier")
+          inputObjs += v2TablePrivileges(tableIdent)
+
         case HasQueryAsLogicalPlan =>
           val query = getFieldVal[LogicalPlan](plan, "query")
           buildQuery(query, inputObjs)
@@ -303,6 +308,10 @@ object v2Commands extends Enumeration {
           actionType = PrivilegeObjectActionType.UPDATE)
       }
     })
+
+  val RefreshTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
+    operationType = QUERY,
+    commandTypes = Seq(HasChildAsIdentifier))
 
   val RepairTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
     operationType = ALTERTABLE_ADDPARTS,

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -289,6 +289,7 @@ object v2Commands extends Enumeration {
         }
       outputObjs += v2TablePrivileges(tableIdent)
     })
+
   val MergeIntoTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
     buildInput = (plan, inputObjs, _) => {
       val table = getFieldVal[DataSourceV2Relation](plan, "sourceTable")
@@ -306,6 +307,11 @@ object v2Commands extends Enumeration {
   val RepairTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
     operationType = ALTERTABLE_ADDPARTS,
     leastVer = Some("3.2"),
+    commandTypes = Seq(HasChildAsIdentifier))
+
+  val ShowCreateTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
+    operationType = SHOW_CREATETABLE,
+    leastVer = Some("3.1"),
     commandTypes = Seq(HasChildAsIdentifier))
 
   val TruncateTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/v2Commands.scala
@@ -311,8 +311,11 @@ object v2Commands extends Enumeration {
 
   val ShowCreateTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
     operationType = SHOW_CREATETABLE,
-    leastVer = Some("3.1"),
     commandTypes = Seq(HasChildAsIdentifier))
+
+  val ShowTableProperties: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
+    operationType = SHOW_CREATETABLE,
+    commandTypes = Seq(HasTableAsIdentifier))
 
   val TruncateTable: CmdPrivilegeBuilder = CmdPrivilegeBuilder(
     leastVer = Some("3.2"),

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -259,7 +259,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   test("[KYUUBI #3424] TRUNCATE TABLE") {
     assume(isSparkV32OrGreater)
 
-    // CreateView with select
     val e1 = intercept[AccessControlException](
       doAs(
         "someone",
@@ -271,7 +270,6 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
   test("[KYUUBI #3424] MSCK REPAIR TABLE") {
     assume(isSparkV32OrGreater)
 
-    // CreateView with select
     val e1 = intercept[AccessControlException](
       doAs(
         "someone",

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -356,4 +356,18 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
     assert(e1.getMessage.contains(s"does not have [select] privilege" +
       s" on [$namespace1/$table1]"))
   }
+
+  test("[KYUUBI #3424] SHOW TBLPROPERTIES") {
+    assume(isSparkV32OrGreater)
+    doAs(
+      "admin",
+      sql(s"SHOW TBLPROPERTIES $catalogV2.$namespace1.$table1"))
+
+    val e1 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"SHOW TBLPROPERTIES $catalogV2.$namespace1.$table1")))
+    assert(e1.getMessage.contains(s"does not have [select] privilege" +
+      s" on [$namespace1/$table1]"))
+  }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/V2JdbcTableCatalogRangerSparkExtensionSuite.scala
@@ -341,6 +341,19 @@ class V2JdbcTableCatalogRangerSparkExtensionSuite extends RangerSparkExtensionSu
         sql(s"COMMENT ON TABLE $catalogV2.$namespace1.$table1 IS 'xYz' ").explain()))
     assert(e3.getMessage.contains(s"does not have [alter] privilege" +
       s" on [$namespace1/$table1]"))
+  }
 
+  test("[KYUUBI #3424] SHOW CREATE TABLE") {
+    assume(isSparkV32OrGreater)
+    doAs(
+      "admin",
+      sql(s"SHOW CREATE TABLE $catalogV2.$namespace1.$table1"))
+
+    val e1 = intercept[AccessControlException](
+      doAs(
+        "someone",
+        sql(s"SHOW CREATE TABLE $catalogV2.$namespace1.$table1")))
+    assert(e1.getMessage.contains(s"does not have [select] privilege" +
+      s" on [$namespace1/$table1]"))
   }
 }


### PR DESCRIPTION
…ich shadowed and implemented in v2Commands.scala

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

- move `ShowCreateTable`, `ShowTableProperties` to v2Commands, and reusing `HasChildAsIdentifier` commandType in v2Commands
- remove duplicate and shadowed v2Commands `DropNamespace` and `MergeIntoTable` from `PrivilegesBuilder`, since they are already implemented in #3424 .


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
