### PR TITLE
Add serverOnly flag for metrics config items

### DIFF
--- a/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConf.scala
+++ b/kyuubi-metrics/src/main/scala/org/apache/kyuubi/metrics/MetricsConf.scala
@@ -27,12 +27,14 @@ object MetricsConf {
 
   val METRICS_ENABLED: ConfigEntry[Boolean] =
     buildConf("kyuubi.metrics.enabled")
+      .serverOnly
       .doc("Set to true to enable kyuubi metrics system")
       .version("1.2.0")
       .booleanConf
       .createWithDefault(true)
 
   val METRICS_REPORTERS: ConfigEntry[Set[String]] = buildConf("kyuubi.metrics.reporters")
+    .serverOnly
     .doc("A comma-separated list for all metrics reporters" +
       "<ul>" +
       " <li>CONSOLE - ConsoleReporter which outputs measurements to CONSOLE periodically.</li>" +
@@ -49,24 +51,28 @@ object MetricsConf {
     .createWithDefault(Set(PROMETHEUS.toString))
 
   val METRICS_CONSOLE_INTERVAL: ConfigEntry[Long] = buildConf("kyuubi.metrics.console.interval")
+    .serverOnly
     .doc("How often should report metrics to console")
     .version("1.2.0")
     .timeConf
     .createWithDefault(Duration.ofSeconds(5).toMillis)
 
   val METRICS_JSON_LOCATION: ConfigEntry[String] = buildConf("kyuubi.metrics.json.location")
+    .serverOnly
     .doc("Where the JSON metrics file located")
     .version("1.2.0")
     .stringConf
     .createWithDefault("metrics")
 
   val METRICS_JSON_INTERVAL: ConfigEntry[Long] = buildConf("kyuubi.metrics.json.interval")
+    .serverOnly
     .doc("How often should report metrics to JSON file")
     .version("1.2.0")
     .timeConf
     .createWithDefault(Duration.ofSeconds(5).toMillis)
 
   val METRICS_PROMETHEUS_PORT: ConfigEntry[Int] = buildConf("kyuubi.metrics.prometheus.port")
+    .serverOnly
     .doc("Prometheus metrics HTTP server port")
     .version("1.2.0")
     .intConf
@@ -74,6 +80,7 @@ object MetricsConf {
     .createWithDefault(10019)
 
   val METRICS_PROMETHEUS_PATH: ConfigEntry[String] = buildConf("kyuubi.metrics.prometheus.path")
+    .serverOnly
     .doc("URI context path of prometheus metrics HTTP server")
     .version("1.2.0")
     .stringConf
@@ -82,12 +89,14 @@ object MetricsConf {
 
   val METRICS_PROMETHEUS_LABELS_INSTANCE_ENABLED: ConfigEntry[Boolean] =
     buildConf("kyuubi.metrics.prometheus.labels.instance.enabled")
+      .serverOnly
       .doc("Whether to add instance label to prometheus metrics")
       .version("1.10.2")
       .booleanConf
       .createWithDefault(false)
 
   val METRICS_SLF4J_INTERVAL: ConfigEntry[Long] = buildConf("kyuubi.metrics.slf4j.interval")
+    .serverOnly
     .doc("How often should report metrics to SLF4J logger")
     .version("1.2.0")
     .timeConf


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

MetricsSystem is only used for KyuubiServer, all the metrics config items are server only.
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

GA.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
