### PR TITLE
Support to use builtin spark python lib with spark.yarn.isPython

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
@@ -34,7 +34,7 @@ os.environ["PYSPARK_PYTHON"] = os.environ.get("PYSPARK_PYTHON", sys.executable)
 
 if "pyspark" not in sys.modules:
     py4j_path = os.environ.get("PY4J_PATH")
-    if py4j_path  is not None:
+    if py4j_path is not None:
         sys.path[:0] = sys_path = [py4j_path]
     else:
         spark_home = os.environ.get("SPARK_HOME", "")

--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
@@ -33,6 +33,7 @@ os.environ["PYSPARK_PYTHON"] = os.environ.get("PYSPARK_PYTHON", sys.executable)
 # add pyspark to sys.path
 
 if "pyspark" not in sys.modules:
+    # try to get PY4J_PATH and use it directly if not none
     py4j_path = os.environ.get("PY4J_PATH")
     if py4j_path is not None:
         sys.path[:0] = sys_path = [py4j_path]

--- a/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
+++ b/externals/kyuubi-spark-sql-engine/src/main/resources/python/execute_python.py
@@ -28,22 +28,26 @@ from glob import glob
 if sys.version_info[0] < 3:
     sys.exit("Python < 3 is unsupported.")
 
-spark_home = os.environ.get("SPARK_HOME", "")
 os.environ["PYSPARK_PYTHON"] = os.environ.get("PYSPARK_PYTHON", sys.executable)
 
 # add pyspark to sys.path
 
 if "pyspark" not in sys.modules:
-    spark_python = os.path.join(spark_home, "python")
-    try:
-        py4j = glob(os.path.join(spark_python, "lib", "py4j-*.zip"))[0]
-    except IndexError:
-        raise Exception(
-            "Unable to find py4j in {}, your SPARK_HOME may not be configured correctly".format(
-                spark_python
+    py4j_path = os.environ.get("PY4J_PATH")
+    if py4j_path  is not None:
+        sys.path[:0] = sys_path = [py4j_path]
+    else:
+        spark_home = os.environ.get("SPARK_HOME", "")
+        spark_python = os.path.join(spark_home, "python")
+        try:
+            py4j = glob(os.path.join(spark_python, "lib", "py4j-*.zip"))[0]
+        except IndexError:
+            raise Exception(
+                "Unable to find py4j in {}, your SPARK_HOME may not be configured correctly".format(
+                    spark_python
+                )
             )
-        )
-    sys.path[:0] = sys_path = [spark_python, py4j]
+        sys.path[:0] = sys_path = [spark_python, py4j]
 else:
     # already imported, no need to patch sys.path
     sys_path = None

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -37,7 +37,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.config.KyuubiConf.{ENGINE_SPARK_PYTHON_ENV_ARCHIVE, ENGINE_SPARK_PYTHON_ENV_ARCHIVE_EXEC_PATH, ENGINE_SPARK_PYTHON_HOME_ARCHIVE}
 import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_USER_KEY, KYUUBI_STATEMENT_ID_KEY}
-import org.apache.kyuubi.engine.spark.KyuubiSparkUtil.SPARK_SCHEDULER_POOL_KEY
+import org.apache.kyuubi.engine.spark.KyuubiSparkUtil._
 import org.apache.kyuubi.operation.ArrayFetchIterator
 import org.apache.kyuubi.operation.log.OperationLog
 import org.apache.kyuubi.session.Session
@@ -69,6 +69,7 @@ class ExecutePython(
 
   override protected def runInternal(): Unit = withLocalProperties {
     try {
+      info(diagnostics)
       val response = worker.runCode(statement)
       val output = response.map(_.content.getOutput()).getOrElse("")
       val status = response.map(_.content.status).getOrElse("UNKNOWN_STATUS")
@@ -152,6 +153,9 @@ case class SessionPythonWorker(
 object ExecutePython extends Logging {
   final val DEFAULT_SPARK_PYTHON_HOME_ARCHIVE_FRAGMENT = "__kyuubi_spark_python_home__"
   final val DEFAULT_SPARK_PYTHON_ENV_ARCHIVE_FRAGMENT = "__kyuubi_spark_python_env__"
+  final val PY4J_REGEX = "py4j-[\\S]*.zip$".r
+  final val PY4J_PATH = "PY4J_PATH"
+  final val IS_PYTHON_APP_KEY = "spark.yarn.isPython"
 
   private val isPythonGatewayStart = new AtomicBoolean(false)
   private val kyuubiPythonPath = Utils.createTempDir()
@@ -184,11 +188,17 @@ object ExecutePython extends Logging {
       .split(File.pathSeparator)
       .++(ExecutePython.kyuubiPythonPath.toString)
     env.put("PYTHONPATH", pythonPath.mkString(File.pathSeparator))
-    env.put(
-      "SPARK_HOME",
-      sys.env.getOrElse(
+    pythonPath.mkString(File.pathSeparator)
+      .split(File.pathSeparator)
+      .find(PY4J_REGEX.findFirstMatchIn(_).nonEmpty)
+      .foreach(env.put(PY4J_PATH, _))
+    if (!spark.sparkContext.getConf.getBoolean(IS_PYTHON_APP_KEY, false)) {
+      env.put(
         "SPARK_HOME",
-        getSparkPythonHomeFromArchive(spark, session).getOrElse(defaultSparkHome)))
+        sys.env.getOrElse(
+          "SPARK_HOME",
+          getSparkPythonHomeFromArchive(spark, session).getOrElse(defaultSparkHome)))
+    }
     env.put("PYTHON_GATEWAY_CONNECTION_INFO", KyuubiPythonGatewayServer.CONNECTION_FILE_PATH)
     logger.info(
       s"""

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/ExecutePython.scala
@@ -188,6 +188,7 @@ object ExecutePython extends Logging {
       .split(File.pathSeparator)
       .++(ExecutePython.kyuubiPythonPath.toString)
     env.put("PYTHONPATH", pythonPath.mkString(File.pathSeparator))
+    // try to find py4j lib from `PYTHONPATH` and set env `PY4J_PATH` into process if found
     pythonPath.mkString(File.pathSeparator)
       .split(File.pathSeparator)
       .find(PY4J_REGEX.findFirstMatchIn(_).nonEmpty)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
If master is yarn and `spark.yarn.isPython` is true, spark will submit the builtin python lib(including pyspark.zip and py4j-*.zip) by default.

Support to use builtin spark python lib with `spark.yarn.isPython`.

- try to get the py4j lib from `PYTHONPATH` and set it as the value of `PY4J_PATH` for the python process
- if `spark.yarn.isPython` is true, SPARK_HOME is not needed to set
- get the PY4J_PATH if set in `execute_python.py` 

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [x] Add screenshots for manual tests if appropriate
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/6757692/205811759-b2bc3734-96c6-492c-875c-a5c273b9f58b.png">
<img width="1336" alt="image" src="https://user-images.githubusercontent.com/6757692/205823571-87830b6c-53a0-4f5f-bad3-c28d890bcaa3.png">

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
