### PR TITLE
[KYUUBI #3930] [Fix] fix ut in SessionSigningSuite by getting session public key and user sign from LocalProperty

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/util/SignUtils.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/util/SignUtils.scala
@@ -46,7 +46,7 @@ object SignUtils {
   def signWithPrivateKey(
       plainText: String,
       privateKey: PrivateKey,
-      algorithm: String = "SHA256withECDSA"): String = synchronized {
+      algorithm: String = "SHA256withECDSA"): String = {
     val privateSignature = Signature.getInstance(algorithm)
     privateSignature.initSign(privateKey)
     privateSignature.update(plainText.getBytes(StandardCharsets.UTF_8))
@@ -57,7 +57,7 @@ object SignUtils {
   def verifySignWithECDSA(
       plainText: String,
       signatureBase64: String,
-      publicKeyBase64: String): Boolean = synchronized {
+      publicKeyBase64: String): Boolean = {
     try {
       val publicKeyBytes = Base64.getDecoder.decode(publicKeyBase64)
       val publicKey: PublicKey = KeyFactory.getInstance(KEYPAIR_ALGORITHM_EC)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionSigningSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionSigningSuite.scala
@@ -90,5 +90,4 @@ class SessionSigningSuite extends WithKyuubiServer with HiveJDBCTestHelper {
       }
     }
   }
-
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionSigningSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionSigningSuite.scala
@@ -17,10 +17,12 @@
 
 package org.apache.kyuubi.session
 
+import org.apache.commons.lang3.StringUtils
+
 import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
-import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_SIGN_PUBLICKEY, KYUUBI_SESSION_USER_SIGN}
+import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_USER_SIGN
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
 import org.apache.kyuubi.util.SignUtils
 
@@ -68,16 +70,22 @@ class SessionSigningSuite extends WithKyuubiServer with HiveJDBCTestHelper {
   test("KYUUBI #3839 session user sign - check session user sign") {
     withSessionConf()()() {
       withJdbcStatement() { statement =>
-        val rs1 = statement.executeQuery(s"SET $KYUUBI_SESSION_SIGN_PUBLICKEY")
+        val value = s"SET ${OPERATION_LANGUAGE.key}=scala"
+        statement.executeQuery(value)
+
+        val rs1 = statement.executeQuery(
+          "spark.sparkContext.getLocalProperty(\"kyuubi.session.sign.publickey\")")
         assert(rs1.next())
-        assert(rs1.getString("value").nonEmpty)
-
-        val rs2 = statement.executeQuery(s"SET $KYUUBI_SESSION_USER_SIGN")
+        val rs2 = statement.executeQuery(
+          s"spark.sparkContext.getLocalProperty(\"kyuubi.session.user.sign\")")
         assert(rs2.next())
-        assert(rs2.getString("value").nonEmpty)
 
-        val publicKeyStr = rs1.getString("value")
-        val sessionUserSign = rs2.getString("value")
+        // to skip scala result starts with "res0: String = "
+        val publicKeyStr = rs1.getString(1).substring(15)
+        val sessionUserSign = rs2.getString(1).substring(15)
+
+        assert(StringUtils.isNotBlank(publicKeyStr))
+        assert(StringUtils.isNotBlank(sessionUserSign))
         assert(SignUtils.verifySignWithECDSA(user, sessionUserSign, publicKeyStr))
       }
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionSigningSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionSigningSuite.scala
@@ -85,7 +85,7 @@ class SessionSigningSuite extends WithKyuubiServer with HiveJDBCTestHelper {
              |""".stripMargin)
         assert(rs2.next())
 
-        // to skip scala result starts with "res0: String = "
+        // skipping prefix "res0: String = " of returned scala result
         val publicKeyStr = rs1.getString(1).substring(15)
         val sessionUserSign = rs2.getString(1).substring(15)
 

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionSigningSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/session/SessionSigningSuite.scala
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils
 import org.apache.kyuubi.WithKyuubiServer
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
-import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_SESSION_USER_SIGN
+import org.apache.kyuubi.config.KyuubiReservedKeys.{KYUUBI_SESSION_SIGN_PUBLICKEY, KYUUBI_SESSION_USER_SIGN}
 import org.apache.kyuubi.operation.HiveJDBCTestHelper
 import org.apache.kyuubi.util.SignUtils
 
@@ -74,10 +74,15 @@ class SessionSigningSuite extends WithKyuubiServer with HiveJDBCTestHelper {
         statement.executeQuery(value)
 
         val rs1 = statement.executeQuery(
-          "spark.sparkContext.getLocalProperty(\"kyuubi.session.sign.publickey\")")
+          s"""
+             |spark.sparkContext.getLocalProperty("$KYUUBI_SESSION_SIGN_PUBLICKEY")
+             |""".stripMargin)
         assert(rs1.next())
+
         val rs2 = statement.executeQuery(
-          s"spark.sparkContext.getLocalProperty(\"kyuubi.session.user.sign\")")
+          s"""
+             |spark.sparkContext.getLocalProperty("$KYUUBI_SESSION_USER_SIGN")
+             |""".stripMargin)
         assert(rs2.next())
 
         // to skip scala result starts with "res0: String = "


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Followed by issue https://github.com/apache/incubator-kyuubi/issues/3930 and pr https://github.com/apache/incubator-kyuubi/pull/3932.

- correct ut in SessionSigningSuite by fetching session public key and user sign via scala scripts instead of `SET` command in SQL , to prevent accidently redacted by `spark.redaction.regex`
- removed `syncronized` in SignUtils introduced in pr #3932 , with confirming no thread safe problem during the signing and verification


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
