### PR TITLE
[DOC] Fix "duplicate label usage" warnings

### DIFF
--- a/docs/tools/kyuubi-admin.rst
+++ b/docs/tools/kyuubi-admin.rst
@@ -14,16 +14,14 @@
    limitations under the License.
 
 Kyuubi Administer Tool
-=======================
+======================
 
 .. versionadded:: 1.6.0
 
 Kyuubi administer tool(kyuubi-admin) provides administrators with some maintenance operations against a kyuubi server or cluster.
 
-.. _installation:
-
 Installation
--------------------------------------
+------------
 To install kyuubi-admin, you need to unpack the tarball. For example,
 
 .. parsed-literal::
@@ -41,21 +39,14 @@ This will result in the creation of a subdirectory named apache-kyuubi-|release|
    │   ├── ...
    ├── ...
 
-
-.. _usage:
-
 Usage
--------------------------------------
+-----
 .. code-block:: bash
 
    bin/kyuubi-admin --help
 
-
-
-.. _refresh_config:
-
 Refresh config
--------------------------------------
+--------------
 
 Refresh the config with specified type.
 
@@ -76,10 +67,8 @@ Usage: ``bin/kyuubi-admin refresh config [options] [<configType>]``
    * - denyUsers
      - The user in the deny list will be denied to connect to kyuubi server.
 
-.. _list_engine:
-
 List Engines
--------------------------------------
+------------
 
 Prints a table of the key information about the specified engines.
 
@@ -100,19 +89,15 @@ Usage: ``bin/kyuubi-admin list engine [options]``
    * - --hs2ProxyUser
      - The proxy user to impersonate. When specified, it will list engines for the hs2ProxyUser.
 
-.. _list_server:
-
 List Servers
--------------------------------------
+------------
 
 Prints a table of the key information about the servers.
 
 Usage: ``bin/kyuubi-admin list server``
 
-.. _delete_engine:
-
 Delete an Engine
--------------------------------------
+----------------
 
 Delete the specified engine.
 

--- a/docs/tools/kyuubi-ctl.rst
+++ b/docs/tools/kyuubi-ctl.rst
@@ -16,8 +16,6 @@
 Administrator CLI
 =================
 
-.. _usage:
-
 Usage
 -----
 .. code-block:: bash
@@ -88,14 +86,10 @@ Output
 
       -h, --help               Show help message and exit.
 
-.. _manage_kyuubi_servers:
-
 Manage kyuubi servers
 ---------------------
 
 You can specify the zookeeper address(``--zk-quorum``) and namespace(``--namespace``), version(``--version``) parameters to query a specific kyuubi server cluster.
-
-.. _list_servers:
 
 List server
 ***********
@@ -105,8 +99,6 @@ List all the service nodes for a particular domain.
 .. code-block:: bash
 
    bin/kyuubi-ctl list server
-
-.. _create_servers:
 
 Create server
 *************
@@ -119,18 +111,14 @@ First read ``kyuubi.ha.namespace`` in ``conf/kyuubi-defaults.conf``, if there ar
 
    bin/kyuubi-ctl create server --namespace XXX
 
-.. _get_servers:
-
 Get server
-***********
+**********
 
 Get Kyuubi server info of domain.
 
 .. code-block:: bash
 
    bin/kyuubi-ctl get server --host XXX --port YYY
-
-.. _delete_servers:
 
 Delete server
 *************
@@ -142,8 +130,6 @@ After the server node is deleted, the kyuubi server stops opening new sessions a
 .. code-block:: bash
 
    bin/kyuubi-ctl delete server --host XXX --port YYY
-
-.. _manage_kyuubi_engines:
 
 Manage kyuubi engines
 ---------------------
@@ -172,8 +158,6 @@ The ``--user`` parameter is the group name corresponding to the user.
 
 The ``--user`` parameter is the user who started the kyuubi server.
 
-.. _list_engines:
-
 List engine
 ***********
 
@@ -189,18 +173,14 @@ The management share level is SERVER, the user who starts the kyuubi server is A
 
    bin/kyuubi-ctl list engine --user A --engine-type TRINO --engine-subdomain adhoc --engine-share-level SERVER
 
-.. _get_engines:
-
 Get engine
-***********
+**********
 
 Get Kyuubi engine info belong to a user.
 
 .. code-block:: bash
 
    bin/kyuubi-ctl get engine --user AAA --host XXX --port YYY
-
-.. _delete_engines:
 
 Delete engine
 *************


### PR DESCRIPTION
### Why are the changes needed?

The main purpose of the PR is to fix the following `duplicate label usage` warnings:
```shell
./kyuubi/docs/tools/kyuubi-admin.rst:48: WARNING: duplicate label usage, other instance in ./kyuubi/docs/tools/index.rst
./kyuubi/docs/tools/kyuubi-ctl.rst:22: WARNING: duplicate label usage, other instance in ./kyuubi/docs/tools/kyuubi-admin.rst
```
Changes:
 - The PR deletes all labels from `./kyuubi/docs/tools/index.rst` and `./kyuubi/docs/tools/kyuubi-admin.rst`, as they are not used (there are no references to them).
 - The PR also fixes the length of the punctuation used to highlight section titles.


### How was this patch tested?

Checked that there are no warnings anymore during the documentation build process and the pages look the same.
```shell
make html
```


### Was this patch authored or co-authored using generative AI tooling?

No
