### PR TITLE
Support to show remaining logs with timeout if the batch failed

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -192,8 +192,8 @@ kyuubi.credentials.update.wait.timeout|PT1M|How long to wait until credentials a
 
 Key | Default | Meaning | Type | Since
 --- | --- | --- | --- | ---
+kyuubi.ctl.batch.log.on.failure.timeout|PT10S|The timeout for fetching remaining batch logs if the batch failed.|duration|1.7.0
 kyuubi.ctl.batch.log.query.interval|PT3S|The interval for fetching batch logs.|duration|1.6.0
-kyuubi.ctl.batch.log.thread.timeout|PT10S|The timeout for fetching batch logs thread. For log batch command, a log thread is used to fetch batch logs, if the batch is failed, the log thread will fetch remaining logs with this timeout.|duration|1.7.0
 kyuubi.ctl.rest.auth.schema|basic|The authentication schema. Valid values are: basic, spnego.|string|1.6.0
 kyuubi.ctl.rest.base.url|&lt;undefined&gt;|The REST API base URL, which contains the scheme (http:// or https://), host name, port number|string|1.6.0
 kyuubi.ctl.rest.connect.timeout|PT30S|The timeout[ms] for establishing the connection with the kyuubi server.A timeout value of zero is interpreted as an infinite timeout.|duration|1.6.0

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -193,6 +193,7 @@ kyuubi.credentials.update.wait.timeout|PT1M|How long to wait until credentials a
 Key | Default | Meaning | Type | Since
 --- | --- | --- | --- | ---
 kyuubi.ctl.batch.log.query.interval|PT3S|The interval for fetching batch logs.|duration|1.6.0
+kyuubi.ctl.batch.log.thread.timeout|PT10S|The timeout for fetching batch logs thread. For log batch command, a log thread is used to fetch batch logs, if the batch is failed, the log thread will fetch remaining logs with this timeout.|duration|1.7.0
 kyuubi.ctl.rest.auth.schema|basic|The authentication schema. Valid values are: basic, spnego.|string|1.6.0
 kyuubi.ctl.rest.base.url|&lt;undefined&gt;|The REST API base URL, which contains the scheme (http:// or https://), host name, port number|string|1.6.0
 kyuubi.ctl.rest.connect.timeout|PT30S|The timeout[ms] for establishing the connection with the kyuubi server.A timeout value of zero is interpreted as an infinite timeout.|duration|1.6.0

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/CtlConf.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/CtlConf.scala
@@ -86,11 +86,9 @@ object CtlConf {
       .timeConf
       .createWithDefault(Duration.ofSeconds(3).toMillis)
 
-  val CTL_BATCH_LOG_THREAD_TIMEOUT: ConfigEntry[Long] =
-    buildConf("kyuubi.ctl.batch.log.thread.timeout")
-      .doc("The timeout for fetching batch logs thread." +
-        " For log batch command, a log thread is used to fetch batch logs," +
-        " if the batch is failed, the log thread will fetch remaining logs with this timeout.")
+  val CTL_BATCH_LOG_ON_FAILURE_TIMEOUT: ConfigEntry[Long] =
+    buildConf("kyuubi.ctl.batch.log.on.failure.timeout")
+      .doc("The timeout for fetching remaining batch logs if the batch failed.")
       .version("1.7.0")
       .timeConf
       .createWithDefault(Duration.ofSeconds(10).toMillis)

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/CtlConf.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/CtlConf.scala
@@ -85,4 +85,13 @@ object CtlConf {
       .version("1.6.0")
       .timeConf
       .createWithDefault(Duration.ofSeconds(3).toMillis)
+
+  val CTL_BATCH_LOG_THREAD_TIMEOUT: ConfigEntry[Long] =
+    buildConf("kyuubi.ctl.batch.log.thread.timeout")
+      .doc("The timeout for fetching batch logs thread." +
+        " For log batch command, a log thread is used to fetch batch logs," +
+        " if the batch is failed, the log thread will fetch remaining logs with this timeout.")
+      .version("1.7.0")
+      .timeConf
+      .createWithDefault(Duration.ofSeconds(10).toMillis)
 }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -56,7 +56,7 @@ class LogBatchCommand(
       withKyuubiInstanceRestClient(kyuubiRestClient, kyuubiInstance) { kyuubiInstanceRestClient =>
         val kyuubiInstanceBatchRestApi: BatchRestApi = new BatchRestApi(kyuubiInstanceRestClient)
 
-        def getOperationLogOnce(): OperationLog = {
+        def retrieveOperationLog(): OperationLog = {
           val log = kyuubiInstanceBatchRestApi.getBatchLocalLog(batchId, from, size)
           from += log.getLogRowSet.size
           log.getLogRowSet.asScala.foreach(x => info(x))
@@ -65,7 +65,7 @@ class LogBatchCommand(
 
         while (!done) {
           try {
-            log = getOperationLogOnce()
+            log = retrieveOperationLog()
             val (latestBatch, shouldFinishLog) =
               checkStatus(kyuubiInstanceBatchRestApi, batchId, log)
             batch = latestBatch
@@ -93,7 +93,7 @@ class LogBatchCommand(
           var hasRemainingLogs = true
           while (hasRemainingLogs && System.currentTimeMillis() - startTime < timeout) {
             try {
-              if (getOperationLogOnce().getLogRowSet.size == 0) {
+              if (retrieveOperationLog().getLogRowSet.size == 0) {
                 hasRemainingLogs = false
               }
             } catch {

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -114,7 +114,7 @@ class LogBatchCommand(
           }
         }
 
-        val batchFailed = BatchUtils.isTerminalState(batch.getState) &&
+        val batchFailed = batch != null && BatchUtils.isTerminalState(batch.getState) &&
           !BatchUtils.isFinishedState(batch.getState)
 
         // if the batch state is not failed, interrupt the log thread;

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -55,15 +55,17 @@ class LogBatchCommand(
 
       withKyuubiInstanceRestClient(kyuubiRestClient, kyuubiInstance) { kyuubiInstanceRestClient =>
         val kyuubiInstanceBatchRestApi: BatchRestApi = new BatchRestApi(kyuubiInstanceRestClient)
+
+        def getOperationLogOnce(): OperationLog = {
+          val log = kyuubiInstanceBatchRestApi.getBatchLocalLog(batchId, from, size)
+          from += log.getLogRowSet.size
+          log.getLogRowSet.asScala.foreach(x => info(x))
+          log
+        }
+
         while (!done) {
           try {
-            log = kyuubiInstanceBatchRestApi.getBatchLocalLog(
-              batchId,
-              from,
-              size)
-            from += log.getLogRowSet.size
-            log.getLogRowSet.asScala.foreach(x => info(x))
-
+            log = getOperationLogOnce()
             val (latestBatch, shouldFinishLog) =
               checkStatus(kyuubiInstanceBatchRestApi, batchId, log)
             batch = latestBatch
@@ -80,6 +82,26 @@ class LogBatchCommand(
 
           if (!done) {
             Thread.sleep(conf.get(CTL_BATCH_LOG_QUERY_INTERVAL))
+          }
+        }
+
+        // if the batch failed, show remaining batch logs with timeout
+        if (batch != null && BatchUtils.isTerminalState(
+            batch.getState) && !BatchUtils.isFinishedState(batch.getState)) {
+          val startTime = System.currentTimeMillis()
+          val timeout = conf.get(CTL_BATCH_LOG_ON_FAILURE_TIMEOUT)
+          var hasRemainingLogs = true
+          while (hasRemainingLogs && System.currentTimeMillis() - startTime < timeout) {
+            try {
+              if (getOperationLogOnce().getLogRowSet.size == 0) {
+                hasRemainingLogs = false
+              }
+            } catch {
+              case e: Exception => error(s"Error fetching batch logs: ${e.getMessage}")
+            }
+          }
+          if (hasRemainingLogs) {
+            info(s"See the complete logs with command `kyuubi-ctl log batch $batchId --forward`.")
           }
         }
       }

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -85,7 +85,12 @@ class LogBatchCommand(
 
               // if it has been done and the last fetched logs is non empty, do not wait a interval
               if (!done || (log != null && log.getRowCount > 0)) {
-                Thread.sleep(conf.get(CTL_BATCH_LOG_QUERY_INTERVAL))
+                try {
+                  Thread.sleep(conf.get(CTL_BATCH_LOG_QUERY_INTERVAL))
+                } catch {
+                  case _: InterruptedException =>
+                    debug("Batch log thread is interrupted, since the command is done")
+                }
               }
             }
           }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If the batch failed, we shall try to show the remaining logs with timeout.

### _How was this patch tested?_
Existing UT.
