### PR TITLE
Drop building support for Flink 1.16

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -185,7 +185,6 @@ jobs:
         java:
           - 8
         flink:
-          - '1.16'
           - '1.17'
           - '1.18'
         flink-archive: [ "" ]

--- a/pom.xml
+++ b/pom.xml
@@ -2316,13 +2316,6 @@
         </profile>
 
         <profile>
-            <id>flink-1.16</id>
-            <properties>
-                <flink.version>1.16.3</flink.version>
-            </properties>
-        </profile>
-
-        <profile>
             <id>flink-1.17</id>
             <properties>
                 <flink.version>1.17.2</flink.version>


### PR DESCRIPTION
# Description

We already marked the support for Flink 1.16 as deprecated, this PR drops the building support for Flink 1.16, while we still keep the cross-version verification to ensure the Flink engine still works on Flink 1.16 runtime.

## Types of changes :bookmark:
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Test Plan 🧪

Pass GA.

---

# Checklist 📝
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] This patch was not authored or co-authored using [Generative Tooling](https://www.apache.org/legal/generative-tooling.html)

**Be nice. Be informative.**
