### PR TITLE
[KYUUBI #3973] Fix a conf fallback for `kyuubi-ctl list server` when kyuubi-defaults.conf use deprecated zk key

### DIFF
--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
@@ -57,8 +57,8 @@ abstract class Command[T](cliConfig: CliConfig) extends Logging {
   private def useDefaultPropertyValueIfMissing(): CliConfig = {
     var arguments: CliConfig = cliConfig.copy()
     if (cliConfig.zkOpts.zkQuorum == null) {
-      val quorum = conf.getOption(HA_ADDRESSES.key).
-        getOrElse(conf.getOption(HA_ZK_QUORUM.key).orNull)
+      val quorum =
+        conf.getOption(HA_ADDRESSES.key).getOrElse(conf.getOption(HA_ZK_QUORUM.key).orNull)
       arguments = arguments.copy(zkOpts = arguments.zkOpts.copy(zkQuorum = quorum))
       if (verbose) {
         super.info(s"Zookeeper quorum is not specified, use value from default conf: $quorum")

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
@@ -57,11 +57,13 @@ abstract class Command[T](cliConfig: CliConfig) extends Logging {
   private def useDefaultPropertyValueIfMissing(): CliConfig = {
     var arguments: CliConfig = cliConfig.copy()
     if (cliConfig.zkOpts.zkQuorum == null) {
-      conf.getOption(HA_ADDRESSES.key).foreach { v =>
-        if (verbose) {
-          super.info(s"Zookeeper quorum is not specified, use value from default conf:$v")
-        }
-        arguments = arguments.copy(zkOpts = arguments.zkOpts.copy(zkQuorum = v))
+      Seq(HA_ADDRESSES.key, HA_ZK_QUORUM.key).map(conf.getOption).find(_.isDefined) match {
+        case Some(Some(quorum)) =>
+          if (verbose) {
+            super.info(s"Zookeeper quorum is not specified, use value from default conf:$quorum")
+          }
+          arguments = arguments.copy(zkOpts = arguments.zkOpts.copy(zkQuorum = quorum))
+        case _ =>
       }
     }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
@@ -57,8 +57,7 @@ abstract class Command[T](cliConfig: CliConfig) extends Logging {
   private def useDefaultPropertyValueIfMissing(): CliConfig = {
     var arguments: CliConfig = cliConfig.copy()
     if (cliConfig.zkOpts.zkQuorum == null) {
-      val quorum =
-        conf.getOption(HA_ADDRESSES.key).getOrElse(conf.getOption(HA_ZK_QUORUM.key).orNull)
+      val quorum = conf.get(HA_ADDRESSES)
       arguments = arguments.copy(zkOpts = arguments.zkOpts.copy(zkQuorum = quorum))
       if (verbose) {
         super.info(s"Zookeeper quorum is not specified, use value from default conf: $quorum")

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/cmd/Command.scala
@@ -57,13 +57,11 @@ abstract class Command[T](cliConfig: CliConfig) extends Logging {
   private def useDefaultPropertyValueIfMissing(): CliConfig = {
     var arguments: CliConfig = cliConfig.copy()
     if (cliConfig.zkOpts.zkQuorum == null) {
-      Seq(HA_ADDRESSES.key, HA_ZK_QUORUM.key).map(conf.getOption).find(_.isDefined) match {
-        case Some(Some(quorum)) =>
-          if (verbose) {
-            super.info(s"Zookeeper quorum is not specified, use value from default conf:$quorum")
-          }
-          arguments = arguments.copy(zkOpts = arguments.zkOpts.copy(zkQuorum = quorum))
-        case _ =>
+      val quorum = conf.getOption(HA_ADDRESSES.key).
+        getOrElse(conf.getOption(HA_ZK_QUORUM.key).orNull)
+      arguments = arguments.copy(zkOpts = arguments.zkOpts.copy(zkQuorum = quorum))
+      if (verbose) {
+        super.info(s"Zookeeper quorum is not specified, use value from default conf: $quorum")
       }
     }
 

--- a/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Validator.scala
+++ b/kyuubi-ctl/src/main/scala/org/apache/kyuubi/ctl/util/Validator.scala
@@ -27,7 +27,7 @@ import org.apache.kyuubi.ctl.opt.CliConfig
 private[ctl] object Validator {
 
   def validateZkArguments(cliConfig: CliConfig): Unit = {
-    if (cliConfig.zkOpts.zkQuorum == null) {
+    if (cliConfig.zkOpts.zkQuorum == null || cliConfig.zkOpts.zkQuorum.isEmpty) {
       fail("Zookeeper quorum is not specified and no default value to load")
     }
     if (cliConfig.zkOpts.namespace == null) {

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ControlCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ControlCliSuite.scala
@@ -23,7 +23,7 @@ import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiFunSuite}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.ctl.cli.{ControlCli, ControlCliArguments}
 import org.apache.kyuubi.ctl.util.{CtlUtils, Render}
-import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ADDRESSES, HA_NAMESPACE, HA_ZK_QUORUM}
+import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ADDRESSES, HA_NAMESPACE}
 import org.apache.kyuubi.ha.client.{DiscoveryClientProvider, ServiceNodeInfo}
 import org.apache.kyuubi.zookeeper.{EmbeddedZookeeper, ZookeeperConf}
 
@@ -226,27 +226,6 @@ class ControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       s"/${namespace}_${KYUUBI_VERSION}_USER_SPARK_SQL/$user/default")
   }
 
-  test("test fallback to zk quorum config") {
-    val args = Array("list", "server")
-//    testPrematureExitForControlCliArgs(args,
-//      "Zookeeper quorum is not specified and no default value to load")
-
-    conf.set(HA_ZK_QUORUM, zkServer.getConnectString)
-
-    new ControlCliArguments(args)
-
-    withDiscoveryClient(conf) { framework =>
-      framework.createAndGetServiceNode(conf, namespace, "localhost:10000")
-
-      val expectedNodes = Seq(
-        ServiceNodeInfo(s"/$namespace", "", "localhost", 10000, Some(KYUUBI_VERSION), None)
-      )
-
-      testPrematureExitForControlCliArgs(args, getRenderedNodesInfoWithoutTitle(expectedNodes))
-    }
-
-  }
-
   test("test list zk service nodes info") {
     val uniqueNamespace = getUniqueNamespace()
     conf
@@ -273,7 +252,6 @@ class ControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
         ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10001, Some(KYUUBI_VERSION), None))
 
       testPrematureExitForControlCli(args, getRenderedNodesInfoWithoutTitle(expectedNodes))
-      new ControlCliArguments(args)
     }
   }
 

--- a/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ControlCliSuite.scala
+++ b/kyuubi-ctl/src/test/scala/org/apache/kyuubi/ctl/ControlCliSuite.scala
@@ -23,7 +23,7 @@ import org.apache.kyuubi.{KYUUBI_VERSION, KyuubiFunSuite}
 import org.apache.kyuubi.config.KyuubiConf
 import org.apache.kyuubi.ctl.cli.{ControlCli, ControlCliArguments}
 import org.apache.kyuubi.ctl.util.{CtlUtils, Render}
-import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ADDRESSES, HA_NAMESPACE}
+import org.apache.kyuubi.ha.HighAvailabilityConf.{HA_ADDRESSES, HA_NAMESPACE, HA_ZK_QUORUM}
 import org.apache.kyuubi.ha.client.{DiscoveryClientProvider, ServiceNodeInfo}
 import org.apache.kyuubi.zookeeper.{EmbeddedZookeeper, ZookeeperConf}
 
@@ -226,6 +226,27 @@ class ControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
       s"/${namespace}_${KYUUBI_VERSION}_USER_SPARK_SQL/$user/default")
   }
 
+  test("test fallback to zk quorum config") {
+    val args = Array("list", "server")
+//    testPrematureExitForControlCliArgs(args,
+//      "Zookeeper quorum is not specified and no default value to load")
+
+    conf.set(HA_ZK_QUORUM, zkServer.getConnectString)
+
+    new ControlCliArguments(args)
+
+    withDiscoveryClient(conf) { framework =>
+      framework.createAndGetServiceNode(conf, namespace, "localhost:10000")
+
+      val expectedNodes = Seq(
+        ServiceNodeInfo(s"/$namespace", "", "localhost", 10000, Some(KYUUBI_VERSION), None)
+      )
+
+      testPrematureExitForControlCliArgs(args, getRenderedNodesInfoWithoutTitle(expectedNodes))
+    }
+
+  }
+
   test("test list zk service nodes info") {
     val uniqueNamespace = getUniqueNamespace()
     conf
@@ -252,6 +273,7 @@ class ControlCliSuite extends KyuubiFunSuite with TestPrematureExit {
         ServiceNodeInfo(s"/$uniqueNamespace", "", "localhost", 10001, Some(KYUUBI_VERSION), None))
 
       testPrematureExitForControlCli(args, getRenderedNodesInfoWithoutTitle(expectedNodes))
+      new ControlCliArguments(args)
     }
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/incubator-kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->
To fix https://github.com/apache/incubator-kyuubi/issues/3973, we found similar problem during upgrade from 1.5 to 1.6


### _How was this patch tested?_
Manual test on internal cluster, UT will be added later on

- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
