### PR TITLE
Fallback to SQL language mode if fail to init python environment and fix log

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -34,7 +34,7 @@ import org.apache.spark.api.python.KyuubiPythonGatewayServer
 import org.apache.spark.sql.{Row, SparkSession}
 import org.apache.spark.sql.types.StructType
 
-import org.apache.kyuubi.Logging
+import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_PYTHON_ENV_ARCHIVE, ENGINE_SPARK_PYTHON_ENV_ARCHIVE_EXEC_PATH, ENGINE_SPARK_PYTHON_HOME_ARCHIVE}
 import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_USER_KEY, KYUUBI_STATEMENT_ID_KEY}
 import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.SPARK_SCHEDULER_POOL_KEY
@@ -154,7 +154,7 @@ object ExecutePython extends Logging {
   final val DEFAULT_SPARK_PYTHON_ENV_ARCHIVE_FRAGMENT = "__kyuubi_spark_python_env__"
 
   private val isPythonGatewayStart = new AtomicBoolean(false)
-  private val kyuubiPythonPath = Files.createTempDirectory("")
+  private val kyuubiPythonPath = Utils.createTempDir()
   def init(): Unit = {
     if (!isPythonGatewayStart.get()) {
       synchronized {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkSQLOperationManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkSQLOperationManager.scala
@@ -90,11 +90,19 @@ class SparkSQLOperationManager private (name: String) extends OperationManager(n
           val repl = sessionToRepl.getOrElseUpdate(session.handle, KyuubiSparkILoop(spark))
           new ExecuteScala(session, repl, statement)
         case OperationLanguages.PYTHON =>
-          ExecutePython.init()
-          val worker = sessionToPythonProcess.getOrElseUpdate(
-            session.handle,
-            ExecutePython.createSessionPythonWorker(spark, session))
-          new ExecutePython(session, statement, worker)
+          try {
+            ExecutePython.init()
+            val worker = sessionToPythonProcess.getOrElseUpdate(
+              session.handle,
+              ExecutePython.createSessionPythonWorker(spark, session))
+            new ExecutePython(session, statement, worker)
+          } catch {
+            case e: Throwable =>
+              spark.conf.set(OPERATION_LANGUAGE.key, OperationLanguages.SQL.toString)
+              throw KyuubiSQLException(
+                s"Failed to init python environment, fall back to SQL language mode",
+                e)
+          }
         case OperationLanguages.UNKNOWN =>
           spark.conf.unset(OPERATION_LANGUAGE.key)
           throw KyuubiSQLException(s"The operation language $lang" +

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkSQLOperationManager.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkSQLOperationManager.scala
@@ -100,7 +100,7 @@ class SparkSQLOperationManager private (name: String) extends OperationManager(n
             case e: Throwable =>
               spark.conf.set(OPERATION_LANGUAGE.key, OperationLanguages.SQL.toString)
               throw KyuubiSQLException(
-                s"Failed to init python environment, fall back to SQL language mode",
+                s"Failed to init python environment, fall back to SQL mode: ${e.getMessage}",
                 e)
           }
         case OperationLanguages.UNKNOWN =>

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/api/python/KyuubiPythonGatewayServer.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/spark/api/python/KyuubiPythonGatewayServer.scala
@@ -24,9 +24,11 @@ import java.nio.file.Files
 import org.apache.spark.SparkConf
 import org.apache.spark.internal.Logging
 
+import org.apache.kyuubi.Utils
+
 object KyuubiPythonGatewayServer extends Logging {
 
-  val CONNECTION_FILE_PATH = Files.createTempDirectory("") + "/connection.info"
+  val CONNECTION_FILE_PATH = Utils.createTempDir() + "/connection.info"
 
   def start(): Unit = {
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Now, if failed to init python environment, we have to re-create the connection.

In this pr, it will fallback to SQL language mode for above case.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="1522" alt="image" src="https://user-images.githubusercontent.com/6757692/205556516-f8b87c3e-34ae-441f-ae42-ba4e3df9e0a4.png">


<img width="1416" alt="image" src="https://user-images.githubusercontent.com/6757692/205554712-0f399d7a-cab8-4fcb-a0f7-4f978bfb3d19.png">

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
