### PR TITLE
[AUTHZ] Remove redundant concatenation with the list of conditions

### DIFF
--- a/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
+++ b/extensions/spark/kyuubi-spark-authz/src/main/scala/org/apache/kyuubi/plugin/spark/authz/PrivilegesBuilder.scala
@@ -69,7 +69,7 @@ object PrivilegesBuilder {
       if (projectionList.isEmpty) {
         privilegeObjects += PrivilegeObject(table, plan.output.map(_.name))
       } else {
-        val cols = columnPrune(projectionList ++ conditionList, plan.outputSet)
+        val cols = columnPrune(projectionList, plan.outputSet)
         privilegeObjects += PrivilegeObject(table, cols.map(_.name).distinct)
       }
     }


### PR DESCRIPTION
### Why are the changes needed?

This concatenation with the list of conditions `conditionList` is redundant as the `columnPrune` method already contains it.

### How was this patch tested?

Existing unit tests.

### Was this patch authored or co-authored using generative AI tooling?

No.
