### PR TITLE
[KYUUBI #3840] [Improvement] Bump scalafmt to 3.6.1 and spotless maven plugin to 2.72.2

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.1.1
+version = 3.6.1
 runner.dialect=scala212
 project.git=true
 

--- a/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
+++ b/extensions/spark/kyuubi-extension-spark-common/src/main/scala/org/apache/kyuubi/sql/watchdog/ForcedMaxOutputRowsBase.scala
@@ -72,7 +72,7 @@ trait ForcedMaxOutputRowsBase extends Rule[LogicalPlan] {
   protected def canInsertLimit(p: LogicalPlan, maxOutputRowsOpt: Option[Int]): Boolean = {
     maxOutputRowsOpt match {
       case Some(forcedMaxOutputRows) => canInsertLimitInner(p) &&
-          !p.maxRows.exists(_ <= forcedMaxOutputRows)
+        !p.maxRows.exists(_ <= forcedMaxOutputRows)
       case None => false
     }
   }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -368,7 +368,6 @@ object PrivilegesBuilder {
         buildQuery(query, inputObjs)
 
       case "CreateView" => // revisit this after spark has view catalog
-
       case "CreateDataSourceTableCommand" | "CreateTableCommand" =>
         val table = getPlanField[CatalogTable]("table").identifier
         // fixme: do we need to add columns to check?

--- a/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/events/OperationLineageEvent.scala
+++ b/extensions/spark/kyuubi-spark-lineage/src/main/scala/org/apache/kyuubi/plugin/lineage/events/OperationLineageEvent.scala
@@ -35,7 +35,7 @@ class Lineage(
   override def equals(other: Any): Boolean = other match {
     case otherLineage: Lineage =>
       otherLineage.inputTables == inputTables && otherLineage.outputTables == outputTables &&
-        otherLineage.columnLineage == columnLineage
+      otherLineage.columnLineage == columnLineage
     case _ => false
   }
 

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/dialect/DorisDialect.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/dialect/DorisDialect.scala
@@ -85,7 +85,7 @@ class DorisDialect extends JdbcDialect {
 
     if (tTypes.nonEmpty) {
       filters += s"(${tTypes.map { tableType => s"$TABLE_TYPE = '$tableType'" }
-        .mkString(" OR ")})"
+          .mkString(" OR ")})"
     }
 
     if (filters.nonEmpty) {

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatusPrinter.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/TrinoStatusPrinter.scala
@@ -67,16 +67,16 @@ object TrinoStatusPrinter {
       val cpuTime = new Duration(stats.getCpuTimeMillis(), MILLISECONDS)
       val cpuTimeSummary = s"CPU Time: ${cpuTime.getValue(SECONDS).formatted("%.1f")}s total, " +
         s"${formatCountRate(
-          stats.getProcessedRows(),
-          cpuTime,
-          false).formatted("%5s")} rows/s, " +
+            stats.getProcessedRows(),
+            cpuTime,
+            false).formatted("%5s")} rows/s, " +
         s"${formatDataRate(
-          DataSize.ofBytes(stats.getProcessedBytes),
-          cpuTime,
-          true).formatted("%8s")}, " +
+            DataSize.ofBytes(stats.getProcessedBytes),
+            cpuTime,
+            true).formatted("%8s")}, " +
         s"${percentage(
-          stats.getCpuTimeMillis(),
-          stats.getWallTimeMillis()).formatted("%d")}% active"
+            stats.getCpuTimeMillis(),
+            stats.getWallTimeMillis()).formatted("%d")}% active"
       out.printLine(cpuTimeSummary)
 
       val parallelism = cpuTime.getValue(MILLISECONDS) / wallTime.getValue(MILLISECONDS)
@@ -84,13 +84,13 @@ object TrinoStatusPrinter {
       // Per Node: 3.5 parallelism, 83.3K rows/s, 0.7 MB/s
       val perNodeSummary = s"Per Node: ${(parallelism / nodes).formatted("%.1f")} parallelism, " +
         s"${formatCountRate(
-          stats.getProcessedRows().toDouble / nodes,
-          wallTime,
-          false).formatted("%5s")} rows/s, " +
+            stats.getProcessedRows().toDouble / nodes,
+            wallTime,
+            false).formatted("%5s")} rows/s, " +
         s"${formatDataRate(
