### PR TITLE
[KYUUBI #7304] Fix NumberFormatException when parsing ISO 8601 duration for session idle timeout

### DIFF
--- a/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
+++ b/externals/kyuubi-spark-sql-engine/src/main/scala/org/apache/kyuubi/engine/spark/session/SparkSessionImpl.scala
@@ -17,7 +17,10 @@
 
 package org.apache.kyuubi.engine.spark.session
 
+import java.time.Duration
 import java.util.concurrent.atomic.AtomicLong
+
+import scala.util.Try
 
 import org.apache.commons.lang3.StringUtils
 import org.apache.spark.sql.{AnalysisException, SparkSession}
@@ -60,9 +63,9 @@ class SparkSessionImpl(
 
   override val sessionIdleTimeoutThreshold: Long = {
     conf.get(SESSION_IDLE_TIMEOUT.key)
-      .map(_.toLong)
-      .getOrElse(
-        sessionManager.getConf.get(SESSION_IDLE_TIMEOUT))
+      .map(_.trim)
+      .map(v => Try(Duration.parse(v).toMillis).getOrElse(v.toLong))
+      .getOrElse(sessionManager.getConf.get(SESSION_IDLE_TIMEOUT))
   }
 
   private val sessionEvent = SessionEvent(this)

--- a/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/session/SessionIdleTimeoutSuite.scala
+++ b/externals/kyuubi-spark-sql-engine/src/test/scala/org/apache/kyuubi/engine/spark/session/SessionIdleTimeoutSuite.scala
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.kyuubi.engine.spark.session
+
+import java.sql.DriverManager
+
+import org.apache.kyuubi.config.KyuubiConf._
+import org.apache.kyuubi.engine.spark.WithSparkSQLEngine
+
+class SessionIdleTimeoutSuite extends WithSparkSQLEngine {
+
+  // Load JDBC driver
+  Class.forName("org.apache.kyuubi.jdbc.KyuubiHiveDriver")
+
+  override def withKyuubiConf: Map[String, String] = {
+    Map(
+      ENGINE_SHARE_LEVEL.key -> "SERVER",
+      ENGINE_SPARK_MAX_INITIAL_WAIT.key -> "0")
+  }
+
+  private def baseJdbcUrl: String =
+    s"jdbc:hive2://${engine.frontendServices.head.connectionUrl}/default"
+
+  test("KYUUBI #7304: session idle timeout supports ISO 8601 duration format") {
+    // Test with ISO 8601 duration format (PT40M = 40 minutes = 2400000 ms)
+    val jdbcUrlWithIso8601Timeout =
+      s"$baseJdbcUrl;#${SESSION_IDLE_TIMEOUT.key}=PT40M"
+    val conn = DriverManager.getConnection(jdbcUrlWithIso8601Timeout, "anonymous", "")
+    try {
+      val statement = conn.createStatement()
+      try {
+        val resultSet = statement.executeQuery("SELECT 1")
+        assert(resultSet.next())
+        assert(resultSet.getInt(1) == 1)
+      } finally {
+        statement.close()
+      }
+    } finally {
+      conn.close()
+    }
+  }
+
+  test("KYUUBI #7304: session idle timeout supports plain milliseconds") {
+    // Test with plain milliseconds (2400000 ms = 40 minutes)
+    val jdbcUrlWithMillisTimeout =
+      s"$baseJdbcUrl;#${SESSION_IDLE_TIMEOUT.key}=2400000"
+    val conn = DriverManager.getConnection(jdbcUrlWithMillisTimeout, "anonymous", "")
+    try {
+      val statement = conn.createStatement()
+      try {
+        val resultSet = statement.executeQuery("SELECT 1")
+        assert(resultSet.next())
+        assert(resultSet.getInt(1) == 1)
+      } finally {
+        statement.close()
+      }
+    } finally {
+      conn.close()
+    }
+  }
+
+  test("KYUUBI #7304: session idle timeout supports various ISO 8601 formats") {
+    // Test with different ISO 8601 duration formats
+    val testCases = Seq("PT1H", "PT30M", "PT1H30M", "PT90S")
+
+    testCases.foreach { durationStr =>
+      val jdbcUrlWithTimeout =
+        s"$baseJdbcUrl;#${SESSION_IDLE_TIMEOUT.key}=$durationStr"
+      val conn = DriverManager.getConnection(jdbcUrlWithTimeout, "anonymous", "")
+      try {
+        val statement = conn.createStatement()
+        try {
+          val resultSet = statement.executeQuery("SELECT 1")
+          assert(resultSet.next())
+          assert(resultSet.getInt(1) == 1)
+        } finally {
+          statement.close()
+        }
+      } finally {
+        conn.close()
+      }
+    }
+  }
+}


### PR DESCRIPTION
The `sessionIdleTimeoutThreshold` in `SparkSessionImpl` was using `.toLong` directly on the config string value, which fails when the value is in ISO 8601 duration format (e.g., `PT40M`). This change uses `Duration.parse()` to properly handle ISO 8601 duration format with fallback to plain milliseconds, consistent with how `ConfigBuilder.timeConf` handles duration parsing elsewhere in the codebase.

Closes #7304

<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

This fixes https://github.com/apache/kyuubi/issues/7304 which affects v1.11.0 and v1.10.3


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tested with integration tests.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Integration tests Generated-by: Claude Opus 4.5

