### PR TITLE
[KYUUBI #3385] Set executor pod name prefix if missing in spark on k8s case

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -353,7 +353,7 @@ object SparkSQLEngine extends Logging {
     val resolvedUserName = userName.replaceAll(pattern, "-")
     val podNamePrefixWithUser = s"kyuubi-$resolvedUserName-${Instant.now().toEpochMilli}"
     if (podNamePrefixWithUser.length >= 237) {
-      s"kyuubi-${UUID.randomUUID().toString}"
+      s"kyuubi-${UUID.randomUUID()}"
     } else {
       podNamePrefixWithUser
     }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -360,14 +360,14 @@ object SparkSQLEngine extends Logging {
         .replaceAll("-+", "-")
         .replaceAll("^-", "")
     val podNamePrefixWithUser = s"kyuubi-$resolvedUserName-${Instant.now().toEpochMilli}"
-    if (podNamePrefixWithUser.length >= EXECUTOR_POD_NAME_PREFIX_MAX_LENGTH) {
-      s"kyuubi-${UUID.randomUUID()}"
-    } else {
+    if (podNamePrefixWithUser.length <= EXECUTOR_POD_NAME_PREFIX_MAX_LENGTH) {
       podNamePrefixWithUser
+    } else {
+      s"kyuubi-${UUID.randomUUID()}"
     }
   }
 
   // Kubernetes pod name max length - '-exec-' - Int.MAX_VALUE.length
   // 253 - 10 - 6
-  private val EXECUTOR_POD_NAME_PREFIX_MAX_LENGTH = 237
+  val EXECUTOR_POD_NAME_PREFIX_MAX_LENGTH = 237
 }

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineSuite.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark
+
+import org.apache.kyuubi.KyuubiFunSuite
+
+class SparkSQLEngineSuite extends KyuubiFunSuite {
+  private val EXECUTOR_POD_NAME_PREFIX_MAX_LENGTH = 237
+
+  test("[KYUUBI #3385] generate executor pod name prefix with user or UUID") {
+
+    val userName1 = "/kyuubi_user+-*"
+    val executorPodNamePrefix1 = SparkSQLEngine.generateExecutorPodNamePrefixForK8s(userName1)
+    assert(executorPodNamePrefix1.contains("-kyuubi-user-"))
+
+    val userName2 = "LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLong" +
+      "LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLong" +
+      "LongLongLongLongLongLongLongLongLongLongLongLongLongLongLongLong" +
+      "LongLongLongLongLongLongLongLongLongLongLongLongName"
+    val executorPodNamePrefix2 = SparkSQLEngine.generateExecutorPodNamePrefixForK8s(userName2)
+    assert(!executorPodNamePrefix2.contains(userName2))
+    assert(executorPodNamePrefix2.length <= EXECUTOR_POD_NAME_PREFIX_MAX_LENGTH)
+  }
+}

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/SparkSQLEngineSuite.scala
@@ -20,10 +20,8 @@ package org.apache.kyuubi.engine.spark
 import org.apache.kyuubi.KyuubiFunSuite
 
 class SparkSQLEngineSuite extends KyuubiFunSuite {
-  private val EXECUTOR_POD_NAME_PREFIX_MAX_LENGTH = 237
 
   test("[KYUUBI #3385] generate executor pod name prefix with user or UUID") {
-
     val userName1 = "/kyuubi_user+-*"
     val executorPodNamePrefix1 = SparkSQLEngine.generateExecutorPodNamePrefixForK8s(userName1)
     assert(executorPodNamePrefix1.contains("-kyuubi-user-"))
@@ -34,6 +32,6 @@ class SparkSQLEngineSuite extends KyuubiFunSuite {
       "LongLongLongLongLongLongLongLongLongLongLongLongName"
     val executorPodNamePrefix2 = SparkSQLEngine.generateExecutorPodNamePrefixForK8s(userName2)
     assert(!executorPodNamePrefix2.contains(userName2))
-    assert(executorPodNamePrefix2.length <= EXECUTOR_POD_NAME_PREFIX_MAX_LENGTH)
+    assert(executorPodNamePrefix2.length <= SparkSQLEngine.EXECUTOR_POD_NAME_PREFIX_MAX_LENGTH)
   }
 }

--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/WithKyuubiServerOnKubernetes.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/WithKyuubiServerOnKubernetes.scala
@@ -24,8 +24,8 @@ import org.apache.kyuubi.KyuubiFunSuite
 
 trait WithKyuubiServerOnKubernetes extends KyuubiFunSuite {
   protected def connectionConf: Map[String, String] = Map.empty
-  private val miniKubernetesClient: DefaultKubernetesClient = MiniKube.getKubernetesClient
 
+  lazy val miniKubernetesClient: DefaultKubernetesClient = MiniKube.getKubernetesClient
   lazy val kyuubiPod: Pod = miniKubernetesClient.pods().withName("kyuubi-test").get()
   lazy val kyuubiServerIp: String = kyuubiPod.getStatus.getPodIP
   lazy val miniKubeIp: String = MiniKube.getIp

--- a/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/deployment/KyuubiOnKubernetesTestsSuite.scala
+++ b/integration-tests/kyuubi-kubernetes-it/src/test/scala/org/apache/kyuubi/kubernetes/test/deployment/KyuubiOnKubernetesTestsSuite.scala
@@ -79,12 +79,21 @@ class KyuubiOnKubernetesWithClientSparkTestsSuite
     super.connectionConf ++ Map(
       "spark.submit.deployMode" -> "client",
       "spark.driver.host" -> kyuubiServerIp,
-      "kyuubi.frontend.connection.url.use.hostname" -> "false")
+      "kyuubi.frontend.connection.url.use.hostname" -> "false",
+      "spark.kubernetes.executor.label.kyuubi-it-test" -> "client")
   }
 
   override protected def jdbcUrl: String = getJdbcUrl(connectionConf)
 
-  override protected lazy val user: String = "client"
+  override protected lazy val user: String = "kyuubi_user"
+
+  test("[KYUUBI #3385] Set executor pod name prefix if missing in spark on k8s case") {
+    miniKubernetesClient.pods().withLabel(
+      "spark.kubernetes.executor.label.kyuubi-it-test",
+      "client").list().getItems.forEach(pod => {
+      assert(pod.getMetadata.getName.contains("kyuubi-user"))
+    })
+  }
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
See more in #3590
For #3590 this PR is reverted, and author not reply for long time.
Fix this issue #3385 here.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
