### PR TITLE
[KYUUBI #3885][1.6] Fix memory leak when using incremental collect mode

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecuteStatement.scala
@@ -95,7 +95,9 @@ class ExecuteStatement(
       iter =
         if (incrementalCollect) {
           info("Execute in incremental collect mode")
-          new IterableFetchIterator[Row](result.toLocalIterator().asScala.toIterable)
+          new IterableFetchIterator[Row](new Iterable[Row] {
+            override def iterator: Iterator[Row] = result.toLocalIterator().asScala
+          })
         } else {
           val resultMaxRows = spark.conf.getOption(OPERATION_RESULT_MAX_ROWS.key).map(_.toInt)
             .getOrElse(session.sessionManager.getConf.get(OPERATION_RESULT_MAX_ROWS))

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkOperationSuite.scala
@@ -31,6 +31,7 @@ import org.apache.spark.kyuubi.SparkContextHelper
 import org.apache.spark.sql.catalyst.analysis.FunctionRegistry
 import org.apache.spark.sql.types._
 
+import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.engine.SemanticVersion
 import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
 import org.apache.kyuubi.engine.spark.schema.SchemaHelper.TIMESTAMP_NTZ
@@ -330,6 +331,53 @@ class SparkOperationSuite extends WithSparkSQLEngine with HiveMetadataTests with
       assert(tFetchResultsResp4.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
       val idSeq4 = tFetchResultsResp4.getResults.getColumns.get(0).getI64Val.getValues.asScala.toSeq
       assertResult(Seq(0L, 1L))(idSeq4)
+    }
+  }
+
+  test("test fetch orientation with incremental collect mode") {
+    val sql = "SELECT id FROM range(2)"
+
+    withSessionConf(Map(KyuubiConf.OPERATION_INCREMENTAL_COLLECT.key -> "true"))()() {
+      withSessionHandle { (client, handle) =>
+        val req = new TExecuteStatementReq()
+        req.setSessionHandle(handle)
+        req.setStatement(sql)
+        val tExecuteStatementResp = client.ExecuteStatement(req)
+        val opHandle = tExecuteStatementResp.getOperationHandle
+        waitForOperationToComplete(client, opHandle)
+
+        // fetch next from before first row
+        val tFetchResultsReq1 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_NEXT, 1)
+        val tFetchResultsResp1 = client.FetchResults(tFetchResultsReq1)
+        assert(tFetchResultsResp1.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq1 = tFetchResultsResp1.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala.toSeq
+        assertResult(Seq(0L))(idSeq1)
+
+        // fetch next from first row
+        val tFetchResultsReq2 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_NEXT, 1)
+        val tFetchResultsResp2 = client.FetchResults(tFetchResultsReq2)
+        assert(tFetchResultsResp2.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq2 = tFetchResultsResp2.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala.toSeq
+        assertResult(Seq(1L))(idSeq2)
+
+        // fetch prior from second row, expected got first row
+        val tFetchResultsReq3 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_PRIOR, 1)
+        val tFetchResultsResp3 = client.FetchResults(tFetchResultsReq3)
+        assert(tFetchResultsResp3.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq3 = tFetchResultsResp3.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala.toSeq
+        assertResult(Seq(0L))(idSeq3)
+
+        // fetch first
+        val tFetchResultsReq4 = new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_FIRST, 3)
+        val tFetchResultsResp4 = client.FetchResults(tFetchResultsReq4)
+        assert(tFetchResultsResp4.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq4 = tFetchResultsResp4.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala.toSeq
+        assertResult(Seq(0L, 1L))(idSeq4)
+      }
     }
   }
 


### PR DESCRIPTION
Fix memory leak when using incremental mode.

FYI: https://stackoverflow.com/questions/45649044/scala-stream-iterate-and-memory-management

- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [X] Add screenshots for manual tests if appropriate before:
![111](https://user-images.githubusercontent.com/17894939/205069225-b41260f3-c53c-44fd-85bc-ab6712ceb5a1.png) after:
![222](https://user-images.githubusercontent.com/17894939/205069251-1ef0bfe4-c964-42b1-9861-8f774f3afd05.png)

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request

Closes #3885 from wForget/dev.

Closes #3885

4f1b1bffb [wForget] add test
129ac1efa [wForget] Fix memory leak when using incremental mode

Authored-by: wForget <643348094@qq.com>
Signed-off-by: fwang12 <fwang12@ebay.com>