### PR TITLE
[KYUUBI #6884][FOLLOWUP] Fix internal kyuubi instance ping failure

### DIFF
--- a/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/BaseRestApi.java
+++ b/kyuubi-rest-client/src/main/java/org/apache/kyuubi/client/BaseRestApi.java
@@ -17,6 +17,8 @@
 
 package org.apache.kyuubi.client;
 
+import java.util.Collections;
+import java.util.Map;
 import org.apache.kyuubi.client.api.v1.dto.VersionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,7 +34,11 @@ public class BaseRestApi {
   }
 
   public String ping() {
-    return this.getClient().get("ping", null, client.getAuthHeader());
+    return ping(Collections.emptyMap());
+  }
+
+  public String ping(Map<String, String> headers) {
+    return this.getClient().get("ping", null, client.getAuthHeader(), headers);
   }
 
   public VersionInfo getVersionInfo() {

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/BatchesResource.scala
@@ -598,7 +598,7 @@ private[v1] class BatchesResource extends ApiRequestContext with Logging {
       throw new IllegalStateException(s"KyuubiInstance is alive: $kyuubiInstance")
     }
     val internalRestClient = getInternalRestClient(kyuubiInstance)
-    if (!Utils.isTesting && internalRestClient.pingAble()) {
+    if (!Utils.isTesting && internalRestClient.pingAble(userName, ipAddress)) {
       throw new IllegalStateException(s"KyuubiInstance is alive: $kyuubiInstance")
     }
     try {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

To fix failure:
```
:2025-12-07 13:40:40.747 ERROR [KyuubiRestFrontendService-134] org.apache.kyuubi.server.api.v1.InternalRestClient: (Ping to internal Kyuubi instance:{}  failed,kyuubistaging-1.kyuubistaginghl.kyuubi-prod.svc.166.tess.io:10011,java.lang.IllegalArgumentException: requirement failed: The auth user shall be not null)
```

In this PR, it will use the authUser and client ipAddress for internal ping.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Integration testing.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.