### PR TITLE
Improve spark.driver.host assignment in Spark on K8s client mode

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/SparkSQLEngine.scala
@@ -17,7 +17,6 @@
 
 package org.apache.kyuubi.engine.spark
 
-import java.net.InetAddress
 import java.time.Instant
 import java.util.{Locale, UUID}
 import java.util.concurrent.{CountDownLatch, ScheduledExecutorService, ThreadPoolExecutor, TimeUnit}
@@ -254,7 +253,7 @@ object SparkSQLEngine extends Logging {
 
       if (!isOnK8sClusterMode) {
         // set driver host to ip instead of kyuubi pod name
-        _sparkConf.set("spark.driver.host", InetAddress.getLocalHost.getHostAddress)
+        _sparkConf.setIfMissing("spark.driver.host", Utils.findLocalInetAddress.getHostAddress)
       }
     }
 


### PR DESCRIPTION
### _Why are the changes needed?_

Before this PR, the ip address obtained in the K8s environment is incorrect, and `spark.driver.host` cannot be manually specified.

This time pr will adjust the way the IP is obtained and support the external parameter `spark.driver.host`

### _How was this patch tested?_

It has been tested in the local environment and verified as expected

Add screenshots for manual tests if appropriate

![image](https://github.com/apache/kyuubi/assets/29895551/5a0b821d-2194-441f-9635-d19f3d688057)
