### PR TITLE
[SPARK] Engine UI support grace stop

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -99,10 +99,8 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
           info(s"Spark engine is de-registering from engine discovery space.")
           frontendServices.flatMap(_.discoveryService).foreach(_.stop())
         }
-        val openSessionCount = backendService.sessionManager.getOpenSessionCount
-        if (openSessionCount > 0) {
-          info(s"$openSessionCount connection(s) are active, delay shutdown")
-        } else {
+
+        if (backendService.sessionManager.getOpenSessionCount <= 0) {
           info(s"Spark engine has no open session now, terminating.")
           stop()
         }
@@ -130,12 +128,9 @@ case class SparkSQLEngine(spark: SparkSession) extends Serverable("SparkSQLEngin
             frontendServices.flatMap(_.discoveryService).foreach(_.stop())
           }
 
-          val openSessionCount = backendService.sessionManager.getOpenSessionCount
-          if (openSessionCount > 0) {
-            info(s"$openSessionCount connection(s) are active, delay shutdown")
-          } else {
+          if (backendService.sessionManager.getOpenSessionCount <= 0) {
             info(s"Spark engine has been running for more than $maxLifetime ms" +
-              s" and no open session now, terminating")
+              s" and no open session now, terminating.")
             stop()
           }
         }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -105,9 +105,9 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
       <ul class="list-unstyled">
         <li>
           <strong>Stop kyuubi engine:</strong>
-          <a href={forceStopLinkUri} onclick={confirmForceStop} class="stop-link">(Force-Kill)</a>
+          <a href={forceStopLinkUri} onclick={confirmForceStop} class="stop-link">(Force kill)</a>
           <a href={gracefulStopLinkUri} onclick={confirmGracefulStop}
-             class="stop-link">(Grace-Kill)</a>
+             class="stop-link">(Graceful kill)</a>
         </li>
       </ul>
     } else {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -93,21 +93,22 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
     val basePath = UIUtils.prependBaseUri(request, parent.basePath)
     if (parent.killEnabled) {
       val confirmForceStop =
-        s"if (window.confirm('Are you sure you want to force kill kyuubi engine ?')) " +
+        s"if (window.confirm('Are you sure you want to stop kyuubi engine immediately ?')) " +
           "{ this.parentNode.submit(); return true; } else { return false; }"
       val forceStopLinkUri = s"$basePath/kyuubi/stop"
 
       val confirmGracefulStop =
-        s"if (window.confirm('Are you sure you want to graceful kill kyuubi engine ?')) " +
+        s"if (window.confirm('Are you sure you want to stop kyuubi engine gracefully ?')) " +
           "{ this.parentNode.submit(); return true; } else { return false; }"
       val gracefulStopLinkUri = s"$basePath/kyuubi/gracefulstop"
 
       <ul class="list-unstyled">
         <li>
           <strong>Stop kyuubi engine:</strong>
-          <a href={forceStopLinkUri} onclick={confirmForceStop} class="stop-link">(Force kill)</a>
-          <a href={gracefulStopLinkUri} onclick={confirmGracefulStop}
-             class="stop-link">(Graceful kill)</a>
+          <a href={forceStopLinkUri} onclick={confirmForceStop} class="stop-link">
+            (Stop Immediately)</a>
+          <a href={gracefulStopLinkUri} onclick={confirmGracefulStop} class="stop-link">
+            (Stop Gracefully)</a>
         </li>
       </ul>
     } else {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EnginePage.scala
@@ -92,14 +92,22 @@ case class EnginePage(parent: EngineTab) extends WebUIPage("") {
   private def stop(request: HttpServletRequest): Seq[Node] = {
     val basePath = UIUtils.prependBaseUri(request, parent.basePath)
     if (parent.killEnabled) {
-      val confirm =
-        s"if (window.confirm('Are you sure you want to kill kyuubi engine ?')) " +
+      val confirmForceStop =
+        s"if (window.confirm('Are you sure you want to force kill kyuubi engine ?')) " +
           "{ this.parentNode.submit(); return true; } else { return false; }"
-      val stopLinkUri = s"$basePath/kyuubi/stop"
-      <ul class ="list-unstyled">
+      val forceStopLinkUri = s"$basePath/kyuubi/stop"
+
+      val confirmGracefulStop =
+        s"if (window.confirm('Are you sure you want to graceful kill kyuubi engine ?')) " +
+          "{ this.parentNode.submit(); return true; } else { return false; }"
+      val gracefulStopLinkUri = s"$basePath/kyuubi/gracefulstop"
+
+      <ul class="list-unstyled">
         <li>
-          <strong>Stop kyuubi engine:  </strong>
-          <a href={stopLinkUri} onclick={confirm} class="stop-link">(kill)</a>
+          <strong>Stop kyuubi engine:</strong>
+          <a href={forceStopLinkUri} onclick={confirmForceStop} class="stop-link">(Force-Kill)</a>
+          <a href={gracefulStopLinkUri} onclick={confirmGracefulStop}
+             class="stop-link">(Grace-Kill)</a>
         </li>
       </ul>
     } else {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineTab.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/ui/EngineTab.scala
@@ -63,8 +63,9 @@ case class EngineTab(
   sparkUI.foreach { ui =>
     try {
       // Spark shade the jetty package so here we use reflection
+      val sparkServletContextHandlerClz = loadSparkServletContextHandler
       val attachHandlerMethod = Class.forName("org.apache.spark.ui.SparkUI")
-        .getMethod("attachHandler", classOf[org.sparkproject.jetty.servlet.ServletContextHandler])
+        .getMethod("attachHandler", sparkServletContextHandlerClz)
       val createRedirectHandlerMethod = Class.forName("org.apache.spark.ui.JettyUtils")
         .getMethod(
           "createRedirectHandler",


### PR DESCRIPTION
### _Why are the changes needed?_
Now the kill operation of the Spark engine ui will directly shut down, and the SQL that is being executed by the engine will fail. 

We can support grace stop, first log off the engine from the znode, and then wait for the SQL execution to complete.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
