### PR TITLE
[KYUUBI #3847][FOLLOWUP] Add jdbc-shaded profile to support IDE debug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,7 @@ install:
   - ./build/mvn --version
 
 before_script:
-  - export MVN_ARGS="-Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn"
+  - export MVN_ARGS="-Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip -V -B -ntp -Dorg.slf4j.simpleLogger.defaultLogLevel=warn -Pjdbc-shaded"
   - ./build/mvn clean install -DskipTests $MVN_ARGS
 
 


### PR DESCRIPTION
### _Why are the changes needed?_

https://app.travis-ci.com/github/apache/incubator-kyuubi/jobs/590599391

```
SparkOperationSuite:
- get catalogs
- get schemas
- get tables
- get type info
- audit Kyuubi Hive JDBC connection common MetaData *** FAILED ***
  "...i Project Hive JDBC []Client" did not equal "...i Project Hive JDBC [Shaded ]Client" (SparkMetadataTests.scala:407)
  Analysis:
  "...i Project Hive JDBC []Client" -> "...i Project Hive JDBC [Shaded ]Client"
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
