### PR TITLE
[DOC] Fix nonexisting document 'client/advanced/features/engine_pool'

### DIFF
--- a/docs/client/advanced/features/index.rst
+++ b/docs/client/advanced/features/index.rst
@@ -22,9 +22,6 @@ Advanced Features
     engine_type
     engine_share_level
     engine_ttl
-    engine_pool
     engine_resources
     scala
     plan_only
-
-


### PR DESCRIPTION
### Why are the changes needed?

The PR fixes `nonexisting document 'client/advanced/features/engine_pool'` warning:
```shell
./kyuubi/docs/client/advanced/features/index.rst:19: WARNING: toctree contains reference to nonexisting document 'client/advanced/features/engine_pool' [toc.not_readable]
```
The document was deleted in the PR https://github.com/apache/kyuubi/pull/7118.


### How was this patch tested?

Checked that there is no  warning anymoreduring the documentation build process.
```shell
make html
```


### Was this patch authored or co-authored using generative AI tooling?

No

