### PR TITLE
[KYUUBI #3990] Support for translating `SELECT TABLE_CAT FROM system.jdbc.catalogs` to `Getcatalogs` operation in Trino front protocol

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/AbstractBackendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/AbstractBackendService.scala
@@ -24,6 +24,7 @@ import scala.concurrent.CancellationException
 import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TGetResultSetMetadataResp, TProtocolVersion, TRowSet}
 
 import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.FrontendProtocol
 import org.apache.kyuubi.operation.{OperationHandle, OperationStatus}
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.session.SessionHandle
@@ -58,12 +59,14 @@ abstract class AbstractBackendService(name: String)
       statement: String,
       confOverlay: Map[String, String],
       runAsync: Boolean,
-      queryTimeout: Long): OperationHandle = {
+      queryTimeout: Long,
+      frontendProtocol: FrontendProtocol): OperationHandle = {
     sessionManager.getSession(sessionHandle).executeStatement(
       statement,
       confOverlay,
       runAsync,
-      queryTimeout)
+      queryTimeout,
+      frontendProtocol)
   }
 
   override def getTypeInfo(sessionHandle: SessionHandle): OperationHandle = {

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/BackendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/BackendService.scala
@@ -19,6 +19,7 @@ package org.apache.kyuubi.service
 
 import org.apache.hive.service.rpc.thrift._
 
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.FrontendProtocol
 import org.apache.kyuubi.operation.{OperationHandle, OperationStatus}
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.session.{SessionHandle, SessionManager}
@@ -50,7 +51,8 @@ trait BackendService {
       statement: String,
       confOverlay: Map[String, String],
       runAsync: Boolean,
-      queryTimeout: Long): OperationHandle
+      queryTimeout: Long,
+      frontendProtocol: FrontendProtocol): OperationHandle
 
   def getTypeInfo(sessionHandle: SessionHandle): OperationHandle
   def getCatalogs(sessionHandle: SessionHandle): OperationHandle

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/FrontendService.scala
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.service
 
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.FrontendProtocol
+
 /**
  * A [[FrontendService]] in Kyuubi architecture is responsible for taking requests from clients
  */
