### PR TITLE
[KYUUBI #2887] Add a POLLING balance policy for spark engine pool

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -243,7 +243,7 @@ kyuubi.engine.jdbc.memory|1g|The heap memory for the jdbc query engine|string|1.
 kyuubi.engine.jdbc.type|&lt;undefined&gt;|The short name of jdbc type|string|1.6.0
 kyuubi.engine.operation.convert.catalog.database.enabled|true|When set to true, The engine converts the JDBC methods of set/get Catalog and set/get Schema to the implementation of different engines|boolean|1.6.0
 kyuubi.engine.operation.log.dir.root|engine_operation_logs|Root directory for query operation log at engine-side.|string|1.4.0
-kyuubi.engine.pool.balance.policy|RANDOM|The balance policy of queries in engine pool.<ul> <li>RANDOM - Randomly use the engine in the pool (default)</li> <li>POLLING - Polling use the engine in the pool.</li> </ul>|string|1.7.0
+kyuubi.engine.pool.balance.policy|RANDOM|The balance policy of queries in engine pool.<ul> <li>RANDOM - Randomly use the engine in the pool</li> <li>POLLING - Polling use the engine in the pool</li> </ul>|string|1.7.0
 kyuubi.engine.pool.name|engine-pool|The name of engine pool.|string|1.5.0
 kyuubi.engine.pool.size|-1|The size of engine pool. Note that, if the size is less than 1, the engine pool will not be enabled; otherwise, the size of the engine pool will be min(this, kyuubi.engine.pool.size.threshold).|int|1.4.0
 kyuubi.engine.pool.size.threshold|9|This parameter is introduced as a server-side parameter, and controls the upper limit of the engine pool.|int|1.4.0

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -243,6 +243,7 @@ kyuubi.engine.jdbc.memory|1g|The heap memory for the jdbc query engine|string|1.
 kyuubi.engine.jdbc.type|&lt;undefined&gt;|The short name of jdbc type|string|1.6.0
 kyuubi.engine.operation.convert.catalog.database.enabled|true|When set to true, The engine converts the JDBC methods of set/get Catalog and set/get Schema to the implementation of different engines|boolean|1.6.0
 kyuubi.engine.operation.log.dir.root|engine_operation_logs|Root directory for query operation log at engine-side.|string|1.4.0
+kyuubi.engine.pool.balance.policy|RANDOM|The balance policy of queries in engine pool.<ul> <li>RANDOM - Randomly use the engine in the pool (default)</li> <li>POLLING - Polling use the engine in the pool.</li> </ul>|string|1.7.0
 kyuubi.engine.pool.name|engine-pool|The name of engine pool.|string|1.5.0
 kyuubi.engine.pool.size|-1|The size of engine pool. Note that, if the size is less than 1, the engine pool will not be enabled; otherwise, the size of the engine pool will be min(this, kyuubi.engine.pool.size.threshold).|int|1.4.0
 kyuubi.engine.pool.size.threshold|9|This parameter is introduced as a server-side parameter, and controls the upper limit of the engine pool.|int|1.4.0

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1394,6 +1394,18 @@ object KyuubiConf {
     .intConf
     .createWithDefault(-1)
 
+  val ENGINE_POOL_BALANCE_POLICY: ConfigEntry[String] =
+    buildConf("kyuubi.engine.pool.balance.policy")
+      .doc("The balance policy of queries in engine pool.Note that, " +
+        "Now,the engine pool balance policy only supports RANDOM or POLLING")
+      .version("1.7.0")
+      .stringConf
+      .transform(_.toUpperCase(Locale.ROOT))
+      .checkValue(
+        Set("RANDOM", "POLLING").contains,
+        "Now,the engine pool balance policy only supports RANDOM or POLLING")
+      .createWithDefault("RANDOM")
+
   val ENGINE_INITIALIZE_SQL: ConfigEntry[Seq[String]] =
     buildConf("kyuubi.engine.initialize.sql")
       .doc("SemiColon-separated list of SQL statements to be initialized in the newly created " +

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1396,14 +1396,13 @@ object KyuubiConf {
 
   val ENGINE_POOL_BALANCE_POLICY: ConfigEntry[String] =
     buildConf("kyuubi.engine.pool.balance.policy")
-      .doc("The balance policy of queries in engine pool.Note that, " +
-        "Now,the engine pool balance policy only supports RANDOM or POLLING")
+      .doc("The balance policy of queries in engine pool.<ul>" +
+        " <li>RANDOM - Randomly use the engine in the pool (default)</li>" +
+        " <li>POLLING - Polling use the engine in the pool.</li> </ul>")
       .version("1.7.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))
-      .checkValue(
-        Set("RANDOM", "POLLING").contains,
-        "Now,the engine pool balance policy only supports RANDOM or POLLING")
+      .checkValues(Set("RANDOM", "POLLING"))
       .createWithDefault("RANDOM")
 
   val ENGINE_INITIALIZE_SQL: ConfigEntry[Seq[String]] =

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1397,8 +1397,8 @@ object KyuubiConf {
   val ENGINE_POOL_BALANCE_POLICY: ConfigEntry[String] =
     buildConf("kyuubi.engine.pool.balance.policy")
       .doc("The balance policy of queries in engine pool.<ul>" +
-        " <li>RANDOM - Randomly use the engine in the pool (default)</li>" +
-        " <li>POLLING - Polling use the engine in the pool.</li> </ul>")
+        " <li>RANDOM - Randomly use the engine in the pool</li>" +
+        " <li>POLLING - Polling use the engine in the pool</li> </ul>")
       .version("1.7.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
@@ -46,6 +46,11 @@ trait DiscoveryClient extends Logging {
   def getData(path: String): Array[Byte]
 
   /**
+   * Set the data under path.
+   */
+  def setData(path: String, data: Array[Byte]): Boolean
+
+  /**
    * Get the paths under given path.
    * @return list of path
    */

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
@@ -172,10 +172,11 @@ trait DiscoveryClient extends Logging {
 
   /**
    * Atomically get an Int number and add one
-   * @param path the path of stored data
+   * @param path the path of stored data,
+   *             If the path does not exist, it will be created and initialized to 0
    * @return the stored data under path
    */
-  def getAndInc(path: String): Int
+  def getAndIncrement(path: String): Int
 }
 
 object DiscoveryClient {

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/DiscoveryClient.scala
@@ -169,6 +169,13 @@ trait DiscoveryClient extends Logging {
       basePath: String,
       initData: String,
       useProtection: Boolean = false): Unit
+
+  /**
+   * Atomically get an Int number and add one
+   * @param path the path of stored data
+   * @return the stored data under path
+   */
+  def getAndInc(path: String): Int
 }
 
 object DiscoveryClient {

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
@@ -124,6 +124,11 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     }
   }
 
+  def setData(path: String, data: Array[Byte]): Boolean = {
+    val response = kvClient.put(ByteSequence.from(path.getBytes), ByteSequence.from(data))
+    response.isDone
+  }
+
   def getChildren(path: String): List[String] = {
     val kvs = kvClient.get(
       ByteSequence.from(path.getBytes()),

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
@@ -295,7 +295,7 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
       ByteSequence.from(initData.getBytes())).get()
   }
 
-  def getAndInc(path: String): Int = {
+  def getAndIncrement(path: String): Int = {
     val lockPath = s"${path}_tmp_for_lock"
     tryWithLock(lockPath, 60 * 1000) {
       if (pathNonExists(path)) {

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/etcd/EtcdDiscoveryClient.scala
@@ -125,8 +125,8 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
   }
 
   def setData(path: String, data: Array[Byte]): Boolean = {
-    val response = kvClient.put(ByteSequence.from(path.getBytes), ByteSequence.from(data))
-    response.isDone
+    val response = kvClient.put(ByteSequence.from(path.getBytes), ByteSequence.from(data)).get()
+    response != null
   }
 
   def getChildren(path: String): List[String] = {
@@ -293,6 +293,19 @@ class EtcdDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     client.getKVClient.put(
       ByteSequence.from(basePath.getBytes()),
       ByteSequence.from(initData.getBytes())).get()
+  }
+
+  def getAndInc(path: String): Int = {
+    val lockPath = s"${path}_tmp_for_lock"
+    tryWithLock(lockPath, 60 * 1000) {
+      if (pathNonExists(path)) {
+        create(path, "PERSISTENT")
+        setData(path, String.valueOf(0).getBytes)
+      }
+      val s = new String(getData(path)).toInt
+      setData(path, String.valueOf(s + 1).getBytes)
+      s
+    }
   }
 
   private def createPersistentNode(

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -86,6 +86,10 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     zkClient.getData.forPath(path)
   }
 
+  def setData(path: String, data: Array[Byte]): Boolean = {
+    zkClient.setData().forPath(path, data) != null
+  }
+
   def getChildren(path: String): List[String] = {
     zkClient.getChildren.forPath(path).asScala.toList
   }

--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -296,7 +296,7 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
     secretNode.start()
   }
 
-  def getAndInc(path: String): Int = {
+  def getAndIncrement(path: String): Int = {
     val dai = new DistributedAtomicInteger(zkClient, path, new RetryForever(1000))
     dai.increment().preValue().intValue()
   }

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
@@ -166,8 +166,8 @@ trait DiscoveryClientTests extends KyuubiFunSuite {
       val path = "/setData_test"
       discoveryClient.create(path, "PERSISTENT")
       discoveryClient.setData(path, data.getBytes)
-      val getSata = new String(discoveryClient.getData(path))
-      assert(data.equals(getSata))
+      val dataFormGet = new String(discoveryClient.getData(path))
+      assert(data == dataFormGet)
     }
   }
 }

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
@@ -166,8 +166,8 @@ trait DiscoveryClientTests extends KyuubiFunSuite {
       val path = "/setData_test"
       discoveryClient.create(path, "PERSISTENT")
       discoveryClient.setData(path, data.getBytes)
-      val dataFormGet = new String(discoveryClient.getData(path))
-      assert(data == dataFormGet)
+      val dataFromGet = new String(discoveryClient.getData(path))
+      assert(data == dataFromGet)
     }
   }
 }

--- a/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
+++ b/kyuubi-ha/src/test/scala/org/apache/kyuubi/ha/client/DiscoveryClientTests.scala
@@ -150,4 +150,24 @@ trait DiscoveryClientTests extends KyuubiFunSuite {
       assert(e.getMessage contains s"Timeout to lock on path [$lockPath]")
     }
   }
+
+  test("getAndIncrement method test") {
+    withDiscoveryClient(conf) { discoveryClient =>
+      (0 until 10).foreach { i =>
+        val ii = discoveryClient.getAndIncrement("/get_and_increment_test")
+        assert(i == ii)
+      }
+    }
+  }
+
+  test("setData method test") {
+    withDiscoveryClient(conf) { discoveryClient =>
+      val data = "abc";
+      val path = "/setData_test"
+      discoveryClient.create(path, "PERSISTENT")
+      discoveryClient.setData(path, data.getBytes)
+      val getSata = new String(discoveryClient.getData(path))
+      assert(data.equals(getSata))
+    }
+  }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -37,7 +37,7 @@ import org.apache.kyuubi.engine.jdbc.JdbcProcessBuilder
 import org.apache.kyuubi.engine.spark.SparkProcessBuilder
 import org.apache.kyuubi.engine.trino.TrinoProcessBuilder
 import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ENGINE_REF_ID, HA_NAMESPACE}
-import org.apache.kyuubi.ha.client.{DiscoveryClient, DiscoveryPaths}
+import org.apache.kyuubi.ha.client.{DiscoveryClient, DiscoveryClientProvider, DiscoveryPaths}
 import org.apache.kyuubi.metrics.MetricsConstants.{ENGINE_FAIL, ENGINE_TIMEOUT, ENGINE_TOTAL}
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.operation.log.OperationLog
@@ -72,26 +72,13 @@ private[kyuubi] class EngineRef(
 
   private val clientPoolName: String = conf.get(ENGINE_POOL_NAME)
 
+  private val enginePoolBalancePolicy: String = conf.get(ENGINE_POOL_BALANCE_POLICY)
+
   // In case the multi kyuubi instances have the small gap of timeout, here we add
   // a small amount of time for timeout
   private val LOCK_TIMEOUT_SPAN_FACTOR = if (Utils.isTesting) 0.5 else 0.1
 
   private var builder: ProcBuilder = _
-
-  @VisibleForTesting
-  private[kyuubi] val subdomain: String = conf.get(ENGINE_SHARE_LEVEL_SUBDOMAIN) match {
-    case Some(_subdomain) => _subdomain
-    case None if clientPoolSize > 0 =>
-      val poolSize = math.min(clientPoolSize, poolThreshold)
-      if (poolSize < clientPoolSize) {
-        warn(s"Request engine pool size($clientPoolSize) exceeds, fallback to " +
-          s"system threshold $poolThreshold")
-      }
-      // TODO: Currently, we use random policy, and later we can add a sequential policy,
-      //  such as AtomicInteger % poolSize.
-      s"$clientPoolName-${Random.nextInt(poolSize)}"
-    case _ => "default" // [KYUUBI #1293]
-  }
 
   // Launcher of the engine
   private[kyuubi] val appUser: String = shareLevel match {
@@ -107,6 +94,47 @@ private[kyuubi] class EngineRef(
           user
       }
     case _ => user
+  }
+
+  @VisibleForTesting
+  private[kyuubi] val subdomain: String = conf.get(ENGINE_SHARE_LEVEL_SUBDOMAIN) match {
+    case Some(_subdomain) => _subdomain
+    case None if clientPoolSize > 0 =>
+      val poolSize = math.min(clientPoolSize, poolThreshold)
+      if (poolSize < clientPoolSize) {
+        warn(s"Request engine pool size($clientPoolSize) exceeds, fallback to " +
+          s"system threshold $poolThreshold")
+      }
+      val seqNum = enginePoolBalancePolicy match {
+        case "POLLING" =>
+          info(s"The engine pool balance policy is POLLING.")
+          val snPath =
+            DiscoveryPaths.makePath(
+              s"${serverSpace}_$shareLevel",
+              "seq_num",
+              Array(appUser, clientPoolName))
+          val snLockPath =
+            DiscoveryPaths.makePath(
+              s"${serverSpace}_$shareLevel",
+              "seq_num_lock",
+              Array(appUser, clientPoolName))
+          DiscoveryClientProvider.withDiscoveryClient(conf) { client =>
+            client.tryWithLock(snLockPath, timeout) {
+              if (client.pathNonExists(snPath)) {
+                client.create(snPath, "PERSISTENT")
+                client.setData(snPath, String.valueOf(0).getBytes)
+              }
+              val seqNum = new String(client.getData(snPath)).toInt
+              client.setData(snPath, String.valueOf(seqNum + 1).getBytes)
+              seqNum
+            }
+          }
+        case "RANDOM" =>
+          info(s"The engine pool balance policy is RANDOM.")
+          Random.nextInt(poolSize)
+      }
+      s"$clientPoolName-${seqNum % poolSize}"
+    case _ => "default" // [KYUUBI #1293]
   }
 
   /**

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/EngineRef.scala
@@ -107,17 +107,15 @@ private[kyuubi] class EngineRef(
       }
       val seqNum = enginePoolBalancePolicy match {
         case "POLLING" =>
-          info(s"The engine pool balance policy is POLLING.")
           val snPath =
             DiscoveryPaths.makePath(
               s"${serverSpace}_${KYUUBI_VERSION}_${shareLevel}_$engineType",
               "seq_num",
               Array(appUser, clientPoolName))
           DiscoveryClientProvider.withDiscoveryClient(conf) { client =>
-            client.getAndInc(snPath)
+            client.getAndIncrement(snPath)
           }
         case "RANDOM" =>
-          info(s"The engine pool balance policy is RANDOM.")
           Random.nextInt(poolSize)
       }
       s"$clientPoolName-${seqNum % poolSize}"

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
@@ -209,6 +209,21 @@ trait EngineRefTests extends KyuubiFunSuite {
     conf.set(ENGINE_POOL_SIZE, 3)
     val engine6 = new EngineRef(conf, user, id, null)
     assert(engine6.subdomain.startsWith(s"$enginePoolName-"))
+
+    // set(ENGINE_POOL_BALANCE_POLICY, "POLLING")
+    conf.unset(ENGINE_SHARE_LEVEL_SUBDOMAIN)
+    conf.set(ENGINE_POOL_SIZE, 5)
+    val pool_name = "pool_default_name"
+    conf.set(ENGINE_POOL_NAME, pool_name)
+    conf.set(HighAvailabilityConf.HA_NAMESPACE, "engine_test")
+    conf.set(HighAvailabilityConf.HA_ADDRESSES, getConnectString())
+    conf.set(ENGINE_POOL_BALANCE_POLICY, "POLLING")
+    (0 until (10)).foreach { i =>
+      val engine7 = new EngineRef(conf, user, id, null)
+      // print(engine7.subdomain +",i:" + i + "\n")
+      val engineNumber = Integer.parseInt(engine7.subdomain.substring(pool_name.length + 1))
+      assert(engineNumber == (i % conf.get(ENGINE_POOL_SIZE)))
+    }
   }
 
   test("start and get engine address with lock") {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/EngineRefTests.scala
@@ -210,7 +210,6 @@ trait EngineRefTests extends KyuubiFunSuite {
     val engine6 = new EngineRef(conf, user, id, null)
     assert(engine6.subdomain.startsWith(s"$enginePoolName-"))
 
-    // set(ENGINE_POOL_BALANCE_POLICY, "POLLING")
     conf.unset(ENGINE_SHARE_LEVEL_SUBDOMAIN)
     conf.set(ENGINE_POOL_SIZE, 5)
     val pool_name = "pool_default_name"
@@ -220,7 +219,6 @@ trait EngineRefTests extends KyuubiFunSuite {
     conf.set(ENGINE_POOL_BALANCE_POLICY, "POLLING")
     (0 until (10)).foreach { i =>
       val engine7 = new EngineRef(conf, user, id, null)
-      // print(engine7.subdomain +",i:" + i + "\n")
       val engineNumber = Integer.parseInt(engine7.subdomain.substring(pool_name.length + 1))
       assert(engineNumber == (i % conf.get(ENGINE_POOL_SIZE)))
     }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

As described in #2887, random policy may cause task-hot-issues or production accident, so a POLLING balance policy is added to avoid this problem, we can "set kyuubi.engine.pool.balance.policy = POLLING" to use it. 


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
