### PR TITLE
Fix `sendCredentials` wrong log

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/client/KyuubiSyncThriftClient.scala
@@ -419,7 +419,10 @@ class KyuubiSyncThriftClient private (
         warn(s"$req failed on engine side", KyuubiSQLException(resp.getStatus))
       }
     } catch {
-      case e: Exception => warn(s"$req failed on engine side", e)
+      case e: Exception =>
+        warn(s"$req failed on engine side", e)
+        // catch exception in HadoopCredentialsManager.sendCredentialsIfNeeded
+        throw e
     }
   }
 }


### PR DESCRIPTION
### _Why are the changes needed?_

`KyuubiSyncThriftClient#sendCredentials` did not throw an exception when it failed, `HadoopCredentialsManager#sendCredentialsIfNeeded` thought the send was successful and output a success log.


```
22/12/19 14:45:32,272 [KyuubiSessionManager-exec-pool: Thread-98994] 
WARN KyuubiSyncThriftClient: TRenewDelegationTokenReq  XXX  failed on engine side


22/12/19 14:45:32,273 [KyuubiSessionManager-exec-pool: Thread-98994] 
INFO HadoopCredentialsManager: Update session credentials epoch from -1 to 0
```



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
