### PR TITLE
Closing existing seekable reader when adding extra log

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/log/OperationLog.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/log/OperationLog.scala
@@ -99,10 +99,8 @@ class OperationLog(path: Path) {
     try {
       extraReaders += Files.newBufferedReader(path, StandardCharsets.UTF_8)
       extraPaths += path
-      if (seekableReader != null) {
-        seekableReader.close()
-        seekableReader = null
-      }
+      Option(seekableReader).foreach(_.close)
+      seekableReader = null
     } catch {
       case _: IOException =>
     }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/log/OperationLog.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/log/OperationLog.scala
@@ -99,6 +99,10 @@ class OperationLog(path: Path) {
     try {
       extraReaders += Files.newBufferedReader(path, StandardCharsets.UTF_8)
       extraPaths += path
+      if (seekableReader != null) {
+        seekableReader.close()
+        seekableReader = null
+      }
     } catch {
       case _: IOException =>
     }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/log/OperationLogSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/log/OperationLogSuite.scala
@@ -262,7 +262,7 @@ class OperationLogSuite extends KyuubiFunSuite {
     assert(msg == msg1)
   }
 
-  test("recreate seekable reader when adding extra log") {
+  test("closing existing seekable reader when adding extra log") {
     val file = Utils.createTempDir().resolve("f")
     val writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)
     val extraFile = Utils.createTempDir().resolve("e")

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/log/OperationLogSuite.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/log/OperationLogSuite.scala
@@ -261,4 +261,40 @@ class OperationLogSuite extends KyuubiFunSuite {
     val msg = log1.read(1).getColumns.get(0).getStringVal.getValues.asScala.head
     assert(msg == msg1)
   }
+
+  test("recreate seekable reader when adding extra log") {
+    val file = Utils.createTempDir().resolve("f")
+    val writer = Files.newBufferedWriter(file, StandardCharsets.UTF_8)
+    val extraFile = Utils.createTempDir().resolve("e")
+    val extraWriter = Files.newBufferedWriter(extraFile, StandardCharsets.UTF_8)
+
+    try {
+      writer.write(s"log")
+      writer.flush()
+      writer.close()
+
+      extraWriter.write("extra_log")
+      extraWriter.flush()
+      extraWriter.close()
+
+      def compareResult(rows: TRowSet, expected: Seq[String]): Unit = {
+        val res = rows.getColumns.get(0).getStringVal.getValues.asScala
+        assert(res.size == expected.size)
+        res.zip(expected).foreach { case (l, r) =>
+          assert(l == r)
+        }
+      }
+
+      val log = new OperationLog(file)
+      // The operation log file is created externally and should be initialized actively.
+      log.initOperationLogIfNecessary()
+
+      compareResult(log.read(0, 1), Seq("log"))
+      log.addExtraLog(extraFile)
+      compareResult(log.read(1, 1), Seq("extra_log"))
+    } finally {
+      Utils.deleteDirectoryRecursively(file.toFile)
+      Utils.deleteDirectoryRecursively(extraFile.toFile)
+    }
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Closing existing seekable reader when adding extra log


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
