### PR TITLE
[KYUUBI #5499][KYUUBI #2503] Catch any exception when closing idle session

### DIFF
--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/session/SessionManager.scala
@@ -23,6 +23,7 @@ import java.util.concurrent.{ConcurrentHashMap, Future, ThreadPoolExecutor, Time
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
+import scala.util.control.NonFatal
 
 import org.apache.hive.service.rpc.thrift.TProtocolVersion
 
@@ -312,7 +313,7 @@ abstract class SessionManager(name: String) extends CompositeService(name) {
               try {
                 closeSession(session.handle)
               } catch {
-                case e: Throwable => warn(s"Error closing idle session ${session.handle}", e)
+                case NonFatal(e) => warn(s"Error closing idle session ${session.handle}", e)
               }
             } else {
               session.closeExpiredOperations()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/latest/community/CONTRIBUTING.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### _Why are the changes needed?_
<!--
Please clarify why the changes are needed. For instance,
  1. If you add a feature, you can talk about the use case of it.
  2. If you fix a bug, you can clarify why it is a bug.
-->

Now only the KyuubiSQLException is caught when closing idle session, we wonder some exception is not caught and cause the session timeout checkTask exit.
### _How was this patch tested?_
- [ ] Add some test cases that check the changes thoroughly including negative and positive cases if possible

- [ ] Add screenshots for manual tests if appropriate

- [x] [Run test](https://kyuubi.readthedocs.io/en/master/contributing/code/testing.html#running-tests) locally before make a pull request


### _Was this patch authored or co-authored using generative AI tooling?_
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
