### PR TITLE
[KYUUBI #3915] Client support detecting ResultSet codec

### DIFF
--- a/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperation.scala
+++ b/externals/kyuubi-flink-sql-engine/src/main/scala/org/apache/kyuubi/engine/flink/operation/FlinkOperation.scala
@@ -23,7 +23,7 @@ import scala.collection.JavaConverters.collectionAsScalaIterableConverter
 
 import org.apache.flink.table.client.gateway.Executor
 import org.apache.flink.table.client.gateway.context.SessionContext
-import org.apache.hive.service.rpc.thrift.{TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet, TTableSchema}
 
 import org.apache.kyuubi.{KyuubiSQLException, Utils}
 import org.apache.kyuubi.engine.flink.result.ResultSet
@@ -74,12 +74,15 @@ abstract class FlinkOperation(session: Session) extends AbstractOperation(sessio
     }
   }
 
-  override def getResultSetSchema: TTableSchema = {
+  override def getResultSetMetadata: TGetResultSetMetadataResp = {
     val tTableSchema = new TTableSchema()
     resultSet.getColumns.asScala.zipWithIndex.foreach { case (f, i) =>
       tTableSchema.addToColumns(RowSet.toTColumnDesc(f, i))
     }
-    tTableSchema
+    val resp = new TGetResultSetMetadataResp
+    resp.setSchema(tTableSchema)
+    resp.setStatus(OK_STATUS)
+    resp
   }
 
   override def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet = {

--- a/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperation.scala
+++ b/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperation.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.Future
 
 import org.apache.hive.service.cli.operation.{Operation, OperationManager}
 import org.apache.hive.service.cli.session.{HiveSession, SessionManager => HiveSessionManager}
-import org.apache.hive.service.rpc.thrift.{TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet, TTableSchema}
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.engine.hive.session.HiveSessionImpl
@@ -84,8 +84,12 @@ abstract class HiveOperation(session: Session) extends AbstractOperation(session
       Option(status.getOperationException).map(KyuubiSQLException(_)))
   }
 
-  override def getResultSetSchema: TTableSchema = {
-    internalHiveOperation.getResultSetSchema.toTTableSchema
+  override def getResultSetMetadata: TGetResultSetMetadataResp = {
+    val schema = internalHiveOperation.getResultSetSchema.toTTableSchema
+    val resp = new TGetResultSetMetadataResp
+    resp.setSchema(schema)
+    resp.setStatus(OK_STATUS)
+    resp
   }
 
   override def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet = {

--- a/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperation.scala
+++ b/externals/kyuubi-hive-sql-engine/src/main/scala/org/apache/kyuubi/engine/hive/operation/HiveOperation.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.Future
 
 import org.apache.hive.service.cli.operation.{Operation, OperationManager}
 import org.apache.hive.service.cli.session.{HiveSession, SessionManager => HiveSessionManager}
-import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet}
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.engine.hive.session.HiveSessionImpl

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.kyuubi.engine.jdbc.operation
 
-import org.apache.hive.service.rpc.thrift.{TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet, TTableSchema}
 
 import org.apache.kyuubi.{KyuubiSQLException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
@@ -100,9 +100,13 @@ abstract class JdbcOperation(session: Session) extends AbstractOperation(session
       getProtocolVersion)
   }
 
-  override def getResultSetSchema: TTableSchema = {
+  override def getResultSetMetadata: TGetResultSetMetadataResp = {
     val schemaHelper = dialect.getSchemaHelper()
-    schemaHelper.toTTTableSchema(schema.columns)
+    val tTableSchema = schemaHelper.toTTTableSchema(schema.columns)
+    val resp = new TGetResultSetMetadataResp
+    resp.setSchema(tTableSchema)
+    resp.setStatus(OK_STATUS)
+    resp
   }
 
   override def shouldRunAsync: Boolean = false

--- a/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
+++ b/externals/kyuubi-jdbc-engine/src/main/scala/org/apache/kyuubi/engine/jdbc/operation/JdbcOperation.scala
@@ -16,7 +16,7 @@
  */
 package org.apache.kyuubi.engine.jdbc.operation
 
-import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet}
 
 import org.apache.kyuubi.{KyuubiSQLException, Utils}
 import org.apache.kyuubi.config.KyuubiConf

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -208,8 +208,8 @@ abstract class SparkOperation(session: Session)
 
   protected def arrowEnabled(): Boolean = {
     resultCodec().equalsIgnoreCase("arrow") &&
-      // TODO: (fchen) make all operation support arrow
-      getClass.getCanonicalName == classOf[ExecuteStatement].getCanonicalName
+    // TODO: (fchen) make all operation support arrow
+    getClass.getCanonicalName == classOf[ExecuteStatement].getCanonicalName
   }
 
   protected def resultCodec(): String = {

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/SparkOperation.scala
@@ -213,6 +213,7 @@ abstract class SparkOperation(session: Session)
   }
 
   protected def resultCodec(): String = {
+    // TODO: respect the config of the operation ExecuteStatement, if it was set.
     spark.conf.get("kyuubi.operation.result.codec", "simple")
   }
 

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -39,8 +39,6 @@ class SparkSessionImpl(
     val spark: SparkSession)
   extends AbstractSession(protocol, user, password, ipAddress, conf, sessionManager) {
 
-  protected var resultCodec: String = null
-
   private def setModifiableConfig(key: String, value: String): Unit = {
     try {
       spark.conf.set(key, value)
@@ -101,13 +99,5 @@ class SparkSessionImpl(
     sessionManager.operationManager.asInstanceOf[SparkSQLOperationManager].closeILoop(handle)
     sessionManager.operationManager.asInstanceOf[SparkSQLOperationManager].closePythonProcess(
       handle)
-  }
-
-  def setResultCodec(codec: String): Unit = {
-    resultCodec = codec
-  }
-
-  def getResultCodec(): Option[String] = {
-    Option(resultCodec)
   }
 }

--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -39,6 +39,8 @@ class SparkSessionImpl(
     val spark: SparkSession)
   extends AbstractSession(protocol, user, password, ipAddress, conf, sessionManager) {
 
+  protected var resultCodec: String = null
+
   private def setModifiableConfig(key: String, value: String): Unit = {
     try {
       spark.conf.set(key, value)
@@ -99,5 +101,13 @@ class SparkSessionImpl(
     sessionManager.operationManager.asInstanceOf[SparkSQLOperationManager].closeILoop(handle)
     sessionManager.operationManager.asInstanceOf[SparkSQLOperationManager].closePythonProcess(
       handle)
+  }
+
+  def setResultCodec(codec: String): Unit = {
+    resultCodec = codec
+  }
+
+  def getResultCodec(): Option[String] = {
+    Option(resultCodec)
   }
 }

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
@@ -21,8 +21,7 @@ import java.io.IOException
 
 import io.trino.client.Column
 import io.trino.client.StatementClient
-import org.apache.hive.service.rpc.thrift.TRowSet
-import org.apache.hive.service.rpc.thrift.TTableSchema
+import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet, TTableSchema}
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.Utils
@@ -47,7 +46,13 @@ abstract class TrinoOperation(session: Session) extends AbstractOperation(sessio
 
   protected var iter: FetchIterator[List[Any]] = _
 
-  override def getResultSetSchema: TTableSchema = SchemaHelper.toTTableSchema(schema)
+  override def getResultSetMetadata: TGetResultSetMetadataResp = {
+    val tTableSchema = SchemaHelper.toTTableSchema(schema)
+    val resp = new TGetResultSetMetadataResp
+    resp.setSchema(tTableSchema)
+    resp.setStatus(OK_STATUS)
+    resp
+  }
 
   override def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet = {
     validateDefaultFetchOrientation(order)

--- a/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
+++ b/externals/kyuubi-trino-engine/src/main/scala/org/apache/kyuubi/engine/trino/operation/TrinoOperation.scala
@@ -21,7 +21,7 @@ import java.io.IOException
 
 import io.trino.client.Column
 import io.trino.client.StatementClient
-import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet}
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.Utils

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/AbstractOperation.scala
@@ -19,8 +19,10 @@ package org.apache.kyuubi.operation
 
 import java.util.concurrent.{Future, ScheduledExecutorService, TimeUnit}
 
+import scala.collection.JavaConverters._
+
 import org.apache.commons.lang3.StringUtils
-import org.apache.hive.service.rpc.thrift.{TProgressUpdateResp, TProtocolVersion, TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TProgressUpdateResp, TProtocolVersion, TRowSet, TStatus, TStatusCode}
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging}
 import org.apache.kyuubi.config.KyuubiConf.OPERATION_IDLE_TIMEOUT
@@ -173,7 +175,7 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
 
   protected def getProtocolVersion: TProtocolVersion = session.protocol
 
-  override def getResultSetSchema: TTableSchema
+  override def getResultSetMetadata: TGetResultSetMetadataResp
 
   override def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet
 
@@ -226,5 +228,13 @@ abstract class AbstractOperation(session: Session) extends Operation with Loggin
       OperationState.isTerminal(state) &&
       lastAccessTime + operationTimeout <= System.currentTimeMillis()
     }
+  }
+
+  final val OK_STATUS = new TStatus(TStatusCode.SUCCESS_STATUS)
+
+  def okStatusWithHints(hints: Seq[String]): TStatus = {
+    val ok = new TStatus(TStatusCode.SUCCESS_STATUS)
+    ok.setInfoMessages(hints.asJava)
+    ok
   }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/Operation.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/Operation.scala
@@ -19,7 +19,7 @@ package org.apache.kyuubi.operation
 
 import java.util.concurrent.Future
 
-import org.apache.hive.service.rpc.thrift.{TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetResultSetMetadataResp, TRowSet}
 
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.log.OperationLog
@@ -31,7 +31,7 @@ trait Operation {
   def cancel(): Unit
   def close(): Unit
 
-  def getResultSetSchema: TTableSchema
+  def getResultSetMetadata: TGetResultSetMetadataResp
   def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet
 
   def getSession: Session

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/OperationManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/operation/OperationManager.scala
@@ -126,8 +126,8 @@ abstract class OperationManager(name: String) extends AbstractService(name) {
     operation.close()
   }
 
-  final def getOperationResultSetSchema(opHandle: OperationHandle): TTableSchema = {
-    getOperation(opHandle).getResultSetSchema
+  final def getOperationResultSetSchema(opHandle: OperationHandle): TGetResultSetMetadataResp = {
+    getOperation(opHandle).getResultSetMetadata
   }
 
   final def getOperationNextRowSet(

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/AbstractBackendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/AbstractBackendService.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.{ExecutionException, TimeoutException, TimeUnit}
 
 import scala.concurrent.CancellationException
 
-import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TProtocolVersion, TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TGetResultSetMetadataResp, TProtocolVersion, TRowSet}
 
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.operation.{OperationHandle, OperationStatus}
@@ -188,7 +188,7 @@ abstract class AbstractBackendService(name: String)
       .getOperation(operationHandle).getSession.closeOperation(operationHandle)
   }
 
-  override def getResultSetMetadata(operationHandle: OperationHandle): TTableSchema = {
+  override def getResultSetMetadata(operationHandle: OperationHandle): TGetResultSetMetadataResp = {
     sessionManager.operationManager
       .getOperation(operationHandle).getSession.getResultSetMetadata(operationHandle)
   }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/BackendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/BackendService.scala
@@ -94,7 +94,7 @@ trait BackendService {
   def getOperationStatus(operationHandle: OperationHandle): OperationStatus
   def cancelOperation(operationHandle: OperationHandle): Unit
   def closeOperation(operationHandle: OperationHandle): Unit
-  def getResultSetMetadata(operationHandle: OperationHandle): TTableSchema
+  def getResultSetMetadata(operationHandle: OperationHandle): TGetResultSetMetadataResp
   def fetchResults(
       operationHandle: OperationHandle,
       orientation: FetchOrientation,

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TFrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TFrontendService.scala
@@ -507,17 +507,15 @@ abstract class TFrontendService(name: String)
 
   override def GetResultSetMetadata(req: TGetResultSetMetadataReq): TGetResultSetMetadataResp = {
     debug(req.toString)
-    val resp = new TGetResultSetMetadataResp
     try {
-      val schema = be.getResultSetMetadata(OperationHandle(req.getOperationHandle))
-      resp.setSchema(schema)
-      resp.setStatus(OK_STATUS)
+      be.getResultSetMetadata(OperationHandle(req.getOperationHandle))
     } catch {
       case e: Exception =>
         error("Error getting result set metadata: ", e)
+        val resp = new TGetResultSetMetadataResp
         resp.setStatus(KyuubiSQLException.toTStatus(e))
+        resp
     }
-    resp
   }
 
   override def FetchResults(req: TFetchResultsReq): TFetchResultsResp = {
@@ -646,5 +644,11 @@ private[kyuubi] object TFrontendService {
     }
 
     def getSessionHandle: SessionHandle = sessionHandle
+  }
+
+  def okStatusWithHint(hint: Seq[String]): TStatus = {
+    val ok = new TStatus(TStatusCode.SUCCESS_STATUS)
+    ok.setInfoMessages(hint.asJava)
+    ok
   }
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -223,7 +223,7 @@ abstract class AbstractSession(
   }
 
   override def getResultSetMetadata(
-      operationHandle: OperationHandle): TTableSchema = withAcquireRelease() {
+      operationHandle: OperationHandle): TGetResultSetMetadataResp = withAcquireRelease() {
     sessionManager.operationManager.getOperationResultSetSchema(operationHandle)
   }
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
@@ -17,7 +17,7 @@
 
 package org.apache.kyuubi.session
 
-import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TProtocolVersion, TRowSet, TTableSchema}
+import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TGetResultSetMetadataResp, TProtocolVersion, TRowSet}
 
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.OperationHandle
@@ -85,7 +85,7 @@ trait Session {
 
   def cancelOperation(operationHandle: OperationHandle): Unit
   def closeOperation(operationHandle: OperationHandle): Unit
-  def getResultSetMetadata(operationHandle: OperationHandle): TTableSchema
+  def getResultSetMetadata(operationHandle: OperationHandle): TGetResultSetMetadataResp
   def fetchResults(
       operationHandle: OperationHandle,
       orientation: FetchOrientation,

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/NoopOperation.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/NoopOperation.scala
@@ -21,7 +21,7 @@ import java.nio.ByteBuffer
 
 import scala.collection.JavaConverters._
 
-import org.apache.hive.service.rpc.thrift.{TColumn, TColumnDesc, TPrimitiveTypeEntry, TRowSet, TStringColumn, TTableSchema, TTypeDesc, TTypeEntry, TTypeId}
+import org.apache.hive.service.rpc.thrift.{TColumn, TColumnDesc, TGetResultSetMetadataResp, TPrimitiveTypeEntry, TRowSet, TStringColumn, TTableSchema, TTypeDesc, TTypeEntry, TTypeId}
 
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
@@ -60,7 +60,7 @@ class NoopOperation(session: Session, shouldFail: Boolean = false)
     setState(OperationState.CLOSED)
   }
 
-  override def getResultSetSchema: TTableSchema = {
+  override def getResultSetMetadata: TGetResultSetMetadataResp = {
     val tColumnDesc = new TColumnDesc()
     tColumnDesc.setColumnName("noop")
     val desc = new TTypeDesc
@@ -70,7 +70,10 @@ class NoopOperation(session: Session, shouldFail: Boolean = false)
     tColumnDesc.setPosition(0)
     val schema = new TTableSchema()
     schema.addToColumns(tColumnDesc)
-    schema
+    val resp = new TGetResultSetMetadataResp
+    resp.setSchema(schema)
+    resp.setStatus(OK_STATUS)
+    resp
   }
 
   override def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet = {

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -24,7 +24,7 @@ import scala.collection.JavaConverters._
 
 import org.apache.commons.io.FileUtils
 import org.apache.commons.lang3.StringUtils
-import org.apache.hive.service.rpc.thrift.{TExecuteStatementReq, TFetchResultsReq, TOpenSessionReq, TStatusCode}
+import org.apache.hive.service.rpc.thrift.{TExecuteStatementReq, TFetchResultsReq, TGetResultSetMetadataReq, TOpenSessionReq, TStatusCode}
 
 import org.apache.kyuubi.{KYUUBI_VERSION, Utils}
 import org.apache.kyuubi.config.KyuubiConf
@@ -407,6 +407,41 @@ trait SparkQueryTests extends SparkDataTypeTests with HiveJDBCTestHelper {
         assert(result.next())
         assert(result.getInt(1) === 1)
       }
+    }
+  }
+
+  test("operation metadata hint - __kyuubi_operation_result_codec__") {
+    withSessionHandle { (client, handle) =>
+      def checkStatusAndResultSetCodecHint(
+          sql: String,
+          expectedCodec: String): Unit = {
+        val stmtReq = new TExecuteStatementReq()
+        stmtReq.setSessionHandle(handle)
+        stmtReq.setStatement(sql)
+        val tExecuteStatementResp = client.ExecuteStatement(stmtReq)
+        val opHandle = tExecuteStatementResp.getOperationHandle
+        waitForOperationToComplete(client, opHandle)
+        val metaReq = new TGetResultSetMetadataReq(opHandle)
+        val resp = client.GetResultSetMetadata(metaReq)
+        assert(resp.getStatus.getStatusCode == TStatusCode.SUCCESS_STATUS)
+        val expectedResultSetCodecHint = s"__kyuubi_operation_result_codec__=$expectedCodec"
+        assert(resp.getStatus.getInfoMessages.contains(expectedResultSetCodecHint))
+      }
+      checkStatusAndResultSetCodecHint(
+        sql = "SELECT 1",
+        expectedCodec = "simple")
+      checkStatusAndResultSetCodecHint(
+        sql = "set kyuubi.operation.result.codec=arrow",
+        expectedCodec = "arrow")
+      checkStatusAndResultSetCodecHint(
+        sql = "SELECT 1",
+        expectedCodec = "arrow")
+      checkStatusAndResultSetCodecHint(
+        sql = "set kyuubi.operation.result.codec=simple",
+        expectedCodec = "simple")
+      checkStatusAndResultSetCodecHint(
+        sql = "set kyuubi.operation.result.codec",
+        expectedCodec = "simple")
     }
   }
 }

--- a/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
+++ b/kyuubi-common/src/test/scala/org/apache/kyuubi/operation/SparkQueryTests.scala
@@ -411,6 +411,7 @@ trait SparkQueryTests extends SparkDataTypeTests with HiveJDBCTestHelper {
   }
 
   test("operation metadata hint - __kyuubi_operation_result_codec__") {
+    assume(!httpMode)
     withSessionHandle { (client, handle) =>
       def checkStatusAndResultSetCodecHint(
           sql: String,

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowQueryResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiArrowQueryResultSet.java
@@ -244,23 +244,6 @@ public class KyuubiArrowQueryResultSet extends KyuubiArrowBasedResultSet {
       // TODO need session handle
       TGetResultSetMetadataResp metadataResp;
       metadataResp = client.GetResultSetMetadata(metadataReq);
-      metadataResp
-          .getStatus()
-          .getInfoMessages()
-          .forEach(
-              line -> {
-                String[] keyValue = line.split("=");
-                String key = keyValue[0];
-                String value = keyValue[1];
-                System.out.println("key = " + key + ", value = " + value);
-                if (key.equals("__kyuubi_operation_result_codec__")) {
-                  try {
-                    ((KyuubiConnection) statement.getConnection()).setOperationResultCodec(value);
-                  } catch (SQLException e) {
-                    e.printStackTrace();
-                  }
-                }
-              });
       Utils.verifySuccess(metadataResp.getStatus());
 
       StringBuilder namesSb = new StringBuilder();

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -111,7 +111,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   private String engineUrl = "";
 
   private boolean isBeeLineMode;
-  private String resultCodec = "simple";
+  private ThreadLocal<String> resultCodec = new ThreadLocal<>();
 
   /** Get all direct HiveServer2 URLs from a ZooKeeper based HiveServer2 URL */
   public static List<JdbcConnectionParams> getAllUrls(String zookeeperBasedHS2Url)
@@ -147,7 +147,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     }
     port = connParams.getPort();
 
-    resultCodec =
+    resultCodec.set(
         connParams
             .getSessionVars()
             .getOrDefault(
@@ -158,7 +158,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
                         "kyuubi.operation.result.codec",
                         connParams
                             .getHiveConfs()
-                            .getOrDefault("kyuubi.operation.result.codec", "simple")));
+                            .getOrDefault("kyuubi.operation.result.codec", "simple"))));
 
     setupTimeout();
 
@@ -1382,6 +1382,10 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   }
 
   String getResultCodec() {
-    return resultCodec;
+    return resultCodec.get();
+  }
+
+  void setOperationResultCodec(String codec) {
+    this.resultCodec.set(codec);
   }
 }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -111,7 +111,6 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   private String engineUrl = "";
 
   private boolean isBeeLineMode;
-  private String resultCodec = "simple";
 
   /** Get all direct HiveServer2 URLs from a ZooKeeper based HiveServer2 URL */
   public static List<JdbcConnectionParams> getAllUrls(String zookeeperBasedHS2Url)
@@ -146,19 +145,6 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
       host = connParams.getHost();
     }
     port = connParams.getPort();
-
-    resultCodec =
-        connParams
-            .getSessionVars()
-            .getOrDefault(
-                "kyuubi.operation.result.codec",
-                connParams
-                    .getHiveVars()
-                    .getOrDefault(
-                        "kyuubi.operation.result.codec",
-                        connParams
-                            .getHiveConfs()
-                            .getOrDefault("kyuubi.operation.result.codec", "simple")));
 
     setupTimeout();
 
@@ -1379,9 +1365,5 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
 
   public String getEngineUrl() {
     return engineUrl;
-  }
-
-  String getResultCodec() {
-    return resultCodec;
   }
 }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiConnection.java
@@ -111,7 +111,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   private String engineUrl = "";
 
   private boolean isBeeLineMode;
-  private ThreadLocal<String> resultCodec = new ThreadLocal<>();
+  private String resultCodec = "simple";
 
   /** Get all direct HiveServer2 URLs from a ZooKeeper based HiveServer2 URL */
   public static List<JdbcConnectionParams> getAllUrls(String zookeeperBasedHS2Url)
@@ -147,7 +147,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
     }
     port = connParams.getPort();
 
