### PR TITLE
Respect terminated app state when building batch info from metadata

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -91,7 +91,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
 
   private def sessionManager = fe.be.sessionManager.asInstanceOf[KyuubiSessionManager]
 
-  private def buildBatch(session: KyuubiBatchSession): Batch = {
+  private def buildBatchFromSession(session: KyuubiBatchSession): Batch = {
     val batchOp = session.batchJobSubmissionOp
     val batchOpStatus = batchOp.getStatus
 
@@ -125,7 +125,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       Map.empty[String, String].asJava)
   }
 
-  private def buildBatch(
+  private def buildBatchFromMetadataAndAppInfo(
       metadata: Metadata,
       batchAppStatus: Option[ApplicationInfo]): Batch = {
     batchAppStatus.map { appStatus =>
@@ -316,7 +316,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
         } match {
           case Success(sessionHandle) =>
             sessionManager.getBatchSession(sessionHandle) match {
-              case Some(batchSession) => buildBatch(batchSession)
+              case Some(batchSession) => buildBatchFromSession(batchSession)
               case None => throw new IllegalStateException(
                   s"can not find batch $batchId from metadata store")
             }
@@ -349,7 +349,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
     val userName = fe.getSessionUser(Map.empty[String, String])
     val sessionHandle = formatSessionHandle(batchId)
     sessionManager.getBatchSession(sessionHandle).map { batchSession =>
-      buildBatch(batchSession)
+      buildBatchFromSession(batchSession)
     }.getOrElse {
       sessionManager.getBatchMetadata(batchId).map { metadata =>
         val isOperationTerminated = (StringUtils.isNotBlank(metadata.state)
@@ -363,7 +363,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
           isApplicationTerminated ||
           metadata.kyuubiInstance == fe.connectionUrl) {
           if (isApplicationTerminated && !isOperationTerminated) {
-            buildBatch(
+            buildBatchFromMetadataAndAppInfo(
               metadata,
               Some(ApplicationInfo(
                 metadata.engineId,
@@ -398,7 +398,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
                   engineState = appInfo.state.toString,
                   engineError = appInfo.error))
               }
-              buildBatch(metadata, batchAppStatus)
+              buildBatchFromMetadataAndAppInfo(metadata, batchAppStatus)
           }
         }
       }.getOrElse {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

Respect terminated app state when building batch info from metadata

It is a followup for https://github.com/apache/kyuubi/pull/2911, 
https://github.com/apache/kyuubi/blob/9e40e39c39566c435ad92f0659c6120b9f2b8578/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala#L128-L142

1. if the kyuubi instance is unreachable during maintain window.
2. the batch app state has been terminated, and the app stated was backfilled by another kyuubi instance peer, see #2911
3. the batch state in the metadata table is still PENDING/RUNNING
4. return the terminated batch state for such case instead of `PENDING or RUNNING`.
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
GA and IT.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
