### PR TITLE
[K8S][HELM] Support additional labels for PrometheusRule

### DIFF
--- a/charts/kyuubi/templates/kyuubi-alert.yaml
+++ b/charts/kyuubi/templates/kyuubi-alert.yaml
@@ -22,6 +22,9 @@ metadata:
   name: {{ .Release.Name }}
   labels:
     {{- include "kyuubi.labels" . | nindent 4 }}
+    {{- if .Values.metrics.prometheusRule.labels }}
+      {{- toYaml .Values.metrics.prometheusRule.labels | nindent 4 }}
+    {{- end }}
 spec:
   groups:
     {{- toYaml .Values.metrics.prometheusRule.groups | nindent 4 }}

--- a/charts/kyuubi/templates/kyuubi-podmonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-podmonitor.yaml
@@ -23,7 +23,7 @@ metadata:
   labels:
     {{- include "kyuubi.labels" . | nindent 4 }}
     {{- if .Values.metrics.podMonitor.labels }}
-    {{- toYaml .Values.metrics.podMonitor.labels | nindent 4 }}
+      {{- toYaml .Values.metrics.podMonitor.labels | nindent 4 }}
     {{- end }}
 spec:
   selector:

--- a/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
+++ b/charts/kyuubi/templates/kyuubi-servicemonitor.yaml
@@ -23,7 +23,7 @@ metadata:
   labels:
     {{- include "kyuubi.labels" . | nindent 4 }}
     {{- if .Values.metrics.serviceMonitor.labels }}
-    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+      {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
     {{- end }}
 spec:
   selector:

--- a/charts/kyuubi/templates/kyuubi-statefulset.yaml
+++ b/charts/kyuubi/templates/kyuubi-statefulset.yaml
@@ -41,7 +41,7 @@ spec:
         checksum/conf: {{ include (print $.Template.BasePath "/kyuubi-configmap.yaml") . | sha256sum }}
         checksum/conf-hadoop: {{ include (print $.Template.BasePath "/kyuubi-hadoop-configmap.yaml") . | sha256sum }}
         {{- with .Values.podAnnotations }}
-        {{- toYaml . | nindent 8 }}
+          {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/kyuubi/values.yaml
+++ b/charts/kyuubi/values.yaml
@@ -346,3 +346,5 @@ metrics:
     enabled: false
     # Content of Prometheus rule file
     groups: []
+    # Additional labels to be used to make PrometheusRule discovered by Prometheus
+    labels: {}


### PR DESCRIPTION
### Why are the changes needed?
The change is needed to be able to add additional labels to `PrometheusRule` similar to [podMonitor](https://github.com/apache/kyuubi/blob/523722788fd4fbf661cce8572c529af09c34079a/charts/kyuubi/values.yaml#L321-L330) and [serviceMonitor](https://github.com/apache/kyuubi/blob/523722788fd4fbf661cce8572c529af09c34079a/charts/kyuubi/values.yaml#L333-L341).
The PR also includes minor identation fixes.


### How was this patch tested?
```shell
helm template kyuubi charts/kyuubi --set metrics.prometheusRule.enabled=true --set metrics.prometheusRule.labels.test-label=true -s templates/kyuubi-alert.yaml
---
# Source: kyuubi/templates/kyuubi-alert.yaml
apiVersion: monitoring.coreos.com/v1
kind: PrometheusRule
metadata:
  name: kyuubi
  labels:
    helm.sh/chart: kyuubi-0.1.0
    app.kubernetes.io/name: kyuubi
    app.kubernetes.io/instance: kyuubi
    app.kubernetes.io/version: "1.10.0"
    app.kubernetes.io/managed-by: Helm
    test-label: true
spec:
  groups:
    []
```

### Was this patch authored or co-authored using generative AI tooling?
No