-    resultCodec.set(
+    resultCodec =
         connParams
             .getSessionVars()
             .getOrDefault(
@@ -158,7 +158,7 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
                         "kyuubi.operation.result.codec",
                         connParams
                             .getHiveConfs()
-                            .getOrDefault("kyuubi.operation.result.codec", "simple"))));
+                            .getOrDefault("kyuubi.operation.result.codec", "simple")));
 
     setupTimeout();
 
@@ -1382,10 +1382,6 @@ public class KyuubiConnection implements SQLConnection, KyuubiLoggable {
   }
 
   String getResultCodec() {
-    return resultCodec.get();
-  }
-
-  void setOperationResultCodec(String codec) {
-    this.resultCodec.set(codec);
+    return resultCodec;
   }
 }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiQueryResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiQueryResultSet.java
@@ -221,6 +221,23 @@ public class KyuubiQueryResultSet extends KyuubiBaseResultSet {
       // TODO need session handle
       TGetResultSetMetadataResp metadataResp;
       metadataResp = client.GetResultSetMetadata(metadataReq);
+      metadataResp
+          .getStatus()
+          .getInfoMessages()
+          .forEach(
+              line -> {
+                String[] keyValue = line.split("=");
+                String key = keyValue[0];
+                String value = keyValue[1];
+                System.out.println("key = " + key + ", value = " + value);
+                if (key.equals("__kyuubi_operation_result_codec__")) {
+                  try {
+                    ((KyuubiConnection) statement.getConnection()).setOperationResultCodec(value);
+                  } catch (SQLException e) {
+                    e.printStackTrace();
+                  }
+                }
+              });
       Utils.verifySuccess(metadataResp.getStatus());
 
       StringBuilder namesSb = new StringBuilder();

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiQueryResultSet.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiQueryResultSet.java
@@ -221,23 +221,6 @@ public class KyuubiQueryResultSet extends KyuubiBaseResultSet {
       // TODO need session handle
       TGetResultSetMetadataResp metadataResp;
       metadataResp = client.GetResultSetMetadata(metadataReq);
-      metadataResp
-          .getStatus()
-          .getInfoMessages()
-          .forEach(
-              line -> {
-                String[] keyValue = line.split("=");
-                String key = keyValue[0];
-                String value = keyValue[1];
-                System.out.println("key = " + key + ", value = " + value);
-                if (key.equals("__kyuubi_operation_result_codec__")) {
-                  try {
-                    ((KyuubiConnection) statement.getConnection()).setOperationResultCodec(value);
-                  } catch (SQLException e) {
-                    e.printStackTrace();
-                  }
-                }
-              });
       Utils.verifySuccess(metadataResp.getStatus());
 
       StringBuilder namesSb = new StringBuilder();

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -26,7 +26,6 @@ import org.apache.kyuubi.jdbc.hive.adapter.SQLStatement;
 import org.apache.kyuubi.jdbc.hive.cli.FetchType;
 import org.apache.kyuubi.jdbc.hive.cli.RowSet;
 import org.apache.kyuubi.jdbc.hive.cli.RowSetFactory;
-import org.apache.kyuubi.jdbc.hive.common.HiveDecimal;
 import org.apache.kyuubi.jdbc.hive.logs.InPlaceUpdateStream;
 import org.apache.kyuubi.jdbc.hive.logs.KyuubiLoggable;
 import org.apache.thrift.TException;

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
   public static final Logger LOG = LoggerFactory.getLogger(KyuubiStatement.class.getName());
   public static final int DEFAULT_FETCH_SIZE = 1000;
+  public static final String DEFAULT_RESULT_CODEC = "simple";
   private final KyuubiConnection connection;
   private TCLIService.Iface client;
   private TOperationHandle stmtHandle = null;
@@ -208,7 +209,7 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
     parseMetadata(metadata, columnNames, columnTypes, columnAttributes);
 
     String resultCodec =
-        properties.getOrDefault("__kyuubi_operation_result_codec__", connection.getResultCodec());
+        properties.getOrDefault("__kyuubi_operation_result_codec__", DEFAULT_RESULT_CODEC);
     LOG.info("kyuubi.operation.result.codec: " + resultCodec);
     switch (resultCodec) {
       case "arrow":
@@ -265,7 +266,7 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
     parseMetadata(metadata, columnNames, columnTypes, columnAttributes);
 
     String resultCodec =
-        properties.getOrDefault("__kyuubi_operation_result_codec__", connection.getResultCodec());
+        properties.getOrDefault("__kyuubi_operation_result_codec__", DEFAULT_RESULT_CODEC);
     LOG.info("kyuubi.operation.result.codec: " + resultCodec);
     switch (resultCodec) {
       case "arrow":

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -796,6 +796,8 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
       metadataResp
           .getStatus()
           .getInfoMessages()
+          .stream()
+          .filter(hint -> Utils.isKyuubiOperationHint(hint))
           .forEach(
               line -> {
                 String[] keyValue = line.split("=");
@@ -803,8 +805,6 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
                   String key = keyValue[0];
                   String value = keyValue[1];
                   properties.put(key, value);
-                } else {
-                  LOG.warn("found unknown kyuubi metadata hint: " + line);
                 }
               });
     }

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -793,10 +793,7 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
     // parse kyuubi hint
     List<String> infoMessages = metadataResp.getStatus().getInfoMessages();
     if (infoMessages != null) {
-      metadataResp
-          .getStatus()
-          .getInfoMessages()
-          .stream()
+      metadataResp.getStatus().getInfoMessages().stream()
           .filter(hint -> Utils.isKyuubiOperationHint(hint))
           .forEach(
               line -> {

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -790,16 +790,19 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
     }
 
     // parse kyuubi hint
-    metadataResp
-        .getStatus()
-        .getInfoMessages()
-        .forEach(
-            line -> {
-              String[] keyValue = line.split("=");
-              String key = keyValue[0];
-              String value = keyValue[1];
-              properties.put(key, value);
-            });
+    List<String> infoMessages = metadataResp.getStatus().getInfoMessages();
+    if (infoMessages != null) {
+      metadataResp
+          .getStatus()
+          .getInfoMessages()
+          .forEach(
+              line -> {
+                String[] keyValue = line.split("=");
+                String key = keyValue[0];
+                String value = keyValue[1];
+                properties.put(key, value);
+              });
+    }
 
     // parse metadata
     List<TColumnDesc> columns = schema.getColumns();

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -800,12 +800,11 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
           .filter(hint -> Utils.isKyuubiOperationHint(hint))
           .forEach(
               line -> {
-                String[] keyValue = line.split("=");
-                if (keyValue.length == 2) {
-                  String key = keyValue[0];
-                  String value = keyValue[1];
-                  properties.put(key, value);
-                }
+                String[] keyValue = line.toLowerCase(Locale.ROOT).split("=");
+                assert keyValue.length == 2 : "Illegal Kyuubi operation hint found!";
+                String key = keyValue[0];
+                String value = keyValue[1];
+                properties.put(key, value);
               });
     }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/KyuubiStatement.java
@@ -799,9 +799,13 @@ public class KyuubiStatement implements SQLStatement, KyuubiLoggable {
           .forEach(
               line -> {
                 String[] keyValue = line.split("=");
-                String key = keyValue[0];
-                String value = keyValue[1];
-                properties.put(key, value);
+                if (keyValue.length == 2) {
+                  String key = keyValue[0];
+                  String value = keyValue[1];
+                  properties.put(key, value);
+                } else {
+                  LOG.warn("found unknown kyuubi metadata hint: " + line);
+                }
               });
     }
 

--- a/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
+++ b/kyuubi-hive-jdbc/src/main/java/org/apache/kyuubi/jdbc/hive/Utils.java
@@ -56,6 +56,9 @@ public class Utils {
   public static final String HIVE_SERVER2_RETRY_TRUE = "true";
   public static final String HIVE_SERVER2_RETRY_FALSE = "false";
 
+  public static final Pattern KYUUBI_OPERATION_HINT_PATTERN =
+      Pattern.compile("^__kyuubi_operation_result_(.*)__=(.*)", Pattern.CASE_INSENSITIVE);
+
   static String getMatchedUrlPrefix(String uri) throws JdbcUriParseException {
     for (String urlPrefix : URL_PREFIX_LIST) {
       if (uri.startsWith(urlPrefix)) {
@@ -469,5 +472,9 @@ public class Utils {
       LOG.warn("Could not retrieve canonical hostname for " + hostName, exception);
       return hostName;
     }
+  }
+
+  public static boolean isKyuubiOperationHint(String hint) {
+    return KYUUBI_OPERATION_HINT_PATTERN.matcher(hint).matches();
   }
 }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -384,11 +384,11 @@ class KyuubiSyncThriftClient private (
     }
   }
 
-  def getResultSetMetadata(operationHandle: TOperationHandle): TTableSchema = {
+  def getResultSetMetadata(operationHandle: TOperationHandle): TGetResultSetMetadataResp = {
     val req = new TGetResultSetMetadataReq(operationHandle)
     val resp = withLockAcquiredAsyncRequest(GetResultSetMetadata(req))
     ThriftUtils.verifyTStatus(resp.getStatus)
-    resp.getSchema
+    resp
   }
 
   def fetchResults(

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiApplicationOperation.scala
@@ -22,7 +22,7 @@ import java.util.{ArrayList => JArrayList}
 
 import scala.collection.JavaConverters._
 
-import org.apache.hive.service.rpc.thrift.{TColumn, TColumnDesc, TPrimitiveTypeEntry, TRow, TRowSet, TStringColumn, TTableSchema, TTypeDesc, TTypeEntry, TTypeId}
+import org.apache.hive.service.rpc.thrift.{TColumn, TColumnDesc, TGetResultSetMetadataResp, TPrimitiveTypeEntry, TRow, TRowSet, TStringColumn, TTableSchema, TTypeDesc, TTypeEntry, TTypeId}
 
 import org.apache.kyuubi.engine.ApplicationInfo
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
@@ -33,7 +33,7 @@ abstract class KyuubiApplicationOperation(session: Session) extends KyuubiOperat
 
   private[kyuubi] def currentApplicationInfo: Option[ApplicationInfo]
 
-  override def getResultSetSchema: TTableSchema = {
+  override def getResultSetMetadata: TGetResultSetMetadataResp = {
     val schema = new TTableSchema()
     Seq("key", "value").zipWithIndex.foreach { case (colName, position) =>
       val tColumnDesc = new TColumnDesc()
@@ -44,7 +44,10 @@ abstract class KyuubiApplicationOperation(session: Session) extends KyuubiOperat
       tColumnDesc.setPosition(position)
       schema.addToColumns(tColumnDesc)
     }
-    schema
+    val resp = new TGetResultSetMetadataResp
+    resp.setSchema(schema)
+    resp.setStatus(okStatusWithHint(Seq.empty))
+    resp
   }
 
   override def getNextRowSet(order: FetchOrientation, rowSetSize: Int): TRowSet = {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiApplicationOperation.scala
@@ -46,7 +46,7 @@ abstract class KyuubiApplicationOperation(session: Session) extends KyuubiOperat
     }
     val resp = new TGetResultSetMetadataResp
     resp.setSchema(schema)
-    resp.setStatus(okStatusWithHint(Seq.empty))
+    resp.setStatus(okStatusWithHints(Seq.empty))
     resp
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/operation/KyuubiOperation.scala
@@ -141,7 +141,7 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
     }
   }
 
-  override def getResultSetSchema: TTableSchema = {
+  override def getResultSetMetadata: TGetResultSetMetadataResp = {
     if (_remoteOpHandle == null) {
       val tColumnDesc = new TColumnDesc()
       tColumnDesc.setColumnName("Result")
@@ -151,7 +151,10 @@ abstract class KyuubiOperation(session: Session) extends AbstractOperation(sessi
       tColumnDesc.setPosition(0)
       val schema = new TTableSchema()
       schema.addToColumns(tColumnDesc)
-      schema
+      val resp = new TGetResultSetMetadataResp
+      resp.setSchema(schema)
+      resp.setStatus(OK_STATUS)
+      resp
     } else {
       client.getResultSetMetadata(_remoteOpHandle)
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
@@ -170,7 +170,8 @@ trait BackendServiceMetric extends BackendService {
     }
   }
 
-  abstract override def getResultSetMetadata(operationHandle: OperationHandle): TTableSchema = {
+  abstract override def getResultSetMetadata(operationHandle: OperationHandle)
+      : TGetResultSetMetadataResp = {
     MetricsSystem.timerTracing(MetricsConstants.BS_GET_RESULT_SET_METADATA) {
       super.getResultSetMetadata(operationHandle)
     }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/OperationsResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/OperationsResource.scala
@@ -104,7 +104,7 @@ private[v1] class OperationsResource extends ApiRequestContext with Logging {
     try {
       val operationHandle = OperationHandle(operationHandleStr)
       new ResultSetMetaData(
-        fe.be.getResultSetMetadata(operationHandle).getColumns.asScala.map(c => {
+        fe.be.getResultSetMetadata(operationHandle).getSchema.getColumns.asScala.map(c => {
           val tPrimitiveTypeEntry = c.getTypeDesc.getTypes.get(0).getPrimitiveEntry
           var precision = 0
           var scale = 0

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLCommandHandler.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLCommandHandler.scala
@@ -195,13 +195,13 @@ class MySQLCommandHandler(
         throw opStatus.exception
           .getOrElse(KyuubiSQLException(s"Error operator state ${opStatus.state}"))
       }
-      val tableSchema = be.getResultSetMetadata(opHandle)
+      val resultSetMetadata = be.getResultSetMetadata(opHandle)
       val rowSet = be.fetchResults(
         opHandle,
         FetchOrientation.FETCH_NEXT,
         Int.MaxValue,
         fetchLog = false)
-      MySQLQueryResult(tableSchema, rowSet)
+      MySQLQueryResult(resultSetMetadata.getSchema, rowSet)
     } catch {
       case rethrow: Exception =>
         warn("Error executing statement: ", rethrow)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

to close #3915

This pr adds support for jdbc client detecting result set codec

1. in this PR, hints are added in the `TStatus.getInfoMessages()` to return, and the hints were added when the client retrieves the result set schema from the server
2. the hints mechanism is a general extension when we need to change the client behavior, e.g. adding support for  result set compression


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
