### PR TITLE
Fix Spark session timezone format

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/schema/RowSet.scala
@@ -261,7 +261,7 @@ object RowSet {
         formatLocalDate(ld)
 
       case (t: Timestamp, TimestampType) =>
-        formatTimestamp(t)
+        formatTimestamp(t, Option(timeZone))
 
       case (t: LocalDateTime, ntz) if ntz.getClass.getSimpleName.equals(TIMESTAMP_NTZ) =>
         formatLocalDateTime(t)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/RowSetUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/RowSetUtils.scala
@@ -24,7 +24,7 @@ import java.time.chrono.IsoChronology
 import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
-import java.util.{Date, Locale}
+import java.util.{Date, Locale, TimeZone}
 import java.util.concurrent.TimeUnit
 
 import scala.language.implicitConversions
@@ -77,8 +77,14 @@ private[kyuubi] object RowSetUtils {
       .getOrElse(timestampFormatter.format(i))
   }
 
-  def formatTimestamp(t: Timestamp): String = {
-    legacyTimestampFormatter.format(t)
+  def formatTimestamp(t: Timestamp, timeZone: Option[ZoneId] = None): String = {
+    timeZone.map(zoneId => {
+      FastDateFormat.getInstance(
+        legacyTimestampFormatter.getPattern,
+        TimeZone.getTimeZone(zoneId),
+        legacyTimestampFormatter.getLocale)
+        .format(t)
+    }).getOrElse(legacyTimestampFormatter.format(t))
   }
 
   implicit def bitSetToBuffer(bitSet: java.util.BitSet): ByteBuffer = {

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkSqlEngineSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/engine/spark/SparkSqlEngineSuite.scala
@@ -132,5 +132,22 @@ class SparkSqlEngineSuite extends WithKyuubiServer with HiveJDBCTestHelper {
     }
   }
 
+  test("Spark session timezone format") {
+    withJdbcStatement() { statement =>
+      val setUTCResultSet = statement.executeQuery("set spark.sql.session.timeZone=UTC")
+      assert(setUTCResultSet.next())
+      val utcResultSet = statement.executeQuery("select from_utc_timestamp(from_unixtime(" +
+        "1670404535000/1000,'yyyy-MM-dd HH:mm:ss'),'GMT+08:00')")
+      assert(utcResultSet.next())
+      assert(utcResultSet.getString(1) == "2022-12-07 17:15:35.0")
+      val setGMT8ResultSet = statement.executeQuery("set spark.sql.session.timeZone=GMT+8")
+      assert(setGMT8ResultSet.next())
+      val gmt8ResultSet = statement.executeQuery("select from_utc_timestamp(from_unixtime(" +
+        "1670404535000/1000,'yyyy-MM-dd HH:mm:ss'),'GMT+08:00')")
+      assert(gmt8ResultSet.next())
+      assert(gmt8ResultSet.getString(1) == "2022-12-08 01:15:35.0")
+    }
+  }
+
   override protected def jdbcUrl: String = getJdbcUrl
 }


### PR DESCRIPTION
### _Why are the changes needed?_
The Spark session supports setting the time zone through `spark.sql.session.timeZone` and formatting according to the time zone, but `timestamp` does not use timezone, resulting in some incorrect results.

### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
