### PR TITLE
Improve `build/dependency.sh` script

### DIFF
--- a/.github/workflows/dep.yml
+++ b/.github/workflows/dep.yml
@@ -47,15 +47,6 @@ jobs:
           cache: 'maven'
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
-      - name: Install modules
-        env:
-          MAVEN_ARGS: -Dorg.slf4j.simpleLogger.defaultLogLevel=error
-        run: |
-          build/mvn clean install \
-            -Pflink-provided,spark-provided,hive-provided \
-            -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip \
-            -DskipTests \
-            -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly -am
       - name: Check dependency list
         run: build/dependency.sh
       - name: Dependency Review

--- a/build/dependency.sh
+++ b/build/dependency.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
@@ -16,49 +17,51 @@
 # limitations under the License.
 #
 
-set -o pipefail
-set -e
-set -x
+set -ex
 
+FWDIR="$(cd "`dirname $0`"/..; pwd)"
+cd "$FWDIR"
+
+# Explicitly set locale in order to make `sort` output consistent across machines.
+# See https://stackoverflow.com/questions/28881 for more details.
 export LC_ALL=C
 
-PWD=$(cd "$(dirname "$0")"/.. || exit; pwd)
+# Starting with Maven 3.9.0, this variable contains arguments passed to Maven before CLI arguments.
+# See https://maven.apache.org/configure.html#maven_args-environment-variable for more details.
+export MAVEN_ARGS="-Pflink-provided,spark-provided,hive-provided -Dmaven.javadoc.skip=true -Drat.skip=true -Dscalastyle.skip=true -Dspotless.check.skip"
 
-MVN="${PWD}/build/mvn"
+MVN="${FWDIR}/build/mvn"
+DEP_PR="${FWDIR}/dev/dependencyList.tmp"
+DEP="${FWDIR}/dev/dependencyList"
 
+# We'll switch the version to a temp. one, publish POMs using that new version, then switch back to
+# the old version. We need to do this because the `dependency:build-classpath` task needs to
+# resolve Kyuubi's internal submodule dependencies.
 
-DEP_PR="${PWD}/dev/dependencyList.tmp"
-DEP="${PWD}/dev/dependencyList"
+# From http://stackoverflow.com/a/26514030
+set +e
+OLD_VERSION=$(grep -A3 "<artifactId>kyuubi-parent</artifactId>" "${FWDIR}/pom.xml" |
+  grep "<version>" | head -n1 | awk -F '[<>]' '{print $3}')
+set -e
 
+TEMP_VERSION="kyuubi-$(awk 'BEGIN {srand(); print int(100000 + rand() * 900000)}')"
 
-function build_classpath() {
-  $MVN dependency:build-classpath --no-snapshot-updates -pl kyuubi-ctl,kyuubi-server,kyuubi-assembly |\
-    grep -v "INFO\|WARN" | \
-    tail -1 | \
-    tr ":" "\n" | \
-    awk -F '/' '{
-      artifact_id=$(NF-2);
-      version=$(NF-1);
-      jar_name=$NF;
-      classifier_start_index=length(artifact_id"-"version"-") + 1;
-      classifier_end_index=index(jar_name, ".jar") - 1;
-      classifier=substr(jar_name, classifier_start_index, classifier_end_index - classifier_start_index + 1);
-      print artifact_id"/"version"/"classifier"/"jar_name
-    }' | grep -v "kyuubi" | sort >> "${DEP_PR}"
+function reset_version {
+  # Delete the temporary POMs that we wrote to the local Maven repo:
+  find "$HOME/.m2/" | grep "$TEMP_VERSION" | xargs rm -rf
+
+  # Restore the original version number:
+  $MVN -q versions:set -DnewVersion=$OLD_VERSION -DgenerateBackupPoms=false > /dev/null
 }
+trap reset_version EXIT
 
-function check_diff() {
-    set +e
-    the_diff=$(diff "${DEP}" "${DEP_PR}")
-    set -e
-    rm -rf "${DEP_PR}"
-    if [[ -n "${the_diff}" ]]; then
-        echo "Dependency List Changed Detected: "
-        echo "${the_diff}"
-        echo "To update the dependency file, run './build/dependency.sh --replace'."
-        exit 1
-    fi
-}
+$MVN -q versions:set -DnewVersion=$TEMP_VERSION -DgenerateBackupPoms=false > /dev/null
+
+echo "Performing Maven install"
+$MVN jar:jar jar:test-jar install:install clean -q
+
+echo "Performing Maven validate"
+$MVN validate -q
 
 rm -rf "${DEP_PR}"
 cat >"${DEP_PR}"<<EOF
@@ -81,7 +84,27 @@ cat >"${DEP_PR}"<<EOF
 
 EOF
 
-build_classpath
+echo "Generating dependency manifest"
+$MVN dependency:build-classpath -pl kyuubi-assembly -am \
+  | grep "Dependencies classpath:" -A 1 \
+  | tail -n 1 | tr ":" "\n" | awk -F '/' '{
+    # For each dependency classpath, we fetch the last three parts split by "/": artifact id, version, and jar name.
+    # Since classifier, if exists, always sits between "artifact_id-version-" and ".jar" suffix in the jar name,
+    # we extract classifier and put it right before the jar name explicitly.
+    # For example, `orc-core/1.5.5/nohive/orc-core-1.5.5-nohive.jar`
+    #                              ^^^^^^
+    #                              extracted classifier
+    #               `okio/1.15.0//okio-1.15.0.jar`
+    #                           ^
+    #                           empty for dependencies without classifier
+    artifact_id=$(NF-2);
+    version=$(NF-1);
+    jar_name=$NF;
+    classifier_start_index=length(artifact_id"-"version"-") + 1;
+    classifier_end_index=index(jar_name, ".jar") - 1;
+    classifier=substr(jar_name, classifier_start_index, classifier_end_index - classifier_start_index + 1);
+    print artifact_id"/"version"/"classifier"/"jar_name
+  }' | sort | grep -v kyuubi >> $DEP_PR
 
 if [[ "$1" == "--replace" ]]; then
     rm -rf "${DEP}"
@@ -89,4 +112,15 @@ if [[ "$1" == "--replace" ]]; then
     exit 0
 fi
 
-check_diff
+set +e
+the_diff=$(diff "${DEP}" "${DEP_PR}")
+set -e
+rm -rf "${DEP_PR}"
+if [[ -n "${the_diff}" ]]; then
+  echo "Dependency List Changed Detected: "
+  echo "${the_diff}"
+  echo "To update the dependency file, run './build/dependency.sh --replace'."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
This PR improves `build/dependency.sh` script inspired by Spark `dev/test-dependencies.sh`

Main advantage - the updated script uses `mvn jar:jar jar:test-jar install:install clean -q` to perform a noop install, which is super faster than making a normal `mvn install` because it triggers the dep resolution without compiling the source code.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass GHA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
