### PR TITLE
[DOCS] Authority of the documentation belongs to the community

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,6 +33,7 @@ import os
 import sys
 import shlex
 import subprocess
+import datetime
 
 sys.path.insert(0, os.path.abspath('.'))
 
@@ -55,24 +56,12 @@ source_parsers = {
 
 project = 'Kyuubi'
 
-copyright = '''
-Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
-this work for additional information regarding copyright ownership.
-The ASF licenses this file to You under the Apache License, Version 2.0
-(the "License"); you may not use this file except in compliance with
-the License.  You may obtain a copy of the License at
+year = datetime.datetime.now().strftime("%Y")
 
-   http://www.apache.org/licenses/LICENSE-2.0
+copyright = year + ' The Apache Software Foundation, Licensed under the Apache License, Version 2.0'
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License
-'''
 
-author = 'Kent Yao'
+author = 'Apache Kyuubi Community'
 
 # The full version, including alpha/beta/rc tags
 release = subprocess.getoutput("cd .. && build/mvn help:evaluate -Dexpression=project.version|grep -v Using|grep -v INFO|grep -v WARNING|tail -n 1").split('\n')[-1]


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

This PR changes the doc authority from Kent to Apache Kyuubi Community. Meanwhile, the footnotes for copyright/license are also simplified.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
