### PR TITLE
Support windows generate `kyuubi-version-info.properties`

### DIFF
--- a/build/kyuubi-build-info.cmd
+++ b/build/kyuubi-build-info.cmd
@@ -1,0 +1,50 @@
+@echo off
+
+rem
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem    http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+rem
+
+SET EXTRA_RESOURCE_DIR=%~1
+IF NOT EXIST "%EXTRA_RESOURCE_DIR%" MKDIR "%EXTRA_RESOURCE_DIR%"
+SET BUILD_INFO="%EXTRA_RESOURCE_DIR%"\kyuubi-version-info.properties
+CALL :echo_build_properties %* > "%BUILD_INFO%"
+
+EXIT /B %ERRORLEVEL%
+
+:echo_build_properties
+echo kyuubi_version=%~2
+echo kyuubi_java_version=%~3
+echo kyuubi_scala_version=%~4
+echo kyuubi_spark_version=%~5
+echo kyuubi_hive_version=%~6
+echo kyuubi_hadoop_version=%~7
+echo kyuubi_flink_version=%~8
+echo kyuubi_trino_version=%~9
+echo user=%username%
+
+FOR /F %%i IN ('git rev-parse HEAD') DO SET "revision=%%i"
+FOR /F %%i IN ('git rev-parse --abbrev-ref HEAD') DO SET "branch=%%i"
+FOR /F %%i IN ('git config --get remote.origin.url') DO SET "url=%%i"
+
+FOR /f %%i IN ('date /t') DO SET current_date=%%i
+FOR /f %%i IN ("%TIME%") DO SET current_time=%%i
+set date=%current_date%_%current_time%
+
+echo revision=%revision%
+echo branch=%branch%
+echo date=%date%
+echo url=%url%
+GOTO:EOF

--- a/kyuubi-common/pom.xml
+++ b/kyuubi-common/pom.xml
@@ -186,8 +186,22 @@
                         <phase>generate-resources</phase>
                         <configuration>
                             <target>
-                                <exec executable="bash">
+                                <exec executable="bash" osfamily="unix">
                                     <arg value="${project.basedir}/../build/kyuubi-build-info"></arg>
+                                    <arg value="${project.build.directory}/extra-resources"></arg>
+                                    <arg value="${project.version}"></arg>
+                                    <arg value="${java.version}"></arg>
+                                    <arg value="${scala.binary.version}"></arg>
+                                    <arg value="${spark.version}"></arg>
+                                    <arg value="${hive.version}"></arg>
+                                    <arg value="${hadoop.version}"></arg>
+                                    <arg value="${flink.version}"></arg>
+                                    <arg value="${trino.client.version}"></arg>
+                                </exec>
+
+                                <exec executable="cmd.exe" osfamily="windows">
+                                    <arg value="/c"></arg>
+                                    <arg value="${project.basedir}/../build/kyuubi-build-info.cmd"></arg>
                                     <arg value="${project.build.directory}/extra-resources"></arg>
                                     <arg value="${project.version}"></arg>
                                     <arg value="${java.version}"></arg>


### PR DESCRIPTION
### _Why are the changes needed?_
#3847

Windows users need to generate `kyuubi-version-info.properties` to debug.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
