### PR TITLE
[SPARK][K8S] Fix Spark master match rule on tagging Spark application

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KyuubiApplicationManager.scala
@@ -160,7 +160,7 @@ object KyuubiApplicationManager {
       conf: KyuubiConf): Unit = {
     (applicationType.toUpperCase, resourceManager.map(_.toUpperCase())) match {
       case ("SPARK", Some("YARN")) => setupSparkYarnTag(applicationTag, conf)
-      case ("SPARK", Some("K8S")) => setupSparkK8sTag(applicationTag, conf)
+      case ("SPARK", Some(rm)) if rm.startsWith("K8S") => setupSparkK8sTag(applicationTag, conf)
       case ("SPARK", _) =>
         // if the master is not identified ahead, add all tags
         setupSparkYarnTag(applicationTag, conf)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
@@ -72,4 +72,8 @@ class SparkBatchProcessBuilder(
   }
 
   override protected def module: String = "kyuubi-spark-batch-submit"
+
+  override def clusterManager(): Option[String] = {
+    batchConf.get(MASTER_KEY).orElse(defaultMaster)
+  }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/spark/SparkBatchProcessBuilder.scala
@@ -72,8 +72,4 @@ class SparkBatchProcessBuilder(
   }
 
   override protected def module: String = "kyuubi-spark-batch-submit"
-
-  override def clusterManager(): Option[String] = {
-    batchConf.get(MASTER_KEY).orElse(defaultMaster)
-  }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KyuubiApplicationManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KyuubiApplicationManagerSuite.scala
@@ -73,9 +73,13 @@ class KyuubiApplicationManagerSuite extends KyuubiFunSuite {
   }
 
   test("Test kyuubi application Manager tag spark on kubernetes application") {
-    val conf: KyuubiConf = KyuubiConf().set("", "")
+    val conf: KyuubiConf = KyuubiConf()
     val tag = "kyuubi-test-tag"
-    KyuubiApplicationManager.tagApplication(tag, "SPARK", Some("k8s://kyuubi-test:8443"), conf)
+    KyuubiApplicationManager.tagApplication(
+      tag,
+      "SPARK",
+      Some("k8s://https://kyuubi-test:8443"),
+      conf)
 
     val kubernetesTag = conf.getOption("spark.kubernetes.driver.label." + LABEL_KYUUBI_UNIQUE_KEY)
     val yarnTag = conf.getOption("spark.yarn.tags")

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KyuubiApplicationManagerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/KyuubiApplicationManagerSuite.scala
@@ -19,6 +19,7 @@ package org.apache.kyuubi.engine
 
 import org.apache.kyuubi.{KyuubiException, KyuubiFunSuite}
 import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.engine.KubernetesApplicationOperation.LABEL_KYUUBI_UNIQUE_KEY
 
 class KyuubiApplicationManagerSuite extends KyuubiFunSuite {
   test("application access path") {
@@ -69,5 +70,16 @@ class KyuubiApplicationManagerSuite extends KyuubiFunSuite {
         appConf,
         localDirLimitConf)
     }
+  }
+
+  test("Test kyuubi application Manager tag spark on kubernetes application") {
+    val conf: KyuubiConf = KyuubiConf().set("", "")
+    val tag = "kyuubi-test-tag"
+    KyuubiApplicationManager.tagApplication(tag, "SPARK", Some("k8s://kyuubi-test:8443"), conf)
+
+    val kubernetesTag = conf.getOption("spark.kubernetes.driver.label." + LABEL_KYUUBI_UNIQUE_KEY)
+    val yarnTag = conf.getOption("spark.yarn.tags")
+    assert(kubernetesTag.nonEmpty && tag.equals(kubernetesTag.get))
+    assert(yarnTag.isEmpty)
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Fix kyuubi application manager tag spark kubernetes application with yarn tag.

The reason for this is the need to determine whether resourceManager start with K8S instead of being equal to K8S.

Remove duplicate code from spark batch process builder.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
