### PR TITLE
[KYUUBI #7235][SPARK] add async fetch hdfs result

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/IterableAsyncFetchIterator.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/operation/IterableAsyncFetchIterator.scala
@@ -1,0 +1,174 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark.operation
+
+import java.util.concurrent._
+
+import scala.reflect.ClassTag
+
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+import org.apache.kyuubi.Logging
+import org.apache.kyuubi.engine.spark.schema.SparkTRowSetGenerator
+import org.apache.kyuubi.operation.FetchIterator
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TProtocolVersion, TRowSet};
+
+class IterableAsyncFetchIterator[A: ClassTag](
+    iterable: Iterable[A],
+    prefetchExecutor: ExecutorService,
+    resultSchema: StructType,
+    protocolVersion: TProtocolVersion,
+    asyncFetchTimeout: Long,
+    rowsetsQueueSize: Int) extends FetchIterator[A] with Logging {
+  val results = new LinkedBlockingQueue[(TRowSet, Int)](rowsetsQueueSize)
+  private var future: Future[Boolean] = _
+  private val tRowSetGenerator = new SparkTRowSetGenerator()
+  var rowSetSize: Int = -1
+
+  private var iter: Iterator[A] = iterable.iterator
+  private var iterEx: Iterator[Row] = iter.asInstanceOf[Iterator[Row]]
+
+  private var fetchStart: Long = 0
+  private var position: Long = 0
+
+  private def startPrefetchThread(): Unit = {
+    val task = new Callable[Boolean] {
+      override def call(): Boolean = {
+        var succeeded = true
+        try {
+          var isEmptyIter = false
+          while (!isEmptyIter) {
+            val taken = iterEx.take(rowSetSize)
+            val rows = taken.toArray
+            val rowSet = tRowSetGenerator.toTRowSet(
+              rows.toSeq,
+              resultSchema,
+              protocolVersion)
+            results.put(rowSet, rows.length)
+            isEmptyIter = (rows.length == 0)
+          }
+        } catch {
+          case e: Throwable =>
+            error(s"An exception occurred in the prefetch thread. message: ${e.getMessage}")
+            e.printStackTrace(System.err)
+            results.clear()
+            succeeded = false
+        }
+        succeeded
+      }
+    }
+  }
+
+  def takeRowSet(numRows: Int): TRowSet = {
+    if (rowSetSize < 0) {
+      rowSetSize = numRows
+      startPrefetchThread()
+    } else {
+      if (numRows != rowSetSize) {
+        throw new Exception("The current size of row set is different from " +
+          "that of the initial call.")
+      }
+    }
+    var result: (TRowSet, Int) = results.poll(3000, TimeUnit.MILLISECONDS)
+    if (result == null && !future.isDone) {
+      warn("Queue of prefetched results is empty, the prefetch thread my be stuck," +
+        s"retry to retrieve result with a timeout of ${asyncFetchTimeout} ms")
+      result = results.poll(asyncFetchTimeout, TimeUnit.MILLISECONDS)
+    }
+    if (result == null) {
+      if (future.isDone) {
+        val prefetchSucceeded = future.get()
+        if (!prefetchSucceeded) {
+          throw new Exception("An exception occurred in the prefetch thread.")
+        } else {
+          result = results.poll()
+          if (result == null) {
+            error("Thrift client fetched more than one empty rowSet!")
+            result = (
+              tRowSetGenerator.toTRowSet(
+                Seq.empty[Row],
+                resultSchema,
+                protocolVersion),
+              0)
+          }
+        }
+      } else {
+        future.cancel(true)
+        throw new Exception("the prefetch thread is stuck.")
+      }
+    }
+    position += result._2
+    result._1
+  }
+
+  /**
+   * Begin a fetch block, forward from the current position.
+   * Resets the fetch start offset.
+   */
+  override def fetchNext(): Unit = fetchStart = position
+
+  /**
+   * Begin a fetch block, moving the iterator to the given position.
+   * Resets the fetch start offset.
+   *
+   * @param pos index to move a position of iterator.
+   */
+  override def fetchAbsolute(pos: Long): Unit = {
+    if (future != null) {
+      future.cancel(true)
+      future.get(5, TimeUnit.SECONDS)
+      if (!future.isDone) {
+        throw new Exception("Cancel the prefetch thread failed")
+      }
+      future = null
+      results.clear()
+    }
+    val newPos = pos max 0
+    resetPosition()
+    while (position < newPos && hasNextInternal) {
+      nextInternal()
+    }
+    rowSetSize = -1
+  }
+
+  override def getFetchStart: Long = fetchStart
+
+  override def getPosition: Long = position
+
+  override def hasNext: Boolean = {
+    throw new Exception("Unsupported function: IterableAsyncFetchIterator.hasNext")
+  }
+  def hasNextInternal: Boolean = iter.hasNext
+  override def next(): A = {
+    throw new Exception("Unsupported function: IterableAsyncFetchIterator.next")
+  }
+  def nextInternal(): A = {
+    position += 1
+    iter.next()
+  }
+
+  private def resetPosition(): Unit = {
+    if (position != 0) {
+      iter = iterable.iterator
+      iterEx = iter.asInstanceOf[Iterator[Row]]
+      position = 0
+      fetchStart = 0
+    }
+  }
+}

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkSaveFilePrefetchSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/operation/SparkSaveFilePrefetchSuite.scala
@@ -1,0 +1,244 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark.operation
+
+import java.sql.ResultSet
+
+import scala.collection.JavaConverters._
+
+import org.apache.hadoop.fs.Path
+
+import org.apache.kyuubi.config.KyuubiConf
+import org.apache.kyuubi.config.KyuubiConf.{ENGINE_JDBC_FETCH_SIZE, OPERATION_RESULT_PREFETCH, OPERATION_RESULT_SAVE_TO_FILE, OPERATION_RESULT_SAVE_TO_FILE_DIR, OPERATION_RESULT_SAVE_TO_FILE_MIN_ROWS, OPERATION_RESULT_SAVE_TO_FILE_MINSIZE}
+import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
+import org.apache.kyuubi.engine.spark.session.SparkSQLSessionManager
+import org.apache.kyuubi.jdbc.hive.KyuubiStatement
+import org.apache.kyuubi.operation.HiveJDBCTestHelper
+import org.apache.kyuubi.shaded.hive.service.rpc.thrift.{TExecuteStatementReq, TFetchOrientation, TFetchResultsReq, TStatusCode}
+
+class SparkSaveFilePrefetchSuite extends WithSparkSQLEngine with HiveJDBCTestHelper {
+  val defaultFetchSize: Int = 300
+
+  override def withKyuubiConf: Map[String, String] = {
+    Map(
+      OPERATION_RESULT_SAVE_TO_FILE.key -> "true",
+      OPERATION_RESULT_SAVE_TO_FILE_MINSIZE.key -> "100",
+      OPERATION_RESULT_SAVE_TO_FILE_MIN_ROWS.key -> "100",
+      OPERATION_RESULT_PREFETCH.key -> "true",
+      ENGINE_JDBC_FETCH_SIZE.key -> defaultFetchSize.toString)
+  }
+
+  override protected def jdbcUrl: String =
+    s"jdbc:hive2://${engine.frontendServices.head.connectionUrl}/;#spark.ui.enabled=false"
+
+  private def sessionHandle: String = {
+    engine.backendService.sessionManager.allSessions().head.handle.identifier.toString
+  }
+
+  private def getOperationHandle: String = {
+    val operationHandle =
+      engine.backendService.sessionManager.operationManager.allOperations()
+        .head.getHandle.identifier.toString
+    s"$sessionHandle/$operationHandle"
+  }
+
+  test("test save file effect") {
+    var enginePath: Path = new Path(kyuubiConf.get(OPERATION_RESULT_SAVE_TO_FILE_DIR))
+    val sparkFileSystem = enginePath.getFileSystem(spark.sparkContext.hadoopConfiguration)
+    var sessionPath: Path = enginePath
+    withJdbcStatement("table1") { statement =>
+      enginePath =
+        engine.backendService.sessionManager.asInstanceOf[SparkSQLSessionManager]
+          .getEngineResultSavePath()
+      sessionPath = new Path(s"$enginePath/$sessionHandle")
+      statement.asInstanceOf[KyuubiStatement].getConnection.getClientInfo
+      statement.setFetchSize(100)
+      val expectedStoppedNum = 1000
+      // test save result skip command
+      statement.executeQuery(s"create table table1 as select id from range($expectedStoppedNum)")
+      var resultPath = new Path(s"$enginePath/$getOperationHandle")
+      assert(!sparkFileSystem.exists(resultPath))
+      statement.executeQuery("show tables")
+      resultPath = new Path(s"$enginePath/$getOperationHandle")
+      assert(!sparkFileSystem.exists(resultPath))
+      // test query save result
+      val res = statement.executeQuery("select * from table1")
+      resultPath = new Path(s"$enginePath/$getOperationHandle")
+      assert(sparkFileSystem.exists(resultPath))
+      res.close()
+      assert(!sparkFileSystem.exists(resultPath))
+      // test rows number less than minRows
+      statement.executeQuery("select * from table1 limit 10")
+      resultPath = new Path(s"$enginePath/$getOperationHandle")
+      assert(!sparkFileSystem.exists(resultPath))
+    }
+    // delete session path after session close
+    assert(!sparkFileSystem.exists(sessionPath))
+  }
+
+  test("check query results with prefetch") {
+    withJdbcStatement("table1") { statement =>
+      statement.setFetchSize(100)
+      val expectedStoppedNum = 1000
+      statement.executeQuery(s"create table table1 as select id from range($expectedStoppedNum)")
+      // check whole query result
+      val res = statement.executeQuery("select * from table1")
+      var numRecords = 0
+      while (res.next()) {
+        assert(res.getLong(1) == numRecords)
+        numRecords += 1
+      }
+      assert(numRecords == expectedStoppedNum)
+    }
+  }
+
+  ignore("[invalid] change rowSetSize while fetching results") {
+    withJdbcStatement("table1") { statement =>
+      statement.setFetchSize(100)
+      val expectedStoppedNum = 1000
+      statement.executeQuery(s"create table table1 as select id from range($expectedStoppedNum)")
+      val res = statement.executeQuery("select * from table1")
+      var numRecords = 0
+      while (res.next()) {
+        assert(res.getLong(1) == numRecords)
+        numRecords += 1
+        if (numRecords == 200) {
+          statement.setFetchSize(200)
+        }
+      }
+      assert(numRecords == expectedStoppedNum)
+    }
+  }
+
+  ignore("fetch record with specified location while fetching results") {
+    withJdbcStatement("table1") { statement =>
+      statement.setFetchSize(100)
+      val expectedStoppedNum = 1000
+      statement.executeQuery(s"create table table1 as select id from range($expectedStoppedNum)")
+      val res = statement.executeQuery("select * from table1")
+      var numRecords = 0
+      while (res.next()) {
+        assert(res.getLong(1) == numRecords)
+        numRecords += 1
+        if (numRecords == 200) {
+          // absolute method is not supported in kyuubi hive driver
+          res.absolute(0)
+          numRecords = 0
+        }
+      }
+      assert(numRecords == expectedStoppedNum)
+    }
+  }
+
+  ignore("change orientation while fetching results") {
+    withJdbcStatement("table1") { statement =>
+      statement.setFetchSize(100)
+      // setFetchDirection method is not supported in kyuubi hive driver
+      statement.setFetchDirection(ResultSet.FETCH_REVERSE)
+      val expectedStoppedNum = 1000
+      statement.executeQuery(s"create table table1 as select id from range($expectedStoppedNum)")
+      val res = statement.executeQuery("select * from table1")
+      var numRecords = 0
+      while (res.next()) {
+        assert(res.getLong(1) == numRecords)
+        numRecords += 1
+      }
+      assert(numRecords == expectedStoppedNum)
+    }
+  }
+
+  test("test fetch orientation with prefetch") {
+    val sql = "SELECT id FROM range(1000)"
+
+    withSessionConf(Map())()() {
+      withSessionHandle { (client, handle) =>
+        val req = new TExecuteStatementReq()
+        req.setSessionHandle(handle)
+        req.setStatement(sql)
+
+        val tExecuteStatementResp = client.ExecuteStatement(req)
+        val opHandle = tExecuteStatementResp.getOperationHandle
+        waitForOperationToComplete(client, opHandle)
+        val fetchSize: Int = 300
+
+        // fetch next from before first row
+        val tFetchResultsReq1 =
+          new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_NEXT, fetchSize)
+        val tFetchResultsResp1 = client.FetchResults(tFetchResultsReq1)
+        assert(tFetchResultsResp1.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq1 = tFetchResultsResp1.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala
+        assertResult(Seq.range(0, fetchSize))(idSeq1)
+
+        // fetch next from first rowSet
+        val tFetchResultsReq2 =
+          new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_NEXT, fetchSize)
+        val tFetchResultsResp2 = client.FetchResults(tFetchResultsReq2)
+        assert(tFetchResultsResp2.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq2 = tFetchResultsResp2.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala
+        assertResult(Seq.range(fetchSize, fetchSize * 2))(idSeq2)
+
+        // fetch prior from second rowSet, expected got first rowSet
+        val tFetchResultsReq3 =
+          new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_PRIOR, fetchSize)
+        val tFetchResultsResp3 = client.FetchResults(tFetchResultsReq3)
+        assert(tFetchResultsResp3.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+
+        // fetch first
+        val tFetchResultsReq4 =
+          new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_FIRST, fetchSize)
+        val tFetchResultsResp4 = client.FetchResults(tFetchResultsReq4)
+        assert(tFetchResultsResp4.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+      }
+    }
+  }
+
+  test("change rowSetSize while fetching results") {
+    val sql = "SELECT id FROM range(1000)"
+
+    withSessionConf(Map(KyuubiConf.OPERATION_RESULT_PREFETCH.key -> "true"))()() {
+      withSessionHandle { (client, handle) =>
+        val req = new TExecuteStatementReq()
+        req.setSessionHandle(handle)
+        req.setStatement(sql)
+
+        val tExecuteStatementResp = client.ExecuteStatement(req)
+        val opHandle = tExecuteStatementResp.getOperationHandle
+        waitForOperationToComplete(client, opHandle)
+        val fetchSize: Int = 300
+
+        // fetch next from before first row
+        val tFetchResultsReq1 =
+          new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_NEXT, fetchSize)
+        val tFetchResultsResp1 = client.FetchResults(tFetchResultsReq1)
+        assert(tFetchResultsResp1.getStatus.getStatusCode === TStatusCode.SUCCESS_STATUS)
+        val idSeq1 = tFetchResultsResp1.getResults.getColumns.get(0)
+          .getI64Val.getValues.asScala
+        assertResult(Seq.range(0, fetchSize))(idSeq1)
+
+        // change rowSetSize(fetchSize) while second fetching
+        val tFetchResultsReq2 =
+          new TFetchResultsReq(opHandle, TFetchOrientation.FETCH_NEXT, fetchSize + 1)
+        val tFetchResultsResp2 = client.FetchResults(tFetchResultsReq2)
+        assert(tFetchResultsResp2.getStatus.getStatusCode === TStatusCode.ERROR_STATUS)
+
+      }
+    }
+  }
+}

