### PR TITLE
[KYUUBI #2887] Add a sequential balance policy for spark engine pool

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1385,6 +1385,13 @@ object KyuubiConf {
     .intConf
     .createWithDefault(-1)
 
+  val ENGINE_POOL_BALANCE_POLICY: ConfigEntry[String] = buildConf("engine.pool.balance.policy")
+    .doc("The balance policy of queries in engine pool.")
+    .version("1.7.0")
+    .stringConf
+    .checkValue(Set("RANDOM", "SEQUENTIAL").apply(_), "Unsupported balance policy")
+    .createWithDefault("RANDOM")
+
   val ENGINE_INITIALIZE_SQL: ConfigEntry[Seq[String]] =
     buildConf("kyuubi.engine.initialize.sql")
       .doc("SemiColon-separated list of SQL statements to be initialized in the newly created " +

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperClientProvider.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperClientProvider.scala
@@ -144,4 +144,21 @@ object ZookeeperClientProvider extends Logging {
     }
   }
 
+  /**
+   * Creates a zookeeper client before calling `f` and close it after calling `f`.
+   */
+  def withZkClient[T](conf: KyuubiConf)(f: CuratorFramework => T): T = {
+    val zkClient = buildZookeeperClient(conf)
+    try {
+      zkClient.start()
+      f(zkClient)
+    } finally {
+      try {
+        zkClient.close()
+      } catch {
+        case e: IOException => error("Failed to release the zkClient", e)
+      }
+    }
+  }
+
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -23,6 +23,8 @@ import scala.util.Random
 
 import com.codahale.metrics.MetricRegistry
 import com.google.common.annotations.VisibleForTesting
+import org.apache.curator.framework.recipes.atomic.DistributedAtomicInteger
+import org.apache.curator.retry.RetryForever
 import org.apache.hadoop.security.UserGroupInformation
 
 import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiSQLException, Logging, Utils}
@@ -38,6 +40,7 @@ import org.apache.kyuubi.engine.spark.SparkProcessBuilder
 import org.apache.kyuubi.engine.trino.TrinoProcessBuilder
 import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ENGINE_REF_ID, HA_NAMESPACE}
 import org.apache.kyuubi.ha.client.{DiscoveryClient, DiscoveryPaths}
+import org.apache.kyuubi.ha.client.zookeeper.ZookeeperClientProvider.withZkClient
 import org.apache.kyuubi.metrics.MetricsConstants.{ENGINE_FAIL, ENGINE_TIMEOUT, ENGINE_TOTAL}
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.operation.log.OperationLog
@@ -72,26 +75,13 @@ private[kyuubi] class EngineRef(
 
   private val clientPoolName: String = conf.get(ENGINE_POOL_NAME)
 
+  private val enginePoolBalancePolicy: String = conf.get(ENGINE_POOL_BALANCE_POLICY)
+
   // In case the multi kyuubi instances have the small gap of timeout, here we add
   // a small amount of time for timeout
   private val LOCK_TIMEOUT_SPAN_FACTOR = if (Utils.isTesting) 0.5 else 0.1
 
   private var builder: ProcBuilder = _
-
-  @VisibleForTesting
-  private[kyuubi] val subdomain: String = conf.get(ENGINE_SHARE_LEVEL_SUBDOMAIN) match {
-    case Some(_subdomain) => _subdomain
-    case None if clientPoolSize > 0 =>
-      val poolSize = math.min(clientPoolSize, poolThreshold)
-      if (poolSize < clientPoolSize) {
-        warn(s"Request engine pool size($clientPoolSize) exceeds, fallback to " +
-          s"system threshold $poolThreshold")
-      }
-      // TODO: Currently, we use random policy, and later we can add a sequential policy,
-      //  such as AtomicInteger % poolSize.
-      s"$clientPoolName-${Random.nextInt(poolSize)}"
-    case _ => "default" // [KYUUBI #1293]
-  }
 
   // Launcher of the engine
   private[kyuubi] val appUser: String = shareLevel match {
@@ -107,6 +97,35 @@ private[kyuubi] class EngineRef(
           user
       }
     case _ => user
+  }
+
+  @VisibleForTesting
+  private[kyuubi] val subdomain: String = conf.get(ENGINE_SHARE_LEVEL_SUBDOMAIN) match {
+    case Some(_subdomain) => _subdomain
+    case None if clientPoolSize > 0 =>
+      val poolSize = math.min(clientPoolSize, poolThreshold)
+      if (poolSize < clientPoolSize) {
+        warn(s"Request engine pool size($clientPoolSize) exceeds, fallback to " +
+          s"system threshold $poolThreshold")
+      }
+      val seqNum =
+        if ("SEQUENTIAL".equals(enginePoolBalancePolicy)) {
+          info(s"The engine pool balance policy is SEQUENTIAL.")
+          val seqNumPath =
+            DiscoveryPaths.makePath(
+              s"${serverSpace}_$shareLevel",
+              "seq_num",
+              Array(appUser, clientPoolName))
+          withZkClient(conf) { zkClient =>
+            val dai = new DistributedAtomicInteger(zkClient, seqNumPath, new RetryForever(1000))
+            dai.increment().preValue().intValue()
+          }
+        } else {
+          info(s"The engine pool balance policy is RANDOM.")
+          Random.nextInt(poolSize)
+        }
+      s"$clientPoolName-${seqNum % poolSize}"
+    case _ => "default" // [KYUUBI #1293]
   }
 
   /**

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
@@ -209,6 +209,17 @@ trait EngineRefTests extends KyuubiFunSuite {
     conf.set(ENGINE_POOL_SIZE, 3)
     val engine6 = new EngineRef(conf, user, id, null)
     assert(engine6.subdomain.startsWith(s"$enginePoolName-"))
+
+    // unset subdomain and set engine pool name and 1 <= engine pool size < threshold
+    // and set ENGINE_POOL_BALANCE_POLICY
+    conf.unset(ENGINE_SHARE_LEVEL_SUBDOMAIN)
+    val enginePoolName7 = "test-pool"
+    conf.set(ENGINE_POOL_NAME, enginePoolName7)
+    conf.set(ENGINE_POOL_BALANCE_POLICY, "SEQUENTIAL")
+    conf.set(ENGINE_POOL_SIZE, 3)
+    val engine7 = new EngineRef(conf, user, id, null)
+    assert(engine7.subdomain.startsWith(s"$enginePoolName7-"))
+
   }
 
   test("start and get engine address with lock") {


### PR DESCRIPTION

### _Why are the changes needed?_

As described in issues#2887, random policy may cause task-hot-issues or production accident, so a SEQUENTIAL policy is added to avoid this problem

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request


 locally before make a pull request 