### PR TITLE
[CI] Skip running tests for documentation only changes

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -22,10 +22,14 @@ on:
     branches:
       - master
       - branch-*
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
       - master
       - branch-*
+    paths-ignore:
+      - 'docs/**'
 
 concurrency:
   group: test-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
### Why are the changes needed?

The PR disables heavy CI tests for documentation-only changes as not needed to speed up PR creation and save resources.


### How was this patch tested?

The PR was not tested and relies on the official documentation:
 - [If you define both branches/branches-ignore and paths/paths-ignore, the workflow will only run when both filters are satisfied.](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore:~:text=the%20path%20again.-,If%20you%20define%20both%20branches/branches%2Dignore%20and%20paths/paths%2Dignore%2C%20the%20workflow%20will%20only%20run%20when%20both%20filters%20are%20satisfied.,-The%20paths%20and)
 - [Example: Excluding paths](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-excluding-paths)


### Was this patch authored or co-authored using generative AI tooling?

No

