### PR TITLE
[KYUUBI #7292] Add instruction to archive older releases

### DIFF
--- a/docs/contributing/code/release.md
+++ b/docs/contributing/code/release.md
@@ -313,7 +313,7 @@ downloads.apache.org should contain the latest release in each branch that is cu
 
 ```shell
 cd work/svn-dev
-export OLD_RELEASE=<release tag, e.g. kyuubi-1.10.2>
+export OLD_RELEASE=<release path, e.g. kyuubi-1.10.2>
 svn delete https://dist.apache.org/repos/dist/release/kyuubi/${OLD_RELEASE} \
   --username "${ASF_USERNAME}" \
   --password "${ASF_PASSWORD}" \


### PR DESCRIPTION
### Why are the changes needed?

Archive older releases https://www.apache.org/legal/release-policy.html#when-to-archive

Closes #7292 

### How was this patch tested?

Not tested

### Was this patch authored or co-authored using generative AI tooling?

No