### PR TITLE
[KYUUBI #3605] [Authz] support catalog in PrivilegeObject and AccessResource 

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegeObject.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegeObject.scala
@@ -44,4 +44,5 @@ case class PrivilegeObject(
     dbname: String,
     objectName: String,
     @Nonnull columns: Seq[String] = Nil,
-    owner: Option[String] = None)
+    owner: Option[String] = None,
+    catalog: Option[String] = None)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResource.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResource.scala
@@ -69,7 +69,7 @@ object AccessResource {
   def apply(
       objectType: ObjectType,
       firstLevelResource: String,
-      catalog: Option[String] = None): AccessResource = {
+      catalog: Option[String]): AccessResource = {
     apply(objectType, firstLevelResource, null, null, catalog = catalog)
   }
 

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResource.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResource.scala
@@ -25,7 +25,8 @@ import org.apache.kyuubi.plugin.spark.authz.{ObjectType, PrivilegeObject}
 import org.apache.kyuubi.plugin.spark.authz.ObjectType._
 import org.apache.kyuubi.plugin.spark.authz.OperationType.OperationType
 
-class AccessResource private (val objectType: ObjectType) extends RangerAccessResourceImpl {
+class AccessResource private (val objectType: ObjectType, val catalog: Option[String])
+  extends RangerAccessResourceImpl {
   implicit def asString(obj: Object): String = if (obj != null) obj.asInstanceOf[String] else null
   def getDatabase: String = getValue("database")
   def getTable: String = getValue("table")
@@ -43,8 +44,9 @@ object AccessResource {
       firstLevelResource: String,
       secondLevelResource: String,
       thirdLevelResource: String,
-      owner: Option[String] = None): AccessResource = {
-    val resource = new AccessResource(objectType)
+      owner: Option[String] = None,
+      catalog: Option[String] = None): AccessResource = {
+    val resource = new AccessResource(objectType, catalog)
 
     resource.objectType match {
       case DATABASE => resource.setValue("database", firstLevelResource)
@@ -64,11 +66,24 @@ object AccessResource {
     resource
   }
 
-  def apply(objectType: ObjectType, firstLevelResource: String): AccessResource = {
-    apply(objectType, firstLevelResource, null, null)
+  def apply(
+      objectType: ObjectType,
+      firstLevelResource: String,
+      catalog: Option[String] = None): AccessResource = {
+    apply(objectType, firstLevelResource, null, null, catalog = catalog)
   }
 
-  def apply(obj: PrivilegeObject, opType: OperationType): AccessResource = {
-    apply(ObjectType(obj, opType), obj.dbname, obj.objectName, obj.columns.mkString(","), obj.owner)
+  def apply(
+      obj: PrivilegeObject,
+      opType: OperationType,
+      catalog: Option[String] = None): AccessResource = {
+    // todo: fill catalog
+    apply(
+      ObjectType(obj, opType),
+      obj.dbname,
+      obj.objectName,
+      obj.columns.mkString(","),
+      obj.owner,
+      catalog = None)
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResource.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResource.scala
@@ -75,15 +75,13 @@ object AccessResource {
 
   def apply(
       obj: PrivilegeObject,
-      opType: OperationType,
-      catalog: Option[String] = None): AccessResource = {
-    // todo: fill catalog
+      opType: OperationType): AccessResource = {
     apply(
       ObjectType(obj, opType),
       obj.dbname,
       obj.objectName,
       obj.columns.mkString(","),
       obj.owner,
-      catalog = None)
+      obj.catalog)
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -56,7 +56,6 @@ object RuleAuthorization {
 
     def addAccessRequest(objects: Seq[PrivilegeObject], isInput: Boolean): Unit = {
       objects.foreach { obj =>
-        // todo: fill catalog
         val resource = AccessResource(obj, opType)
         val accessType = ranger.AccessType(obj, opType, isInput)
         if (accessType != AccessType.NONE && !requests.exists(o =>

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -56,6 +56,7 @@ object RuleAuthorization {
 
     def addAccessRequest(objects: Seq[PrivilegeObject], isInput: Boolean): Unit = {
       objects.foreach { obj =>
+        // todo: fill catalog
         val resource = AccessResource(obj, opType)
         val accessType = ranger.AccessType(obj, opType, isInput)
         if (accessType != AccessType.NONE && !requests.exists(o =>
@@ -79,7 +80,8 @@ object RuleAuthorization {
                 resource.getDatabase,
                 resource.getTable,
                 col,
-                Option(resource.getOwnerUser))
+                Option(resource.getOwnerUser),
+                resource.catalog)
             AccessRequest(cr, ugi, opType, request.accessType).asInstanceOf[RangerAccessRequest]
           }
         case _ => Seq(request)

--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/ranger/RuleAuthorization.scala
@@ -50,7 +50,7 @@ object RuleAuthorization {
     val (inputs, outputs, opType) = PrivilegesBuilder.build(plan, spark)
     val requests = new ArrayBuffer[AccessRequest]()
     if (inputs.isEmpty && opType == OperationType.SHOWDATABASES) {
-      val resource = AccessResource(DATABASE, null)
+      val resource = AccessResource(DATABASE, null, None)
       requests += AccessRequest(resource, ugi, opType, AccessType.USE)
     }
 

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
@@ -64,7 +64,7 @@ class AccessResourceSuite extends AnyFunSuite {
     assert(resource4.getColumns === Seq("my_col_1", "my_col_2"))
   }
 
-  test("generate spark ranger resources with catalog") {
+  test("KYUUBI #3605: generate spark ranger resources with catalog") {
     val catalog = Some("my_cat")
 
     val resource = AccessResource(DATABASE, "my_db_name", null, null, catalog = catalog)
@@ -88,26 +88,5 @@ class AccessResourceSuite extends AnyFunSuite {
     assert(resource1.getColumn === null)
     assert(resource1.getColumns.isEmpty)
     assert(resource1.getOwnerUser === "Bob")
-
-    val resource2 = AccessResource(FUNCTION, "my_db_name", "my_func_name", null, catalog = catalog)
-    assert(resource2.getDatabase === "my_db_name")
-    assert(resource2.getTable === null)
-    assert(resource2.getValue("udf") === "my_func_name")
-    assert(resource1.getColumn === null)
-    assert(resource1.getColumns.isEmpty)
-
-    val resource3 =
-      AccessResource(TABLE, "my_db_name", "my_table_name", "my_col_1,my_col_2", catalog = catalog)
-    assert(resource3.getDatabase === "my_db_name")
-    assert(resource3.getTable === "my_table_name")
-    assert(resource3.getColumn === null)
-    assert(resource3.getColumns.isEmpty)
-
-    val resource4 =
-      AccessResource(COLUMN, "my_db_name", "my_table_name", "my_col_1,my_col_2", catalog = catalog)
-    assert(resource4.getDatabase === "my_db_name")
-    assert(resource4.getTable === "my_table_name")
-    assert(resource4.getColumn === "my_col_1,my_col_2")
-    assert(resource4.getColumns === Seq("my_col_1", "my_col_2"))
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
@@ -26,6 +26,7 @@ class AccessResourceSuite extends AnyFunSuite {
 // scalastyle:on
   test("generate spark ranger resources") {
     val resource = AccessResource(DATABASE, "my_db_name")
+    assert(resource.catalog.isEmpty)
     assert(resource.getDatabase === "my_db_name")
     assert(resource.getTable === null)
     assert(resource.getColumn === null)
@@ -33,6 +34,7 @@ class AccessResourceSuite extends AnyFunSuite {
 
     val resource1 =
       AccessResource(DATABASE, null, "my_table_name", "my_col_1,my_col_2", Some("Bob"))
+    assert(resource.catalog.isEmpty)
     assert(resource1.getDatabase === null)
     assert(resource1.getTable === null)
     assert(resource1.getColumn === null)
@@ -40,6 +42,7 @@ class AccessResourceSuite extends AnyFunSuite {
     assert(resource1.getOwnerUser === "Bob")
 
     val resource2 = AccessResource(FUNCTION, "my_db_name", "my_func_name", null)
+    assert(resource.catalog.isEmpty)
     assert(resource2.getDatabase === "my_db_name")
     assert(resource2.getTable === null)
     assert(resource2.getValue("udf") === "my_func_name")
@@ -47,12 +50,61 @@ class AccessResourceSuite extends AnyFunSuite {
     assert(resource1.getColumns.isEmpty)
 
     val resource3 = AccessResource(TABLE, "my_db_name", "my_table_name", "my_col_1,my_col_2")
+    assert(resource.catalog.isEmpty)
     assert(resource3.getDatabase === "my_db_name")
     assert(resource3.getTable === "my_table_name")
     assert(resource3.getColumn === null)
     assert(resource3.getColumns.isEmpty)
 
     val resource4 = AccessResource(COLUMN, "my_db_name", "my_table_name", "my_col_1,my_col_2")
+    assert(resource.catalog.isEmpty)
+    assert(resource4.getDatabase === "my_db_name")
+    assert(resource4.getTable === "my_table_name")
+    assert(resource4.getColumn === "my_col_1,my_col_2")
+    assert(resource4.getColumns === Seq("my_col_1", "my_col_2"))
+  }
+
+  test("generate spark ranger resources with catalog") {
+    val catalog = Some("my_cat")
+
+    val resource = AccessResource(DATABASE, "my_db_name", null, null, catalog = catalog)
+    assert(resource.catalog.get === "my_cat")
+    assert(resource.getDatabase === "my_db_name")
+    assert(resource.getTable === null)
+    assert(resource.getColumn === null)
+    assert(resource.getColumns.isEmpty)
+
+    val resource1 =
+      AccessResource(
+        DATABASE,
+        null,
+        "my_table_name",
+        "my_col_1,my_col_2",
+        Some("Bob"),
+        catalog = catalog)
+    assert(resource.catalog.get === "my_cat")
+    assert(resource1.getDatabase === null)
+    assert(resource1.getTable === null)
+    assert(resource1.getColumn === null)
+    assert(resource1.getColumns.isEmpty)
+    assert(resource1.getOwnerUser === "Bob")
+
+    val resource2 = AccessResource(FUNCTION, "my_db_name", "my_func_name", null, catalog = catalog)
+    assert(resource2.getDatabase === "my_db_name")
+    assert(resource2.getTable === null)
+    assert(resource2.getValue("udf") === "my_func_name")
+    assert(resource1.getColumn === null)
+    assert(resource1.getColumns.isEmpty)
+
+    val resource3 =
+      AccessResource(TABLE, "my_db_name", "my_table_name", "my_col_1,my_col_2", catalog = catalog)
+    assert(resource3.getDatabase === "my_db_name")
+    assert(resource3.getTable === "my_table_name")
+    assert(resource3.getColumn === null)
+    assert(resource3.getColumns.isEmpty)
+
+    val resource4 =
+      AccessResource(COLUMN, "my_db_name", "my_table_name", "my_col_1,my_col_2", catalog = catalog)
     assert(resource4.getDatabase === "my_db_name")
     assert(resource4.getTable === "my_table_name")
     assert(resource4.getColumn === "my_col_1,my_col_2")

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
@@ -75,18 +75,11 @@ class AccessResourceSuite extends AnyFunSuite {
     assert(resource.getColumns.isEmpty)
 
     val resource1 =
-      AccessResource(
-        DATABASE,
-        null,
-        "my_table_name",
-        "my_col_1,my_col_2",
-        Some("Bob"),
-        catalog = catalog)
+      AccessResource(COLUMN, "my_db_name", "my_table_name", "my_col_1,my_col_2", catalog = catalog)
     assert(resource.catalog.get === "my_cat")
-    assert(resource1.getDatabase === null)
-    assert(resource1.getTable === null)
-    assert(resource1.getColumn === null)
-    assert(resource1.getColumns.isEmpty)
-    assert(resource1.getOwnerUser === "Bob")
+    assert(resource1.getDatabase === "my_db_name")
+    assert(resource1.getTable === "my_table_name")
+    assert(resource1.getColumn === "my_col_1,my_col_2")
+    assert(resource1.getColumns === Seq("my_col_1", "my_col_2"))
   }
 }

--- a/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/test/scala/org/apache/kyuubi/plugin/spark/authz/ranger/AccessResourceSuite.scala
@@ -25,7 +25,7 @@ import org.apache.kyuubi.plugin.spark.authz.ObjectType._
 class AccessResourceSuite extends AnyFunSuite {
 // scalastyle:on
   test("generate spark ranger resources") {
-    val resource = AccessResource(DATABASE, "my_db_name")
+    val resource = AccessResource(DATABASE, "my_db_name", None)
     assert(resource.catalog.isEmpty)
     assert(resource.getDatabase === "my_db_name")
     assert(resource.getTable === null)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
to close #3605.

1. add `catalog` in AccessResource for Ranger plugin auth by catalog
2. add `catalog` in PrivilegeObject, and pass it to AccessResource


### _How was this patch tested?_
- [x] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
