### PR TITLE
[K8S] Add service account name in values.yaml to config kyuubi's serviceAccountName in helm template file

### DIFF
--- a/docker/helm/templates/kyuubi-deployment.yaml
+++ b/docker/helm/templates/kyuubi-deployment.yaml
@@ -35,6 +35,9 @@ spec:
         app: {{ template "kyuubi.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.serviceAccount }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end}}
       containers:
         - name: kyuubi-server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/docker/helm/values.yaml
+++ b/docker/helm/values.yaml
@@ -28,6 +28,10 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: "master-snapshot"
 
+# ServiceAccount used for Kyuubi create/list/delete pod in kubernetes
+serviceAccount:
+  name: default
+
 probe:
   liveness:
     enabled: true


### PR DESCRIPTION

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
For kyuubi run in kubernetes, kyuubi need permissions to create/list/delete pods.

Kubernetes provides serviceAccountName for quick configuration of permissions(Get details in [RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)).

Add `serviceAccoutName` to the values.yaml file to help users add configurations without changing the template file.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request

![WX20221128-114911](https://user-images.githubusercontent.com/52876270/204190111-b463239f-0427-4197-b3b4-e2a3a0bdf7ad.png)