### PR TITLE
[CI] Skip Python Client unit tests when only documentation changes are made

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,10 +22,14 @@ on:
     branches:
       - master
       - branch-*
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
       - master
       - branch-*
+    paths-ignore:
+      - 'docs/**'
 
 concurrency:
   group: python-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
### Why are the changes needed?
The PR disables Python Client unit tests for documentation-only changes as not needed, similar to PR https://github.com/apache/kyuubi/pull/7223.


### How was this patch tested?
The PR was not tested directly, but it is similar to already tested PR https://github.com/apache/kyuubi/pull/7223.


### Was this patch authored or co-authored using generative AI tooling?
No
