### PR TITLE
Replace recommonmark with myst

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,18 +38,11 @@ import datetime
 sys.path.insert(0, os.path.abspath('.'))
 
 import sphinx_markdown_tables
-import recommonmark
-from recommonmark.transform import AutoStructify
-from recommonmark.parser import CommonMarkParser
 
 source_suffix = {
     '.rst': 'restructuredtext',
     '.txt': 'restructuredtext',
     '.md': 'markdown',
-}
-
-source_parsers = {
-    '.md': CommonMarkParser,
 }
 
 # -- Project information -----------------------------------------------------
@@ -76,7 +69,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.mathjax',
-    'recommonmark',
+    'myst_parser',
     'sphinx_copybutton',
     'sphinx_markdown_tables',
     'sphinx_togglebutton',
@@ -126,13 +119,5 @@ pygments_style = 'sphinx'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 html_css_files = ["css/custom.css"]
-htmlhelp_basename = 'Recommonmarkdoc'
 
 github_doc_root = 'https://github.com/apache/kyuubi/tree/master/docs/'
-def setup(app):
-    app.add_config_value('recommonmark_config', {
-        'url_resolver': lambda url: github_doc_root + url,
-        'auto_toc_tree_section': 'Contents',
-        'enable_eval_rst': True,
-    }, True)
-    app.add_transform(AutoStructify)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -18,7 +18,7 @@
 #
 
 markdown==3.7
-recommonmark==0.7.1
+myst-parser==4.0.1
 sphinx==8.1.3
 sphinx-book-theme==1.1.3
 sphinx-markdown-tables==0.0.17


### PR DESCRIPTION
### Why are the changes needed?
The PR replaces deprecated [recommonmark](https://github.com/readthedocs/recommonmark) (last release on December 17, 2020) with recommended [MyST](https://github.com/executablebooks/MyST-Parser) to generate documentation from markdown. Sphinx documentation also assumes that MyST is used.


### How was this patch tested?
Build the docs with the following command, and verify that the pages generated from the markdown files look the same:
```shell
make html
```


### Was this patch authored or co-authored using generative AI tooling?
No
