### PR TITLE
Print engine id when get service node info

### DIFF
--- a/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
+++ b/kyuubi-ha/src/main/scala/org/apache/kyuubi/ha/client/zookeeper/ZookeeperDiscoveryClient.scala
@@ -48,6 +48,7 @@ import org.apache.kyuubi.KyuubiException
 import org.apache.kyuubi.KyuubiSQLException
 import org.apache.kyuubi.Logging
 import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiReservedKeys.KYUUBI_ENGINE_ID
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ENGINE_REF_ID
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_NODE_TIMEOUT
 import org.apache.kyuubi.ha.HighAvailabilityConf.HA_ZK_PUBLISH_CONFIGS
@@ -216,11 +217,14 @@ class ZookeeperDiscoveryClient(conf: KyuubiConf) extends DiscoveryClient {
         val path = ZKPaths.makePath(namespace, p)
         val instance = new String(zkClient.getData.forPath(path), StandardCharsets.UTF_8)
         val (host, port) = DiscoveryClient.parseInstanceHostPort(instance)
-        val version = p.split(";").find(_.startsWith("version=")).map(_.stripPrefix("version="))
-        val engineRefId = p.split(";").find(_.startsWith("refId=")).map(_.stripPrefix("refId="))
         val attributes =
-          p.split(";").map(_.split("=", 2)).filter(_.size == 2).map(kv => (kv.head, kv.last)).toMap
-        info(s"Get service instance:$instance and version:$version under $namespace")
+          p.split(";").map(_.split("=", 2)).filter(_.length == 2).map(kv =>
+            (kv.head, kv.last)).toMap
+        val version = attributes.get("version")
+        val engineRefId = attributes.get("refId")
+        val engineIdStr = attributes.get(KYUUBI_ENGINE_ID).map(" engine id:" + _).getOrElse("")
+        info(s"Get service instance:$instance$engineIdStr and version:${version.getOrElse("")} " +
+          s"under $namespace")
         ServiceNodeInfo(namespace, p, host, port, version, engineRefId, attributes)
       }
     } catch {


### PR DESCRIPTION
### _Why are the changes needed?_

Current
```
2022-12-20 13:00:34.038 INFO org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient: 
Get service instance:XXX:54876 and version:Some(1.7.0-SNAPSHOT) under /kyuubi_1.7.0-SNAPSHOT_USER_SPARK_SQL/anonymous/default
```
Fix
```
2022-12-20 13:02:01.622 INFO org.apache.kyuubi.ha.client.zookeeper.ZookeeperDiscoveryClient: 
Get service instance:XXX:55039 engine id:local-1671512509106 and version:1.7.0-SNAPSHOT under /kyuubi_1.7.0-SNAPSHOT_USER_SPARK_SQL/anonymous/default
```



### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
