### PR TITLE
[KYUUBI #3671] [TEST] assert error message for SCHEMA_NOT_FOUND and TABLE_OR_VIEW_NOT_FOUND for Spark 3.4

### DIFF
--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/IcebergMetadataTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/IcebergMetadataTests.scala
@@ -17,15 +17,11 @@
 
 package org.apache.kyuubi.operation
 
-import org.apache.kyuubi.{IcebergSuiteMixin, SPARK_COMPILE_VERSION}
-import org.apache.kyuubi.engine.SemanticVersion
+import org.apache.kyuubi.IcebergSuiteMixin
 import org.apache.kyuubi.operation.meta.ResultSetSchemaConstant._
+import org.apache.kyuubi.util.SparkVersionUtil.isSparkVersionAtLeast
 
 trait IcebergMetadataTests extends HiveJDBCTestHelper with IcebergSuiteMixin {
-
-  def isSparkVersionAtLeast(ver: String): Boolean = {
-    SemanticVersion(SPARK_COMPILE_VERSION).isVersionAtLeast(ver)
-  }
 
   test("get catalogs") {
     withJdbcStatement() { statement =>

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -25,8 +25,8 @@ import scala.collection.JavaConverters._
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.StringUtils
 import org.apache.hive.service.rpc.thrift.{TExecuteStatementReq, TFetchResultsReq, TOpenSessionReq, TStatusCode}
-import org.apache.kyuubi.{KYUUBI_VERSION, Utils}
 
+import org.apache.kyuubi.{KYUUBI_VERSION, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.SemanticVersion
 import org.apache.kyuubi.util.SparkVersionUtil.isSparkVersionAtLeast

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/util/SparkVersionUtil.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/util/SparkVersionUtil.scala
@@ -21,7 +21,9 @@ import org.apache.kyuubi.SPARK_COMPILE_VERSION
 import org.apache.kyuubi.engine.SemanticVersion
 
 object SparkVersionUtil {
+  lazy val sparkSemanticVersion: SemanticVersion = SemanticVersion(SPARK_COMPILE_VERSION)
+
   def isSparkVersionAtLeast(ver: String): Boolean = {
-    SemanticVersion(SPARK_COMPILE_VERSION).isVersionAtLeast(ver)
+    sparkSemanticVersion.isVersionAtLeast(ver)
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/util/SparkVersionUtil.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/util/SparkVersionUtil.scala
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.util
+
+import org.apache.kyuubi.SPARK_COMPILE_VERSION
+import org.apache.kyuubi.engine.SemanticVersion
+
+object SparkVersionUtil {
+  def isSparkVersionAtLeast(ver: String): Boolean = {
+    SemanticVersion(SPARK_COMPILE_VERSION).isVersionAtLeast(ver)
+  }
+}


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
to close #3671.

- fix assert message for '[SCHEMA_NOT_FOUND]' and '[TABLE_OR_VIEW_NOT_FOUND]'
- introduce SparkVersionUtil in kyuubi-common test for checking Spark version

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
