### PR TITLE
[K8S] Create kyuubi user dir  while building kyuubi docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,9 +53,6 @@ RUN set -ex && \
     apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps && \
     useradd -u ${kyuubi_uid} -g root kyuubi -d /home/kyuubi -m && \
     mkdir -p ${KYUUBI_HOME} ${KYUUBI_LOG_DIR} ${KYUUBI_PID_DIR} ${KYUUBI_WORK_DIR_ROOT} && \
-    chown -R kyuubi:root ${KYUUBI_HOME} && \
-    chmod ug+rw -R ${KYUUBI_HOME} && \
-    chmod a+rwx -R ${KYUUBI_WORK_DIR_ROOT} && \
     rm -rf /var/cache/apt/*
 
 COPY bin ${KYUUBI_HOME}/bin
@@ -64,6 +61,9 @@ COPY beeline-jars ${KYUUBI_HOME}/beeline-jars
 COPY externals/engines/spark ${KYUUBI_HOME}/externals/engines/spark
 
 WORKDIR ${KYUUBI_HOME}
+RUN chown -R kyuubi:root ${KYUUBI_HOME} && \
+    chmod ug+rw -R ${KYUUBI_HOME} && \
+    chmod a+rwx -R ${KYUUBI_WORK_DIR_ROOT}
 
 CMD [ "./bin/kyuubi", "run" ]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,8 +51,9 @@ RUN set -ex && \
     sed -i 's/http:\/\/deb.\(.*\)/https:\/\/deb.\1/g' /etc/apt/sources.list && \
     apt-get update && \
     apt install -y bash tini libc6 libpam-modules krb5-user libnss3 procps && \
-    useradd -u ${kyuubi_uid} -g root kyuubi && \
+    useradd -u ${kyuubi_uid} -g root kyuubi -d /home/kyuubi -m && \
     mkdir -p ${KYUUBI_HOME} ${KYUUBI_LOG_DIR} ${KYUUBI_PID_DIR} ${KYUUBI_WORK_DIR_ROOT} && \
+    chown -R kyuubi:root ${KYUUBI_HOME} && \
     chmod ug+rw -R ${KYUUBI_HOME} && \
     chmod a+rwx -R ${KYUUBI_WORK_DIR_ROOT} && \
     rm -rf /var/cache/apt/*


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->


### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Create kyuubi user directory  while building kyuubi docker image to avoid the issue that kyuubi user do not have a default user directory or do not have permission to create a default user.

Also improved, change `KYUUBI_HOME` owner to kyuubi user.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request

- [X] build docker image and run in kubernetes