-          DataSize.ofBytes(stats.getProcessedBytes() / nodes),
-          wallTime,
-          true).formatted("%8s")}"
+            DataSize.ofBytes(stats.getProcessedBytes() / nodes),
+            wallTime,
+            true).formatted("%8s")}"
       out.reprintLine(perNodeSummary)
 
       // Parallelism: 5.3

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTables.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/GetTables.scala
@@ -57,7 +57,7 @@ class GetTables(
     }
     if (tableTypes.nonEmpty) {
       filters += s"(${tableTypes.map { tableType => s"$TABLE_TYPE = '$tableType'" }
-        .mkString(" OR ")})"
+          .mkString(" OR ")})"
     }
 
     if (filters.nonEmpty) {

--- a/pom.xml
+++ b/pom.xml
@@ -2040,7 +2040,7 @@
                             </includes>
                             <scalafmt>
                                 <version>${spotless.scala.scalafmt.version}</version>
-                                <majorScalaVersion>${scala.binary.version}</majorScalaVersion>
+                                <scalaMajorVersion>${scala.binary.version}</scalaMajorVersion>
                                 <file>${maven.multiModuleProjectDirectory}/.scalafmt.conf</file>
                             </scalafmt>
                         </scala>

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
             org.scalatest.tags.Slow,org.apache.kyuubi.tags.HudiTest,org.apache.kyuubi.tags.PySparkTest
         </maven.plugin.scalatest.exclude.tags>
         <maven.plugin.scalatest.include.tags></maven.plugin.scalatest.include.tags>
-        <maven.plugin.spotless.version>2.24.1</maven.plugin.spotless.version>
+        <maven.plugin.spotless.version>2.27.2</maven.plugin.spotless.version>
         <maven.plugin.jacoco.version>0.8.7</maven.plugin.jacoco.version>
         <maven.plugin.jar.version>3.2.0</maven.plugin.jar.version>
         <maven.plugin.scalastyle.version>1.0.0</maven.plugin.scalastyle.version>
@@ -226,8 +226,10 @@
         <kyuubi.shade.packageName>org.apache.kyuubi.shade</kyuubi.shade.packageName>
 
         <!-- Needed for Spotless style check-->
+        <spotless.java.googlejavaformat.version>1.7</spotless.java.googlejavaformat.version>
         <spotless.python.includes/>
         <spotless.python.black.version>22.3.0</spotless.python.black.version>
+        <spotless.scala.scalafmt.version>3.6.1</spotless.scala.scalafmt.version>
 
         <distMgmtReleaseId>apache.releases.https</distMgmtReleaseId>
         <distMgmtReleaseName>Apache Release Distribution Repository</distMgmtReleaseName>
@@ -2026,10 +2028,10 @@
                                 <include>src/test/java/**/*.java</include>
                             </includes>
                             <googleJavaFormat>
-                                <version>1.7</version>
+                                <version>${spotless.java.googlejavaformat.version}</version>
                                 <style>GOOGLE</style>
                             </googleJavaFormat>
-                            <removeUnusedImports />
+                            <removeUnusedImports/>
                         </java>
                         <scala>
                             <includes>
@@ -2037,7 +2039,8 @@
                                 <include>src/test/scala/**/*.scala</include>
                             </includes>
                             <scalafmt>
-                                <version>3.1.1</version>
+                                <version>${spotless.scala.scalafmt.version}</version>
+                                <majorScalaVersion>${scala.binary.version}</majorScalaVersion>
                                 <file>${maven.multiModuleProjectDirectory}/.scalafmt.conf</file>
                             </scalafmt>
                         </scala>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
to close #3840.

- bump scalafmt from 3.1.1 to 3.6.1 
- bump spotless maven plugin from 2.41.1 to 2.72.2
- add `scalaMajorVersion` setting to spotless plugin configs


### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
