### PR TITLE
[SPARK][K8S][BATCH] Kyuubi should set env SPARK_USER_NAME on submitting Spark batch job to K8s

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
@@ -54,6 +54,7 @@ class SparkBatchProcessBuilder(
       buffer += s"${convertConfigKey(k)}=$v"
     }
 
+    setSparkUserName(proxyUser, buffer)
     buffer += PROXY_USER
     buffer += proxyUser
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -91,26 +91,14 @@ class SparkProcessBuilder(
       buffer += s"${convertConfigKey(k)}=$v"
     }
 
-    // For spark on kubernetes, spark pod using env SPARK_USER_NAME as current user
-    def setSparkUserName(userName: String): Unit = {
-      clusterManager().foreach(cm => {
-        if (cm.startsWith("k8s://")) {
-          buffer += CONF
-          buffer += s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$userName"
-          buffer += CONF
-          buffer += s"spark.executorEnv.SPARK_USER_NAME=$userName"
-        }
-      })
-    }
-
     // if the keytab is specified, PROXY_USER is not supported
     tryKeytab() match {
       case None =>
-        setSparkUserName(proxyUser)
+        setSparkUserName(proxyUser, buffer)
         buffer += PROXY_USER
         buffer += proxyUser
       case Some(name) =>
-        setSparkUserName(name)
+        setSparkUserName(name, buffer)
     }
 
     mainResource.foreach { r => buffer += r }
@@ -185,6 +173,17 @@ class SparkProcessBuilder(
 
   override def validateConf: Unit = Validator.validateConf(conf)
 
+  // For spark on kubernetes, spark pod using env SPARK_USER_NAME as current user
+  def setSparkUserName(userName: String, buffer: ArrayBuffer[String]): Unit = {
+    clusterManager().foreach(cm => {
+      if (cm.startsWith("k8s://")) {
+        buffer += CONF
+        buffer += s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$userName"
+        buffer += CONF
+        buffer += s"spark.executorEnv.SPARK_USER_NAME=$userName"
+      }
+    })
+  }
 }
 
 object SparkProcessBuilder {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -175,14 +175,14 @@ class SparkProcessBuilder(
 
   // For spark on kubernetes, spark pod using env SPARK_USER_NAME as current user
   def setSparkUserName(userName: String, buffer: ArrayBuffer[String]): Unit = {
-    clusterManager().foreach(cm => {
+    clusterManager().foreach { cm =>
       if (cm.toUpperCase.startsWith("K8S")) {
         buffer += CONF
         buffer += s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$userName"
         buffer += CONF
         buffer += s"spark.executorEnv.SPARK_USER_NAME=$userName"
       }
-    })
+    }
   }
 }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkProcessBuilder.scala
@@ -176,7 +176,7 @@ class SparkProcessBuilder(
   // For spark on kubernetes, spark pod using env SPARK_USER_NAME as current user
   def setSparkUserName(userName: String, buffer: ArrayBuffer[String]): Unit = {
     clusterManager().foreach(cm => {
-      if (cm.startsWith("k8s://")) {
+      if (cm.toUpperCase.startsWith("K8S")) {
         buffer += CONF
         buffer += s"spark.kubernetes.driverEnv.SPARK_USER_NAME=$userName"
         buffer += CONF


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Batch job should also submit with `SPARK_USER_NAME`.

See more in pre pr #3527 .

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
