### PR TITLE
Correctly calculate active stages in SQLOperationListener

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/kyuubi/SQLOperationListener.scala
@@ -144,7 +144,7 @@ class SQLOperationListener(
 
   override def onTaskStart(taskStart: SparkListenerTaskStart): Unit = activeStages.synchronized {
     val stageAttempt = StageAttempt(taskStart.stageId, taskStart.stageAttemptId)
-    if (activeStages.contains(stageAttempt)) {
+    if (activeStages.containsKey(stageAttempt)) {
       activeStages.get(stageAttempt).numActiveTasks += 1
       super.onTaskStart(taskStart)
     }
@@ -152,7 +152,7 @@ class SQLOperationListener(
 
   override def onTaskEnd(taskEnd: SparkListenerTaskEnd): Unit = activeStages.synchronized {
     val stageAttempt = StageAttempt(taskEnd.stageId, taskEnd.stageAttemptId)
-    if (activeStages.contains(stageAttempt)) {
+    if (activeStages.containsKey(stageAttempt)) {
       activeStages.get(stageAttempt).numActiveTasks -= 1
       if (taskEnd.reason == org.apache.spark.Success) {
         activeStages.get(stageAttempt).numCompleteTasks += 1


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Code of Conduct_
- [x] I agree to follow this project's [Code of Conduct](https://www.apache.org/foundation/policies/conduct)


### _Search before asking_
- [x] I have searched in the [issues](https://github.com/apache/incubator-kyuubi/issues?q=is%3Aissue) and found no similar issues.

### _Describe the bug_
activeStages key is StageAttempt, and its value is StageInfo. The contains function defaults to 'containsValue'

### _Affects Version(s)_
master/1.7/1.6

### _Are you willing to submit PR?_
- [x] Yes. I can submit a PR independently to fix.
- [ ] Yes. I would be willing to submit a PR with guidance from the Kyuubi community to fix.
- [ ] No. I cannot submit a PR at this time.

