### PR TITLE
Release requires Java 17 or 21

### DIFF
--- a/build/release/release.sh
+++ b/build/release/release.sh
@@ -62,8 +62,8 @@ else
 fi
 
 JAVA_VERSION=$($JAVA -version 2>&1 | awk -F '"' '/version/ {print $2}')
-if [[ $JAVA_VERSION != 1.8.* ]]; then
-  echo "Unexpected Java version: $JAVA_VERSION. Java 8 is required for release."
+if [[ $JAVA_VERSION != 17.* && $JAVA_VERSION != 21.* ]]; then
+  echo "Unexpected Java version: $JAVA_VERSION. Java 17 or 21 is required for release."
   exit 1
 fi
 

--- a/docs/contributing/code/release.md
+++ b/docs/contributing/code/release.md
@@ -90,7 +90,7 @@ export ASF_PASSWORD=<your apache password>
 #### Java Home
 
 An available environment variable `JAVA_HOME`, you can do `echo $JAVA_HOME` to check it.
-Note that, the Java version should be 8.
+Note that, the Java 17 or 21 is required since 1.11.0, for earlier versions, it requires Java 8.
 
 #### Subversion
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

I hit an issue while preparing 1.11.0 RC0, which indicates I need to use a higher version of JDK for releasing.

```
[INFO] --- antlr4:4.13.1:antlr4 (default) @ kyuubi-extension-spark-4-0_2.13 ---
[WARNING] Error injecting: org.antlr.mojo.antlr4.Antlr4Mojo
java.lang.UnsupportedClassVersionError: org/antlr/v4/Tool has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
    at java.lang.ClassLoader.defineClass1 (Native Method)
    at java.lang.ClassLoader.defineClass (ClassLoader.java:756)
    at java.security.SecureClassLoader.defineClass (SecureClassLoader.java:142)
```

In https://github.com/apache/kyuubi/pull/7144, we made it always use `-release:8` for `jdk9+`, so we still produce Java 8 compatible bytecode even using JDK 17, for all modules except Spark 4.0/4.1 extension modules.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Will verify this in the next RC of 1.11.0

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
