### PR TITLE
[KYUUBI #3727] Extract the common variables of GetTables in flink and spark to ResultSetSchemaConstant 

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTables.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/GetTables.scala
@@ -80,11 +80,11 @@ class GetTables(
           Column.physical(TABLE_NAME, DataTypes.STRING),
           Column.physical(TABLE_TYPE, DataTypes.STRING),
           Column.physical(REMARKS, DataTypes.STRING),
-          Column.physical("TYPE_CAT", DataTypes.STRING),
-          Column.physical("TYPE_SCHEM", DataTypes.STRING),
-          Column.physical("TYPE_NAME", DataTypes.STRING),
-          Column.physical("SELF_REFERENCING_COL_NAME", DataTypes.STRING),
-          Column.physical("REF_GENERATION", DataTypes.STRING))
+          Column.physical(TYPE_CAT, DataTypes.STRING),
+          Column.physical(TYPE_SCHEM, DataTypes.STRING),
+          Column.physical(TYPE_NAME, DataTypes.STRING),
+          Column.physical(SELF_REFERENCING_COL_NAME, DataTypes.STRING),
+          Column.physical(REF_GENERATION, DataTypes.STRING))
         .data(tables)
         .build
     } catch onError()

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTables.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/GetTables.scala
@@ -47,16 +47,16 @@ class GetTables(
       .add(TABLE_NAME, "string", nullable = true, "Table name.")
       .add(TABLE_TYPE, "string", nullable = true, "The table type, e.g. \"TABLE\", \"VIEW\"")
       .add(REMARKS, "string", nullable = true, "Comments about the table.")
-      .add("TYPE_CAT", "string", nullable = true, "The types catalog.")
-      .add("TYPE_SCHEM", "string", nullable = true, "the types schema (may be null)")
-      .add("TYPE_NAME", "string", nullable = true, "Type name.")
+      .add(TYPE_CAT, "string", nullable = true, "The types catalog.")
+      .add(TYPE_SCHEM, "string", nullable = true, "the types schema (may be null)")
+      .add(TYPE_NAME, "string", nullable = true, "Type name.")
       .add(
-        "SELF_REFERENCING_COL_NAME",
+        SELF_REFERENCING_COL_NAME,
         "string",
         nullable = true,
         "Name of the designated \"identifier\" column of a typed table.")
       .add(
-        "REF_GENERATION",
+        REF_GENERATION,
         "string",
         nullable = true,
         "Specifies how values in SELF_REFERENCING_COL_NAME are created.")

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/meta/ResultSetSchemaConstant.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/meta/ResultSetSchemaConstant.scala
@@ -187,4 +187,25 @@ object ResultSetSchemaConstant {
    * for example with overload functions
    */
   final val SPECIFIC_NAME = "SPECIFIC_NAME"
+
+  /**
+   * String => The types catalog.
+   */
+  final val TYPE_CAT = "TYPE_CAT"
+
+  /**
+   * String => the types schema (may be null).
+   */
+  final val TYPE_SCHEM = "TYPE_SCHEM"
+
+  /**
+   * String => Name of the designated "identifier" column of a typed table.
+   */
+  final val SELF_REFERENCING_COL_NAME = "SELF_REFERENCING_COL_NAME"
+
+  /**
+   * String => Specifies how values in SELF_REFERENCING_COL_NAME are created.
+   */
+  final val REF_GENERATION = "REF_GENERATION"
+
 }


### PR DESCRIPTION


<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
fix #3727 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