--- a/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
+++ b/kyuubi-common/src/main/scala/org/apache/kyuubi/config/KyuubiConf.scala
@@ -2345,6 +2345,29 @@ object KyuubiConf {
       .stringConf
       .createOptional
 
+  val OPERATION_RESULT_PREFETCH: ConfigEntry[Boolean] =
+    buildConf("kyuubi.operation.result.prefetch.enabled")
+      .doc("The switch for Spark to prefetch query results.")
+      .version("1.9.0")
+      .booleanConf
+      .createWithDefault(false)
+
+  val OPERATION_RESULT_PREFETCH_QUEUE_SIZE: ConfigEntry[Int] =
+    buildConf("kyuubi.operation.result.prefetch.rowsetsQueue.size")
+      .doc("Size of the rowsets queue for the prefetch thread.")
+      .version("1.9.0")
+      .intConf
+      .createWithDefault(50)
+
+  val OPERATION_RESULT_PREFETCH_TIMEOUT: ConfigEntry[Long] =
+    buildConf("kyuubi.operation.result.prefetch.timeout")
+      .doc(f"The maximum wait time to retrieve results from the queue. " +
+        f"If ${OPERATION_RESULT_PREFETCH.key} is true, We will attempt to " +
+        f"wait for the prefetch thread to write results to the queue.")
+      .version("1.9.0")
+      .timeConf
+      .createWithDefault(Duration.ofMinutes(2).toMillis)
+
   @deprecated("using kyuubi.engine.share.level instead", "1.2.0")
   val LEGACY_ENGINE_SHARE_LEVEL: ConfigEntry[String] =
     buildConf("kyuubi.session.engine.share.level")

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLine.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLine.java
@@ -2085,6 +2085,9 @@ public class BeeLine implements Closeable {
     if (signalHandler != null) {
       signalHandler.setStatement(stmnt);
     }
+    if (getOpts().getFetchSize() != -1) {
+      stmnt.setFetchSize(getOpts().getFetchSize());
+    }
     return stmnt;
   }
 

--- a/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLineOpts.java
+++ b/kyuubi-hive-beeline/src/main/java/org/apache/hive/beeline/BeeLineOpts.java
@@ -57,6 +57,7 @@ class BeeLineOpts implements Completer {
   public static final char DEFAULT_DELIMITER_FOR_DSV = '|';
   public static final int DEFAULT_MAX_COLUMN_WIDTH = 50;
   public static final int DEFAULT_INCREMENTAL_BUFFER_ROWS = 1000;
+  public static final int DEFAULT_FETCH_SIZE = 10000;
   public static final String DEFAULT_DELIMITER = ";";
 
   public static final String URL_ENV_PREFIX = "BEELINE_URL_";
@@ -85,6 +86,7 @@ class BeeLineOpts implements Completer {
   private int maxWidth = DEFAULT_MAX_WIDTH;
   private int maxHeight = DEFAULT_MAX_HEIGHT;
   private int maxColumnWidth = DEFAULT_MAX_COLUMN_WIDTH;
+  private int fetchSize = DEFAULT_FETCH_SIZE;
   int timeout = -1;
   private String isolation = DEFAULT_ISOLATION_LEVEL;
   private String outputFormat = "table";
@@ -284,7 +286,13 @@ class BeeLineOpts implements Completer {
 
   public boolean set(String key, String value, boolean quiet) {
     try {
-      beeLine.getReflector().invoke(this, "set" + key, new Object[] {value});
+      if (value.equals("true") || value.equals("false")) {
+        beeLine
+            .getReflector()
+            .invoke(this, "set" + key, new Object[] {new Boolean(value.equals("true"))});
+      } else {
+        beeLine.getReflector().invoke(this, "set" + key, new Object[] {value});
+      }
       return true;
     } catch (Exception e) {
       if (!quiet) {
@@ -380,6 +388,18 @@ class BeeLineOpts implements Completer {
 
   public int getMaxColumnWidth() {
     return maxColumnWidth;
+  }
+
+  public int getFetchSize() {
+    return fetchSize;
+  }
+
+  public void setFetchSize(int fetchSize) {
+    this.fetchSize = fetchSize;
+  }
+
+  public void setFetchSize(String fetchSize) {
+    this.fetchSize = Integer.parseInt(fetchSize);
   }
 
   public void setTimeout(int timeout) {


### PR DESCRIPTION
Previously, Spark SQL retrieved results from HDFS using a single thread, which was very slow. Adding a thread pool now improves the execution speed.

### Why are the changes needed?
Improve execution efficiency


### How was this patch tested?
UT added

### Was this patch authored or co-authored using generative AI tooling?
No
