### PR TITLE
[KYUUBI #3615][FOLLOWUP] Client close session when retry to open failed

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -182,7 +182,8 @@ class KyuubiSessionImpl(
               _client.closeSession()
             } catch {
               case e: Throwable =>
-                error("Close _client session failed", e)
+                warn("Error on closing broken client of engine " +
+                  s"[${engine.defaultEngineName} $host:$port]", e)
             }
           }
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -177,9 +177,9 @@ class KyuubiSessionImpl(
             throw e
         } finally {
           attempt += 1
-          if (shouldRetry) {
+          if (shouldRetry && _client != null) {
             try {
-              if (_client != null) _client.closeSession()
+              _client.closeSession()
             } catch {
               case e: Throwable =>
                 error("Close _client session failed", e)

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -182,8 +182,10 @@ class KyuubiSessionImpl(
               _client.closeSession()
             } catch {
               case e: Throwable =>
-                warn("Error on closing broken client of engine " +
-                  s"[${engine.defaultEngineName} $host:$port]", e)
+                warn(
+                  "Error on closing broken client of engine " +
+                    s"[${engine.defaultEngineName} $host:$port]",
+                  e)
             }
           }
         }

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/session/KyuubiSessionImpl.scala
@@ -177,6 +177,14 @@ class KyuubiSessionImpl(
             throw e
         } finally {
           attempt += 1
+          if (shouldRetry) {
+            try {
+              if (_client != null) _client.closeSession()
+            } catch {
+              case e: Throwable =>
+                error("Close _client session failed", e)
+            }
+          }
         }
       }
       sessionEvent.openedTime = System.currentTimeMillis()


### PR DESCRIPTION
### _Why are the changes needed?_
Client will retry to open the engine when encountering a special error in [KYUUBI #3615](https://github.com/apache/incubator-kyuubi/pull/3618), but it will lead to `TProtocol` leaks when the attempt failed.

### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [ ] [Run test](https://kyuubi.apache.org/docs/latest/develop_tools/testing.html#running-tests) locally before make a pull request
