### PR TITLE
[KYUUBI #3441][FOLLOWUP] Change default Spark version to 3.3 in kyuubi-spark-authz, kyuubi-spark-lineage's README

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/README.md
+++ b/extensions/spark/kyuubi-spark-authz/README.md
@@ -35,8 +35,8 @@ build/mvn clean package -pl :kyuubi-spark-authz_2.12 -Dspark.version=3.2.1 -Dran
 `-Dspark.version=`
 
 - [x] master
-- [x] 3.3.x
-- [x] 3.2.x (default)
+- [x] 3.3.x (default)
+- [x] 3.2.x
 - [x] 3.1.x
 - [x] 3.0.x
 - [ ] 2.4.x and earlier

--- a/extensions/spark/kyuubi-spark-lineage/README.md
+++ b/extensions/spark/kyuubi-spark-lineage/README.md
@@ -34,6 +34,6 @@ build/mvn clean package -pl :kyuubi-spark-lineage_2.12 -Dspark.version=3.2.1
 `-Dspark.version=`
 
 - [x] master
-- [x] 3.3.x
-- [x] 3.2.x (default)
+- [x] 3.3.x (default)
+- [x] 3.2.x
 - [x] 3.1.x


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Set Apache Spark3.3 as the default in kyuubi-spark-authz, kyuubi-spark-lineage's readme documentation

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
