### PR TITLE
[KYUUBI #3942] adapt Spark's JDBC data types to Hive data type definitions in KyuubiHiveDialect

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
@@ -36,23 +36,26 @@ object KyuubiHiveDialect extends JdbcDialect {
     colName.split('.').map(part => s"`$part`").mkString(".")
   }
 
+  /**
+   * Adapt to Hive data type definitions
+   * in https://cwiki.apache.org/confluence/display/hive/languagemanual+types .
+   *
+   * @param dt DataType in Spark SQL
+   * @return JdbcType with type definition adapted to Hive
+   */
   override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
-
-    // "INTEGER" is synonym for INT since Hive 2.2.0
+    // [HIVE-14950] "INTEGER" is synonym for INT since Hive 2.2.0
     // fallback to "INT" for better compatibility
     case IntegerType => Option(JdbcType("INT", java.sql.Types.INTEGER))
-
-    // "DOUBLE PRECISION" alias for "DOUBLE", only available starting with Hive 2.2.0
+    // [HIVE-13556] "DOUBLE PRECISION" is alias for "DOUBLE" since Hive 2.2.0
     // fallback to "DOUBLE" for better compatibility
     case DoubleType => Option(JdbcType("DOUBLE", java.sql.Types.DOUBLE))
-
     // adapt to Hive data type definition
     case FloatType => Option(JdbcType("FLOAT", java.sql.Types.FLOAT))
     case ByteType => Option(JdbcType("TINYINT", java.sql.Types.TINYINT))
     case BooleanType => Option(JdbcType("BOOLEAN", java.sql.Types.BIT))
     case StringType => Option(JdbcType("STRING", java.sql.Types.CLOB))
     case BinaryType => Option(JdbcType("BINARY", java.sql.Types.BLOB))
-
     case _ => JdbcUtils.getCommonJDBCType(dt)
   }
 

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcType}
-import org.apache.spark.sql.types.{BinaryType, BooleanType, DataType, DoubleType, FloatType, StringType}
+import org.apache.spark.sql.types._
 
 object KyuubiHiveDialect extends JdbcDialect {
 
@@ -44,8 +44,9 @@ object KyuubiHiveDialect extends JdbcDialect {
 
     // adapt to Hive data type definition
     case FloatType => Option(JdbcType("FLOAT", java.sql.Types.FLOAT))
-    case StringType => Option(JdbcType("STRING", java.sql.Types.CLOB))
+    case ByteType => Option(JdbcType("TINYINT", java.sql.Types.TINYINT))
     case BooleanType => Option(JdbcType("BOOLEAN", java.sql.Types.BIT))
+    case StringType => Option(JdbcType("STRING", java.sql.Types.CLOB))
     case BinaryType => Option(JdbcType("BINARY", java.sql.Types.BLOB))
 
     case _ => JdbcUtils.getCommonJDBCType(dt)

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcType}
-import org.apache.spark.sql.types.{DataType, DoubleType, FloatType, StringType}
+import org.apache.spark.sql.types.{BooleanType, DataType, DoubleType, FloatType, StringType}
 
 object KyuubiHiveDialect extends JdbcDialect {
 
@@ -41,7 +41,9 @@ object KyuubiHiveDialect extends JdbcDialect {
     // which is alias for DOUBLE, only available starting with Hive 2.2.0
     // overriding to "DOUBLE" for better compatibility
     case DoubleType => Option(JdbcType("DOUBLE", java.sql.Types.DOUBLE))
+    case FloatType => Option(JdbcType("FLOAT", java.sql.Types.FLOAT))
     case StringType => Option(JdbcType("STRING", java.sql.Types.CLOB))
+    case BooleanType => Option(JdbcType("BOOLEAN", java.sql.Types.BIT))
     case _ => JdbcUtils.getCommonJDBCType(dt)
   }
 

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
@@ -41,9 +41,12 @@ object KyuubiHiveDialect extends JdbcDialect {
     // which is alias for DOUBLE, only available starting with Hive 2.2.0
     // overriding to "DOUBLE" for better compatibility
     case DoubleType => Option(JdbcType("DOUBLE", java.sql.Types.DOUBLE))
+
+    // adapt to Hive data type definition
     case FloatType => Option(JdbcType("FLOAT", java.sql.Types.FLOAT))
     case StringType => Option(JdbcType("STRING", java.sql.Types.CLOB))
     case BooleanType => Option(JdbcType("BOOLEAN", java.sql.Types.BIT))
+
     case _ => JdbcUtils.getCommonJDBCType(dt)
   }
 

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
@@ -37,9 +37,13 @@ object KyuubiHiveDialect extends JdbcDialect {
   }
 
   override def getJDBCType(dt: DataType): Option[JdbcType] = dt match {
-    // JdbcUtils.getCommonJDBCType is mapping DoubleType to "DOUBLE PRECISION"
-    // which is alias for DOUBLE, only available starting with Hive 2.2.0
-    // overriding to "DOUBLE" for better compatibility
+
+    // "INTEGER" is synonym for INT since Hive 2.2.0
+    // fallback to "INT" for better compatibility
+    case IntegerType => Option(JdbcType("INT", java.sql.Types.INTEGER))
+
+    // "DOUBLE PRECISION" alias for "DOUBLE", only available starting with Hive 2.2.0
+    // fallback to "DOUBLE" for better compatibility
     case DoubleType => Option(JdbcType("DOUBLE", java.sql.Types.DOUBLE))
 
     // adapt to Hive data type definition

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/main/scala/org/apache/spark/sql/dialect/KyuubiHiveDialect.scala
@@ -21,7 +21,7 @@ import java.util.Locale
 
 import org.apache.spark.sql.execution.datasources.jdbc.JdbcUtils
 import org.apache.spark.sql.jdbc.{JdbcDialect, JdbcType}
-import org.apache.spark.sql.types.{BooleanType, DataType, DoubleType, FloatType, StringType}
+import org.apache.spark.sql.types.{BinaryType, BooleanType, DataType, DoubleType, FloatType, StringType}
 
 object KyuubiHiveDialect extends JdbcDialect {
 
@@ -46,6 +46,7 @@ object KyuubiHiveDialect extends JdbcDialect {
     case FloatType => Option(JdbcType("FLOAT", java.sql.Types.FLOAT))
     case StringType => Option(JdbcType("STRING", java.sql.Types.CLOB))
     case BooleanType => Option(JdbcType("BOOLEAN", java.sql.Types.BIT))
+    case BinaryType => Option(JdbcType("BINARY", java.sql.Types.BLOB))
 
     case _ => JdbcUtils.getCommonJDBCType(dt)
   }

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
@@ -17,6 +17,8 @@
 
 package org.apache.spark.sql.dialect
 
+import org.apache.spark.sql.dialect.KyuubiHiveDialect._
+import org.apache.spark.sql.types._
 // scalastyle:off
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -24,12 +26,19 @@ class KyuubiHiveDialectSuite extends AnyFunSuite {
 // scalastyle:on
 
   test("[KYUUBI #3489] Kyuubi Hive dialect: can handle jdbc url") {
-    assert(KyuubiHiveDialect.canHandle("jdbc:hive2://"))
-    assert(KyuubiHiveDialect.canHandle("jdbc:kyuubi://"))
+    assert(canHandle("jdbc:hive2://"))
+    assert(canHandle("jdbc:kyuubi://"))
   }
 
   test("[KYUUBI #3489] Kyuubi Hive dialect: quoteIdentifier") {
-    assertResult("`id`")(KyuubiHiveDialect.quoteIdentifier("id"))
-    assertResult("`table`.`id`")(KyuubiHiveDialect.quoteIdentifier("table.id"))
+    assertResult("`id`")(quoteIdentifier("id"))
+    assertResult("`table`.`id`")(quoteIdentifier("table.id"))
+  }
+
+  test("[KYUUBI #3489] Kyuubi Hive dialect: quoteIdentifier") {
+    assertResult("DOUBLE")(getJDBCType(DoubleType).get.databaseTypeDefinition)
+    assertResult("FLOAT")(getJDBCType(FloatType).get.databaseTypeDefinition)
+    assertResult("STRING")(getJDBCType(StringType).get.databaseTypeDefinition)
+    assertResult("BOOLEAN")(getJDBCType(BooleanType).get.databaseTypeDefinition)
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
@@ -46,5 +46,6 @@ class KyuubiHiveDialectSuite extends AnyFunSuite {
     assertResult("BOOLEAN")(getJdbcTypeDefinition(BooleanType))
     assertResult("STRING")(getJdbcTypeDefinition(StringType))
     assertResult("BINARY")(getJdbcTypeDefinition(BinaryType))
+    assertResult("DATE")(getJdbcTypeDefinition(DateType))
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
@@ -38,8 +38,9 @@ class KyuubiHiveDialectSuite extends AnyFunSuite {
   test("KYUUBI #3942 adapt to Hive data type definitions") {
     assertResult("DOUBLE")(getJDBCType(DoubleType).get.databaseTypeDefinition)
     assertResult("FLOAT")(getJDBCType(FloatType).get.databaseTypeDefinition)
-    assertResult("STRING")(getJDBCType(StringType).get.databaseTypeDefinition)
+    assertResult("TINYINT")(getJDBCType(ByteType).get.databaseTypeDefinition)
     assertResult("BOOLEAN")(getJDBCType(BooleanType).get.databaseTypeDefinition)
+    assertResult("STRING")(getJDBCType(StringType).get.databaseTypeDefinition)
     assertResult("BINARY")(getJDBCType(BinaryType).get.databaseTypeDefinition)
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
@@ -40,5 +40,6 @@ class KyuubiHiveDialectSuite extends AnyFunSuite {
     assertResult("FLOAT")(getJDBCType(FloatType).get.databaseTypeDefinition)
     assertResult("STRING")(getJDBCType(StringType).get.databaseTypeDefinition)
     assertResult("BOOLEAN")(getJDBCType(BooleanType).get.databaseTypeDefinition)
+    assertResult("BINARY")(getJDBCType(BinaryType).get.databaseTypeDefinition)
   }
 }

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
@@ -35,7 +35,7 @@ class KyuubiHiveDialectSuite extends AnyFunSuite {
     assertResult("`table`.`id`")(quoteIdentifier("table.id"))
   }
 
-  test("[KYUUBI #3489] Kyuubi Hive dialect: quoteIdentifier") {
+  test("KYUUBI #3942 adapt to Hive data type definitions") {
     assertResult("DOUBLE")(getJDBCType(DoubleType).get.databaseTypeDefinition)
     assertResult("FLOAT")(getJDBCType(FloatType).get.databaseTypeDefinition)
     assertResult("STRING")(getJDBCType(StringType).get.databaseTypeDefinition)

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
@@ -39,6 +39,7 @@ class KyuubiHiveDialectSuite extends AnyFunSuite {
     def getJdbcTypeDefinition(dt: DataType): String = {
       getJDBCType(dt).get.databaseTypeDefinition
     }
+    assertResult("INT")(getJdbcTypeDefinition(IntegerType))
     assertResult("DOUBLE")(getJdbcTypeDefinition(DoubleType))
     assertResult("FLOAT")(getJdbcTypeDefinition(FloatType))
     assertResult("TINYINT")(getJdbcTypeDefinition(ByteType))

--- a/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-jdbc-dialect/src/test/scala/org/apache/spark/sql/dialect/KyuubiHiveDialectSuite.scala
@@ -36,11 +36,14 @@ class KyuubiHiveDialectSuite extends AnyFunSuite {
   }
 
   test("KYUUBI #3942 adapt to Hive data type definitions") {
-    assertResult("DOUBLE")(getJDBCType(DoubleType).get.databaseTypeDefinition)
-    assertResult("FLOAT")(getJDBCType(FloatType).get.databaseTypeDefinition)
-    assertResult("TINYINT")(getJDBCType(ByteType).get.databaseTypeDefinition)
-    assertResult("BOOLEAN")(getJDBCType(BooleanType).get.databaseTypeDefinition)
-    assertResult("STRING")(getJDBCType(StringType).get.databaseTypeDefinition)
-    assertResult("BINARY")(getJDBCType(BinaryType).get.databaseTypeDefinition)
+    def getJdbcTypeDefinition(dt: DataType): String = {
+      getJDBCType(dt).get.databaseTypeDefinition
+    }
+    assertResult("DOUBLE")(getJdbcTypeDefinition(DoubleType))
+    assertResult("FLOAT")(getJdbcTypeDefinition(FloatType))
+    assertResult("TINYINT")(getJdbcTypeDefinition(ByteType))
+    assertResult("BOOLEAN")(getJdbcTypeDefinition(BooleanType))
+    assertResult("STRING")(getJdbcTypeDefinition(StringType))
+    assertResult("BINARY")(getJdbcTypeDefinition(BinaryType))
   }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

to close #3942 .

Adapt Spark's JDBC data type to Hive data type definitions.
1. adapt `DoubleType` to "DOUBLE" for compatibility with Hive 2.1.x and below
  - "DOUBLE PRECISION" mapped in [`JdbcUtils.getCommonJDBCType` ](https://github.com/apache/spark/blob/v3.3.1/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/jdbc/JdbcUtils.scala#L145) is a pure alias for DOUBLE, only available starting with Hive 2.2.0.  
2. adapt `IntegerType` to "INT" instead of "INTEGER" for compatibility with Hive 2.1.x and below
  -  "INTEGER" is synonym for INT since Hive 2.2.0
3. fix the unsupported Spark data type mapping to the Hive data type definition with correct mappings:
- FloatType to "FLOAT" instead of "REAL"
- StringType to "STRING" instead of "TEXT"
- BooleanType to "BOOLEAN" instead of "BIT(1)"
- BinaryType to "BINARY" instead of "BLOB"
- ByteType to "TINYINT" instead of "BYTE"
 
Hive Data Type docs refers to https://cwiki.apache.org/confluence/display/hive/languagemanual+types .


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