@@ -46,4 +48,9 @@ trait FrontendService {
    * Attributes map for [[FrontendService]] to expose
    */
   def attributes: Map[String, String] = Map.empty
+
+  /**
+   * Frontend protocol of the [[FrontendService]].
+   */
+  def frontendProtocol: FrontendProtocol
 }

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TBinaryFrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TBinaryFrontendService.scala
@@ -30,6 +30,7 @@ import org.apache.thrift.transport.{TServerSocket, TSSLTransportFactory}
 
 import org.apache.kyuubi.{KyuubiException, Logging}
 import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.{FrontendProtocol, THRIFT_BINARY}
 import org.apache.kyuubi.util.NamedThreadFactory
 
 /**
@@ -53,6 +54,8 @@ abstract class TBinaryFrontendService(name: String)
   protected var server: Option[TServer] = None
   private var _actualPort: Int = _
   override protected lazy val actualPort: Int = _actualPort
+
+  override def frontendProtocol: FrontendProtocol = THRIFT_BINARY
 
   // Removed OOM hook since Kyuubi #1800 to respect the hive server2 #2383
 

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TFrontendService.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/service/TFrontendService.scala
@@ -249,7 +249,8 @@ abstract class TFrontendService(name: String)
         statement,
         confOverlay.asScala.toMap,
         runAsync,
-        queryTimeout)
+        queryTimeout,
+        frontendProtocol)
       val tOperationHandle = operationHandle.toTOperationHandle
       tOperationHandle.setOperationType(TOperationType.EXECUTE_STATEMENT)
       resp.setOperationHandle(tOperationHandle)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/AbstractSession.scala
@@ -23,6 +23,7 @@ import org.apache.hive.service.rpc.thrift._
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging}
 import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.FrontendProtocol
 import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_CLIENT_IP_KEY
 import org.apache.kyuubi.operation.{Operation, OperationHandle}
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
@@ -125,7 +126,8 @@ abstract class AbstractSession(
       statement: String,
       confOverlay: Map[String, String],
       runAsync: Boolean,
-      queryTimeout: Long): OperationHandle = withAcquireRelease() {
+      queryTimeout: Long,
+      frontendProtocol: FrontendProtocol): OperationHandle = withAcquireRelease() {
     val operation = sessionManager.operationManager
       .newExecuteStatementOperation(this, statement, confOverlay, runAsync, queryTimeout)
     runOperation(operation)

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/Session.scala
@@ -19,6 +19,7 @@ package org.apache.kyuubi.session
 
 import org.apache.hive.service.rpc.thrift.{TGetInfoType, TGetInfoValue, TGetResultSetMetadataResp, TProtocolVersion, TRowSet}
 
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.FrontendProtocol
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
 import org.apache.kyuubi.operation.OperationHandle
 
@@ -51,7 +52,8 @@ trait Session {
       statement: String,
       confOverlay: Map[String, String],
       runAsync: Boolean,
-      queryTimeout: Long): OperationHandle
+      queryTimeout: Long,
+      frontendProtocol: FrontendProtocol): OperationHandle
 
   def getTableTypes: OperationHandle
   def getTypeInfo: OperationHandle

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/BackendServiceMetric.scala
@@ -19,6 +19,7 @@ package org.apache.kyuubi.server
 
 import org.apache.hive.service.rpc.thrift._
 
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.FrontendProtocol
 import org.apache.kyuubi.metrics.{MetricsConstants, MetricsSystem}
 import org.apache.kyuubi.operation.{OperationHandle, OperationStatus}
 import org.apache.kyuubi.operation.FetchOrientation.FetchOrientation
@@ -57,9 +58,16 @@ trait BackendServiceMetric extends BackendService {
       statement: String,
       confOverlay: Map[String, String],
       runAsync: Boolean,
-      queryTimeout: Long): OperationHandle = {
+      queryTimeout: Long,
+      frontendProtocol: FrontendProtocol): OperationHandle = {
     MetricsSystem.timerTracing(MetricsConstants.BS_EXECUTE_STATEMENT) {
-      super.executeStatement(sessionHandle, statement, confOverlay, runAsync, queryTimeout)
+      super.executeStatement(
+        sessionHandle,
+        statement,
+        confOverlay,
+        runAsync,
+        queryTimeout,
+        frontendProtocol)
     }
   }
 

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiMySQLFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiMySQLFrontendService.scala
@@ -29,6 +29,7 @@ import io.netty.handler.logging.{LoggingHandler, LogLevel}
 import org.apache.kyuubi._
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.{FrontendProtocol, MYSQL}
 import org.apache.kyuubi.server.mysql._
 import org.apache.kyuubi.server.mysql.NettyUtils._
 import org.apache.kyuubi.server.mysql.authentication.MySQLAuthHandler
@@ -49,6 +50,8 @@ class KyuubiMySQLFrontendService(override val serverable: Serverable)
   private var bindFuture: ChannelFuture = _
 
   @volatile protected var isStarted = false
+
+  override def frontendProtocol: FrontendProtocol = MYSQL
 
   override def initialize(conf: KyuubiConf): Unit = synchronized {
     val minThreads = conf.get(FRONTEND_MYSQL_MIN_WORKER_THREADS)
@@ -87,6 +90,7 @@ class KyuubiMySQLFrontendService(override val serverable: Serverable)
             serverAddr,
             connectionUrl,
             serverable.backendService,
+            frontendProtocol,
             execPool))
       })
     super.initialize(conf)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiRestFrontendService.scala
@@ -31,6 +31,7 @@ import org.eclipse.jetty.servlet.FilterHolder
 import org.apache.kyuubi.{KyuubiException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{FRONTEND_REST_BIND_HOST, FRONTEND_REST_BIND_PORT, FRONTEND_REST_MAX_WORKER_THREADS, METADATA_RECOVERY_THREADS}
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.{FrontendProtocol, REST}
 import org.apache.kyuubi.server.api.v1.ApiRootResource
 import org.apache.kyuubi.server.http.authentication.{AuthenticationFilter, KyuubiHttpAuthenticationFactory}
 import org.apache.kyuubi.server.ui.JettyServer
@@ -64,6 +65,8 @@ class KyuubiRestFrontendService(override val serverable: Serverable)
         Utils.findLocalInetAddress.getHostAddress
       }
     }
+
+  override def frontendProtocol: FrontendProtocol = REST
 
   override def initialize(conf: KyuubiConf): Unit = synchronized {
     this.conf = conf

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTHttpFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTHttpFrontendService.scala
@@ -38,6 +38,7 @@ import org.eclipse.jetty.util.thread.ExecutorThreadPool
 import org.apache.kyuubi.KyuubiException
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.{FrontendProtocol, THRIFT_HTTP}
 import org.apache.kyuubi.metrics.MetricsConstants.{THRIFT_HTTP_CONN_FAIL, THRIFT_HTTP_CONN_OPEN, THRIFT_HTTP_CONN_TOTAL}
 import org.apache.kyuubi.metrics.MetricsSystem
 import org.apache.kyuubi.server.http.ThriftHttpServlet
@@ -64,6 +65,8 @@ final class KyuubiTHttpFrontendService(
   private val APPLICATION_THRIFT = "application/x-thrift"
 
   override protected def hadoopConf: Configuration = KyuubiServer.getHadoopConf()
+
+  override def frontendProtocol: FrontendProtocol = THRIFT_HTTP
 
   /**
    * Configure Jetty to serve http requests. Example of a client connection URL:

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTrinoFrontendService.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/KyuubiTrinoFrontendService.scala
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.apache.kyuubi.{KyuubiException, Utils}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.config.KyuubiConf.{FRONTEND_TRINO_BIND_HOST, FRONTEND_TRINO_BIND_PORT, FRONTEND_TRINO_MAX_WORKER_THREADS}
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.{FrontendProtocol, TRINO}
 import org.apache.kyuubi.server.trino.api.v1.ApiRootResource
 import org.apache.kyuubi.server.ui.JettyServer
 import org.apache.kyuubi.service.{AbstractFrontendService, Serverable, Service}
@@ -36,6 +37,8 @@ class KyuubiTrinoFrontendService(override val serverable: Serverable)
   private var server: JettyServer = _
 
   private val isStarted = new AtomicBoolean(false)
+
+  override def frontendProtocol: FrontendProtocol = TRINO
 
   lazy val host: String = conf.get(FRONTEND_TRINO_BIND_HOST)
     .getOrElse {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
@@ -185,7 +185,8 @@ private[v1] class SessionsResource extends ApiRequestContext with Logging {
         request.getStatement,
         Map.empty,
         request.isRunAsync,
-        request.getQueryTimeout)
+        request.getQueryTimeout,
+        fe.frontendProtocol)
     } catch {
       case NonFatal(e) =>
         val errorMsg = "Error executing statement"

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLCommandHandler.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/mysql/MySQLCommandHandler.scala
@@ -28,6 +28,7 @@ import io.netty.channel.{ChannelHandlerContext, SimpleChannelInboundHandler}
 import org.apache.hive.service.rpc.thrift.TProtocolVersion
 
 import org.apache.kyuubi.{KyuubiSQLException, Logging}
+import org.apache.kyuubi.config.KyuubiConf.FrontendProtocols.FrontendProtocol
 import org.apache.kyuubi.config.KyuubiReservedKeys._
 import org.apache.kyuubi.operation.FetchOrientation
 import org.apache.kyuubi.operation.OperationState._
@@ -45,6 +46,7 @@ class MySQLCommandHandler(
     serverAddr: InetAddress,
     connectionUrl: String,
     be: BackendService,
+    frontendProtocol: FrontendProtocol,
     execPool: ThreadPoolExecutor)
   extends SimpleChannelInboundHandler[MySQLCommandPacket] with Logging {
 
@@ -189,7 +191,8 @@ class MySQLCommandHandler(
         sql,
         confOverlay = Map.empty,
         runAsync = false,
-        queryTimeout = 0)
+        queryTimeout = 0,
+        frontendProtocol)
       val opStatus = be.getOperationStatus(opHandle)
       if (opStatus.state != FINISHED) {
         throw opStatus.exception

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/sql/plan/translate/trino/GetCatalogsTranslatorNode.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/sql/plan/translate/trino/GetCatalogsTranslatorNode.scala
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.sql.plan.translate.trino
+
+import org.apache.kyuubi.operation.{GetCatalogs, KyuubiOperation}
+import org.apache.kyuubi.session.KyuubiSession
+
+case class GetCatalogsTranslatorNode() extends TrinoTranslatorNode {
+
+  override def translate(session: KyuubiSession): KyuubiOperation = {
+    new GetCatalogs(session)
+  }
+}

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/sql/plan/translate/trino/TrinoTranslatorNode.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/sql/plan/translate/trino/TrinoTranslatorNode.scala
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.sql.plan.translate.trino
+
+import org.apache.kyuubi.operation.KyuubiOperation
+import org.apache.kyuubi.session.KyuubiSession
+import org.apache.kyuubi.sql.plan.KyuubiTreeNode
+
+/**
+ * A Translate tree node with Trino front protocol, which will translate
+ * a KyuubiTreeNode to KyuubiOperation.
+ */
+trait TrinoTranslatorNode extends KyuubiTreeNode {
+
+  /**
+   * Translate a tree node to KyuubiOperation.
+   */
+  def translate(session: KyuubiSession): KyuubiOperation
+
+  override def name(): String = s"Trino front protocol translator node: ${getClass.getSimpleName}"
+}

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/OperationsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/OperationsResourceSuite.scala
@@ -136,7 +136,13 @@ class OperationsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper
 
     val op =
       if (statement.nonEmpty) {
-        fe.be.executeStatement(sessionHandle, statement, Map.empty, runAsync = true, 3000)
+        fe.be.executeStatement(
+          sessionHandle,
+          statement,
+          Map.empty,
+          runAsync = true,
+          3000,
+          fe.frontendProtocol)
       } else {
         fe.be.getCatalogs(sessionHandle)
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
close https://github.com/apache/incubator-kyuubi/issues/3990, Kyuubi introduce Trino front protocol in https://github.com/apache/incubator-kyuubi/issues/3901, this issue as a subtask to support for translating `SELECT TABLE_CAT FROM system.jdbc.catalogs` to `Getcatalogs` operation.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
