### PR TITLE
[KYUUBI #3818] [Subtask] [PySpark] set local properties to spark context for python scripts

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -67,12 +67,12 @@ class ExecutePython(
   override protected def withLocalProperties[T](f: => T): T = {
     try {
       worker.runCode(s"spark.sparkContext.setLocalProperty(" +
-        s"'${KYUUBI_SESSION_USER_KEY}', '${session.user}')")
+        s"'$KYUUBI_SESSION_USER_KEY', '${session.user}')")
 
       f
     } finally {
       worker.runCode(s"spark.sparkContext.setLocalProperty(" +
-        s"'${KYUUBI_SESSION_USER_KEY}', '')")
+        s"'$KYUUBI_SESSION_USER_KEY', '')")
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -68,7 +68,6 @@ class ExecutePython(
     val setSparkLocalProperties = (key: String, value: String) => {
       worker.runCode(s"spark.sparkContext.setLocalProperty('$key', '$value')")
     }
-
     try {
       setSparkLocalProperties(KYUUBI_SESSION_USER_KEY, session.user)
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -65,14 +65,16 @@ class ExecutePython(
   }
 
   override protected def withLocalProperties[T](f: => T): T = {
+    val setSparkLocalProperties = (key: String, value: String) => {
+      worker.runCode(s"spark.sparkContext.setLocalProperty('$key', '$value')")
+    }
+
     try {
-      worker.runCode(s"spark.sparkContext.setLocalProperty(" +
-        s"'$KYUUBI_SESSION_USER_KEY', '${session.user}')")
+      setSparkLocalProperties(KYUUBI_SESSION_USER_KEY, session.user)
 
       f
     } finally {
-      worker.runCode(s"spark.sparkContext.setLocalProperty(" +
-        s"'$KYUUBI_SESSION_USER_KEY', '')")
+      setSparkLocalProperties(KYUUBI_SESSION_USER_KEY, "")
     }
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -32,7 +32,8 @@ import org.apache.spark.sql.{Row, RuntimeConfig}
 import org.apache.spark.sql.types.StructType
 
 import org.apache.kyuubi.Logging
-import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_USER_KEY
+import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_USER_KEY, KYUUBI_STATEMENT_ID_KEY}
+import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.SPARK_SCHEDULER_POOL_KEY
 import org.apache.kyuubi.operation.ArrayFetchIterator
 import org.apache.kyuubi.session.Session
 
@@ -69,14 +70,24 @@ class ExecutePython(
       worker.runCode(s"spark.sparkContext.setLocalProperty('$key', '$value')")
     }
     try {
+      worker.runCode("spark.sparkContext.setJobGroup" +
+        s"($statementId, $redactedStatement, $forceCancel)")
       setSparkLocalProperties(KYUUBI_SESSION_USER_KEY, session.user)
+      setSparkLocalProperties(KYUUBI_STATEMENT_ID_KEY, statementId)
+      schedulerPool match {
+        case Some(pool) =>
+          setSparkLocalProperties(SPARK_SCHEDULER_POOL_KEY, pool)
+        case None =>
+      }
 
       f
     } finally {
       setSparkLocalProperties(KYUUBI_SESSION_USER_KEY, "")
+      setSparkLocalProperties(KYUUBI_STATEMENT_ID_KEY, "")
+      setSparkLocalProperties(SPARK_SCHEDULER_POOL_KEY, "")
+      worker.runCode("spark.sparkContext.clearJobGroup()")
     }
   }
-
 }
 
 case class SessionPythonWorker(

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -66,10 +66,10 @@ abstract class SparkOperation(session: Session)
     }
   }
 
-  private val forceCancel =
+  protected val forceCancel =
     session.sessionManager.getConf.get(KyuubiConf.OPERATION_FORCE_CANCEL)
 
-  private val schedulerPool =
+  protected val schedulerPool =
     spark.conf.getOption(KyuubiConf.OPERATION_SCHEDULER_POOL.key).orElse(
       session.sessionManager.getConf.get(KyuubiConf.OPERATION_SCHEDULER_POOL))
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
to close #3818 .
- add `withLocalProperties` in `ExecutePython`
- set Spark local properties `kyuubi.session.user`, `kyuubi.statement.id`, `spark.scheduler.pool`, `spark.scheduler.pool` in withLocalProperties for other feature relied on it , e.g. Authz plugin.


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
