### PR TITLE
[KYUUBI #6024] Insert crc checksum observer after all project nodes

### DIFF
--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSQLConf.scala
@@ -296,4 +296,11 @@ object KyuubiSQLConf {
       .version("1.9.0")
       .booleanConf
       .createWithDefault(true)
+
+  val INSERT_CHECKSUM_OBSERVER_AFTER_PROJECT_ENABLED =
+    buildConf("spark.sql.optimizer.insertChecksumObserverAfterProject.enabled")
+      .doc("If true, insert crc checksum observer after all project nodes.")
+      .version("1.9.0")
+      .booleanConf
+      .createWithDefault(false)
 }

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/KyuubiSparkSQLExtension.scala
@@ -19,6 +19,7 @@ package org.apache.kyuubi.sql
 
 import org.apache.spark.sql.{FinalStageResourceManager, InjectCustomResourceProfile, SparkSessionExtensions}
 
+import org.apache.kyuubi.sql.observe.InsertChecksumObserverAfterProject
 import org.apache.kyuubi.sql.watchdog.{ForcedMaxOutputRowsRule, KyuubiUnsupportedOperationsCheck, MaxScanStrategy}
 
 // scalastyle:off line.size.limit
@@ -31,6 +32,8 @@ import org.apache.kyuubi.sql.watchdog.{ForcedMaxOutputRowsRule, KyuubiUnsupporte
 class KyuubiSparkSQLExtension extends (SparkSessionExtensions => Unit) {
   override def apply(extensions: SparkSessionExtensions): Unit = {
     KyuubiSparkSQLCommonExtension.injectCommonExtensions(extensions)
+
+    extensions.injectResolutionRule(InsertChecksumObserverAfterProject(_))
 
     extensions.injectPostHocResolutionRule(RebalanceBeforeWritingDatasource)
     extensions.injectPostHocResolutionRule(RebalanceBeforeWritingHive)

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/observe/InsertChecksumObserverAfterProject.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/main/scala/org/apache/kyuubi/sql/observe/InsertChecksumObserverAfterProject.scala
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.kyuubi.sql.observe
+
+import java.util.concurrent.atomic.AtomicLong
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.{Alias, Attribute, Cast, Crc32, Expression, Literal, NamedExpression}
+import org.apache.spark.sql.catalyst.expressions.aggregate.{Count, Sum}
+import org.apache.spark.sql.catalyst.plans.logical.{CollectMetrics, LogicalPlan, Project}
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.catalyst.trees.TreeNodeTag
+import org.apache.spark.sql.types.{BinaryType, ByteType, DecimalType, IntegerType, LongType, ShortType, StringType}
+
+import org.apache.kyuubi.sql.KyuubiSQLConf.INSERT_CHECKSUM_OBSERVER_AFTER_PROJECT_ENABLED
+import org.apache.kyuubi.sql.observe.InsertChecksumObserverAfterProject._
+
+case class InsertChecksumObserverAfterProject(session: SparkSession) extends Rule[LogicalPlan] {
+
+  private val INSERT_COLLECT_METRICS_TAG = TreeNodeTag[Unit]("__INSERT_COLLECT_METRICS_TAG")
+
+  override def apply(plan: LogicalPlan): LogicalPlan = {
+    if (conf.getConf(INSERT_CHECKSUM_OBSERVER_AFTER_PROJECT_ENABLED)) {
+      plan resolveOperatorsUp {
+        case p: Project if p.resolved && p.getTagValue(INSERT_COLLECT_METRICS_TAG).isEmpty =>
+          val metricExprs = p.output.map(toChecksumExpr) :+ countExpr
+          p.setTagValue(INSERT_COLLECT_METRICS_TAG, ())
+          CollectMetrics(nextObserverName, metricExprs, p)
+      }
+    } else {
+      plan
+    }
+  }
+
+  private def toChecksumExpr(attr: Attribute): NamedExpression = {
+    // sum(cast(crc32(cast(attr as binary)) as decimal(20, 0))) as attr_crc_sum
+    Alias(
+      Sum(Cast(Crc32(toBinaryExpr(attr)), LongDecimal)).toAggregateExpression(),
+      attr.name + "_crc_sum")()
+  }
+
+  private def toBinaryExpr(attr: Attribute): Expression = {
+    attr.dataType match {
+      case BinaryType => attr
+      case StringType | ByteType | ShortType | IntegerType | LongType => Cast(attr, BinaryType)
+      case _ => Cast(Cast(attr, StringType), BinaryType)
+    }
+  }
+
+  private def countExpr: NamedExpression = {
+    Alias(Count(Literal(1)).toAggregateExpression(), "cnt")()
+  }
+}
+
+object InsertChecksumObserverAfterProject {
+  private val id = new AtomicLong(0)
+  private def nextObserverName: String = s"CHECKSUM_OBSERVER_${id.getAndIncrement()}"
+  private val LongDecimal = DecimalType(20, 0)
+}

--- a/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/observe/InsertChecksumObserverAfterProjectSuite.scala
+++ b/extensions/spark/kyuubi-extension-spark-3-5/src/test/scala/org/apache/spark/sql/observe/InsertChecksumObserverAfterProjectSuite.scala
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql.observe
+
+import org.apache.spark.sql.{KyuubiSparkSQLExtensionTest, QueryTest, Row}
+
+import org.apache.kyuubi.sql.KyuubiSQLConf.INSERT_CHECKSUM_OBSERVER_AFTER_PROJECT_ENABLED
+
+class InsertChecksumObserverAfterProjectSuite extends KyuubiSparkSQLExtensionTest {
+
+  test("insert checksum observer after project") {
+    withSQLConf(INSERT_CHECKSUM_OBSERVER_AFTER_PROJECT_ENABLED.key -> "true") {
+      withTable("t") {
+        sql("CREATE TABLE t(i int)")
+        sql("INSERT INTO t VALUES (1), (2), (3)")
+        val df = sql("select a from (SELECT i as a FROM t) where a > 1")
+        df.collect()
+        val metrics = df.queryExecution.observedMetrics
+        assert(metrics.size == 2)
+        QueryTest.sameRows(
+          Seq(Row(BigDecimal(6569872598L), 2), Row(BigDecimal(8017165408L), 3)),
+          metrics.values.toSeq)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
# :mag: Description
## Issue References 🔗
<!-- Append the issue number after #. If there is no issue for you to link create one or -->
<!-- If there are no issues to link, please provide details here. -->

This pull request fixes #6024

## Describe Your Solution 🔧

Insert crc checksum observer after all `Project` nodes to compare data at all stage of SQL.


## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

#### Behavior Without This Pull Request :coffin:


#### Behavior With This Pull Request :tada:


#### Related Unit Tests

org.apache.spark.sql.observe.InsertChecksumObserverAfterProjectSuite

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
