### PR TITLE
[KYUUBI #2887][FOLLOWUP] Rename configuration to kyuubi.engine.pool.selectPolicy

### DIFF
--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -246,8 +246,8 @@ kyuubi.engine.jdbc.memory|1g|The heap memory for the jdbc query engine|string|1.
 kyuubi.engine.jdbc.type|&lt;undefined&gt;|The short name of jdbc type|string|1.6.0
 kyuubi.engine.operation.convert.catalog.database.enabled|true|When set to true, The engine converts the JDBC methods of set/get Catalog and set/get Schema to the implementation of different engines|boolean|1.6.0
 kyuubi.engine.operation.log.dir.root|engine_operation_logs|Root directory for query operation log at engine-side.|string|1.4.0
-kyuubi.engine.pool.balance.policy|RANDOM|The balance policy of queries in engine pool.<ul> <li>RANDOM - Randomly use the engine in the pool</li> <li>POLLING - Polling use the engine in the pool</li> </ul>|string|1.7.0
 kyuubi.engine.pool.name|engine-pool|The name of engine pool.|string|1.5.0
+kyuubi.engine.pool.selectPolicy|RANDOM|The policy of selecting engine in a pool engine for session.<ul><li>RANDOM - Randomly use the engine in the pool</li><li>POLLING - Polling use the engine in the pool</li></ul>|string|1.7.0
 kyuubi.engine.pool.size|-1|The size of engine pool. Note that, if the size is less than 1, the engine pool will not be enabled; otherwise, the size of the engine pool will be min(this, kyuubi.engine.pool.size.threshold).|int|1.4.0
 kyuubi.engine.pool.size.threshold|9|This parameter is introduced as a server-side parameter, and controls the upper limit of the engine pool.|int|1.4.0
 kyuubi.engine.session.initialize.sql||SemiColon-separated list of SQL statements to be initialized in the newly created engine session before queries. This configuration can not be used in JDBC url due to the limitation of Beeline/JDBC driver.|seq|1.3.0

--- a/docs/deployment/settings.md
+++ b/docs/deployment/settings.md
@@ -247,7 +247,7 @@ kyuubi.engine.jdbc.type|&lt;undefined&gt;|The short name of jdbc type|string|1.6
 kyuubi.engine.operation.convert.catalog.database.enabled|true|When set to true, The engine converts the JDBC methods of set/get Catalog and set/get Schema to the implementation of different engines|boolean|1.6.0
 kyuubi.engine.operation.log.dir.root|engine_operation_logs|Root directory for query operation log at engine-side.|string|1.4.0
 kyuubi.engine.pool.name|engine-pool|The name of engine pool.|string|1.5.0
-kyuubi.engine.pool.selectPolicy|RANDOM|The policy of selecting engine in a pool engine for session.<ul><li>RANDOM - Randomly use the engine in the pool</li><li>POLLING - Polling use the engine in the pool</li></ul>|string|1.7.0
+kyuubi.engine.pool.selectPolicy|RANDOM|The select policy of an engine from the corresponding engine pool engine for a session. <ul><li>RANDOM - Randomly use the engine in the pool</li><li>POLLING - Polling use the engine in the pool</li></ul>|string|1.7.0
 kyuubi.engine.pool.size|-1|The size of engine pool. Note that, if the size is less than 1, the engine pool will not be enabled; otherwise, the size of the engine pool will be min(this, kyuubi.engine.pool.size.threshold).|int|1.4.0
 kyuubi.engine.pool.size.threshold|9|This parameter is introduced as a server-side parameter, and controls the upper limit of the engine pool.|int|1.4.0
 kyuubi.engine.session.initialize.sql||SemiColon-separated list of SQL statements to be initialized in the newly created engine session before queries. This configuration can not be used in JDBC url due to the limitation of Beeline/JDBC driver.|seq|1.3.0

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1646,10 +1646,12 @@ object KyuubiConf {
     .createWithDefault(-1)
 
   val ENGINE_POOL_BALANCE_POLICY: ConfigEntry[String] =
-    buildConf("kyuubi.engine.pool.balance.policy")
-      .doc("The balance policy of queries in engine pool.<ul>" +
-        " <li>RANDOM - Randomly use the engine in the pool</li>" +
-        " <li>POLLING - Polling use the engine in the pool</li> </ul>")
+    buildConf("kyuubi.engine.pool.selectPolicy")
+      .doc("The policy of selecting engine in a pool engine for session." +
+        "<ul>" +
+        "<li>RANDOM - Randomly use the engine in the pool</li>" +
+        "<li>POLLING - Polling use the engine in the pool</li>" +
+        "</ul>")
       .version("1.7.0")
       .stringConf
       .transform(_.toUpperCase(Locale.ROOT))

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -1647,8 +1647,8 @@ object KyuubiConf {
 
   val ENGINE_POOL_BALANCE_POLICY: ConfigEntry[String] =
     buildConf("kyuubi.engine.pool.selectPolicy")
-      .doc("The policy of selecting engine in a pool engine for session." +
-        "<ul>" +
+      .doc("The select policy of an engine from the corresponding engine pool engine for " +
+        "a session. <ul>" +
         "<li>RANDOM - Randomly use the engine in the pool</li>" +
         "<li>POLLING - Polling use the engine in the pool</li>" +
         "</ul>")


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
After some thought and some offline discussions, I propose to change the configuration key from `kyuubi.engine.pool.balance.policy` to `kyuubi.engine.pool.selectPolicy`.

And in the future if we introduce properties for specific policy, e.g. supposing we have a engine selection policy named `LOAD`, the properties would be

```
kyuubi.engine.pool.selectPolicy.load.abc=xxxx
kyuubi.engine.pool.selectPolicy.load.xyz=xxxx
```

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
