### PR TITLE
Fix countMetadata if the params is empty

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -280,7 +280,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
     queryBuilder.append(s" ${assembleWhereClause(filter, params)}")
     val query = queryBuilder.toString
     JdbcUtils.executeQueryWithRowMapper(query) { stmt =>
-      setStatementParams(stmt, params)
+      setStatementParams(stmt, params: _*)
     } { resultSet =>
       resultSet.getInt(1)
     }.head

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreSuite.scala
@@ -224,6 +224,7 @@ class JDBCMetadataStoreSuite extends KyuubiFunSuite {
     jdbcMetadataStore.updateMetadata(newBatchState)
 
     assert(jdbcMetadataStore.getMetadata(batchId) == newBatchState)
+    assert(jdbcMetadataStore.countMetadata(MetadataFilter()) > 0)
 
     assert(jdbcMetadataStore.getMetadataList(
       MetadataFilter(


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Without this PR.
It will meet issue if the params is empty. 
```
jdbcMetadataStore.countMetadata(MetadataFilter())
```
<img width="1443" height="742" alt="image" src="https://github.com/user-attachments/assets/e099c469-7468-4d6a-90e8-e20ba144316b" />

<img width="877" height="160" alt="image" src="https://github.com/user-attachments/assets/1773d395-87f7-4108-ac6c-21c2ca04ca71" />


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

UT.
### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
