### PR TITLE
[IT][CI] CI build kyuubi docker image should using mvn_args to speed up 

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -342,7 +342,7 @@ jobs:
           # passthrough CI into build container
           build-args: |
             CI=${CI} 
-            MVN_ARG="-Pflink-provided,spark-provided,hive-provided -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests"
+            MVN_ARG="-Pflink-provided,hive-provided -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests"
           context: .
           file: build/Dockerfile
           load: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -342,7 +342,7 @@ jobs:
           # passthrough CI into build container
           build-args: |
             CI=${CI} 
-            MVN_ARG="-Pflink-provided,hive-provided -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests"
+            MVN_ARG="--flink-provided --hive-provided -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests"
           context: .
           file: build/Dockerfile
           load: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -340,7 +340,9 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           # passthrough CI into build container
-          build-args: CI=${CI}
+          build-args: |
+            CI=${CI} 
+            MVN_ARG="-Pflink-provided,spark-provided,hive-provided -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests"
           context: .
           file: build/Dockerfile
           load: true

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -342,7 +342,7 @@ jobs:
           # passthrough CI into build container
           build-args: |
             CI=${CI} 
-            MVN_ARG="--flink-provided --hive-provided -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests"
+            MVN_ARG=--flink-provided --hive-provided -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -DskipTests
           context: .
           file: build/Dockerfile
           load: true


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
CI using `build/dockerfile` to build kyuubi docker image, which will build distribution frist.

We should pass servals maven args to help build speed up.

We only test spark engine for kyuubi on kubernetes it test, so we use hive and flink provided.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request

- [x] Wait CI
