### PR TITLE
Print the simple batch report if no log fetch to prevent misunderstand

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -83,8 +83,8 @@ class LogBatchCommand(
           if (!done) {
             if (!Option(log).exists(_.getRowCount > 0)) {
               Option(batch).foreach { batch =>
-                info(s"Batch report for ${batch.getId} (appId: ${batch.getAppId}," +
-                  s" state: ${batch.getState})")
+                info(s"Application report for ${batch.getAppId} (state: ${batch.getAppState})," +
+                  s" batch id: $batchId (state: ${batch.getState})")
               }
             }
             Thread.sleep(conf.get(CTL_BATCH_LOG_QUERY_INTERVAL))

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -83,7 +83,8 @@ class LogBatchCommand(
           if (!done) {
             if (!Option(log).exists(_.getRowCount > 0)) {
               Option(batch).foreach { batch =>
-                info(s"Batch report for ${batch.getId} (state: ${batch.getState})")
+                info(s"Batch report for ${batch.getId} (appId: ${batch.getAppId}," +
+                  s" state: ${batch.getState})")
               }
             }
             Thread.sleep(conf.get(CTL_BATCH_LOG_QUERY_INTERVAL))

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -83,7 +83,7 @@ class LogBatchCommand(
           if (!done) {
             if (!Option(log).exists(_.getRowCount > 0)) {
               Option(batch).foreach { batch =>
-                 info(s"Batch report for ${batch.getId} (state: ${batch.getState})")
+                info(s"Batch report for ${batch.getId} (state: ${batch.getState})")
               }
             }
             Thread.sleep(conf.get(CTL_BATCH_LOG_QUERY_INTERVAL))

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/log/LogBatchCommand.scala
@@ -81,6 +81,11 @@ class LogBatchCommand(
           }
 
           if (!done) {
+            if (!Option(log).exists(_.getRowCount > 0)) {
+              Option(batch).foreach { batch =>
+                 info(s"Batch report for ${batch.getId} (state: ${batch.getState})")
+              }
+            }
             Thread.sleep(conf.get(CTL_BATCH_LOG_QUERY_INTERVAL))
           }
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
With yarn-cluster mode, if `spark.yarn.submit.waitAppCompletion` is false and `kyuubi-ctl` wait completion is true, we need still print some simple batch report to prevent misunderstand.

The batch report format refer spark-submit log.
```
Application report for <ApplicationID> (state: RUNNING)
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
