### PR TITLE
[K8S][HELM] Add configuration files support to helm chart

### DIFF
--- a/docker/helm/templates/kyuubi-configmap.yaml
+++ b/docker/helm/templates/kyuubi-configmap.yaml
@@ -18,7 +18,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-kyuubi-defaults
+  name: {{ .Release.Name }}
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     app.kubernetes.io/name: {{ .Chart.Name }}
@@ -26,31 +26,22 @@ metadata:
     app.kubernetes.io/version: {{ .Values.image.tag | default .Chart.AppVersion | quote }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
+  {{- with .Values.server.conf.kyuubiEnv }}
+  kyuubi-env.sh: |
+    #!/usr/bin/env bash
+    {{- tpl . $ | nindent 4 }}
+  {{- end }}
   kyuubi-defaults.conf: |
-    #
-    # Licensed to the Apache Software Foundation (ASF) under one or more
-    # contributor license agreements.  See the NOTICE file distributed with
-    # this work for additional information regarding copyright ownership.
-    # The ASF licenses this file to You under the Apache License, Version 2.0
-    # (the "License"); you may not use this file except in compliance with
-    # the License.  You may obtain a copy of the License at
-    #
-    #    http://www.apache.org/licenses/LICENSE-2.0
-    #
-    # Unless required by applicable law or agreed to in writing, software
-    # distributed under the License is distributed on an "AS IS" BASIS,
-    # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    # See the License for the specific language governing permissions and
-    # limitations under the License.
-    #
-
-    ## Kyuubi Configurations
-
-    #
-    # kyuubi.authentication           NONE
-    #
+    ## Helm chart provided Kyuubi configurations
     kyuubi.frontend.bind.host={{ .Values.server.bind.host }}
     kyuubi.frontend.bind.port={{ .Values.server.bind.port }}
     kyuubi.kubernetes.namespace={{ .Release.Namespace }}
 
-    # Details in https://kyuubi.apache.org/docs/latest/deployment/settings.html
+    ## User provided Kyuubi configurations
+    {{- with .Values.server.conf.kyuubiDefaults }}
+    {{- tpl . $ | nindent 4 }}
+    {{- end }}
+  {{- with .Values.server.conf.log4j2 }}
+  log4j2.xml: |
+    {{- tpl . $ | nindent 4 }}
+  {{- end }}

--- a/docker/helm/templates/kyuubi-deployment.yaml
+++ b/docker/helm/templates/kyuubi-deployment.yaml
@@ -36,6 +36,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Chart.Name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        checksum/conf: {{ include (print $.Template.BasePath "/kyuubi-configmap.yaml") . | sha256sum }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
@@ -79,12 +81,12 @@ spec:
           resources:  {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - name: kyuubi-defaults
-              mountPath: {{ .Values.server.conf.mountPath }}
+            - name: conf
+              mountPath: {{ .Values.server.confDir }}
       volumes:
-        - name: kyuubi-defaults
+        - name: conf
           configMap:
-            name: {{ .Release.Name }}-kyuubi-defaults
+            name: {{ .Release.Name }}
       {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/docker/helm/values.yaml
+++ b/docker/helm/values.yaml
@@ -61,8 +61,19 @@ server:
   bind:
     host: 0.0.0.0
     port: 10009
+  confDir: /opt/kyuubi/conf
   conf:
-    mountPath: /opt/kyuubi/conf
+    # The value (templated string) is used for kyuubi-env.sh file
+    # See https://kyuubi.apache.org/docs/latest/deployment/settings.html#environments for more details
+    kyuubiEnv: ~
+
+    # The value (templated string) is used for kyuubi-defaults.conf file
+    # See https://kyuubi.apache.org/docs/latest/deployment/settings.html#kyuubi-configurations for more details
+    kyuubiDefaults: ~
+
+    # The value (templated string) is used for log4j2.xml file
+    # See https://kyuubi.apache.org/docs/latest/deployment/settings.html#logging for more details
+    log4j2: ~
 
 # Environment variables (templated)
 env: []


### PR DESCRIPTION
### _Why are the changes needed?_
The changes allow to:
1. set Kyuubi configuration files:
    - `kyuubi-env.sh`
    - `kyuubi-defaults.conf`
    - `log4j2.xml`
2. restart (recreate) Kyuubi server pods if configuration files have changed
    - this probably should be revisited after https://github.com/apache/incubator-kyuubi/pull/3983

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
