### PR TITLE
If the k8s application is pending, audit the status as well

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/engine/KubernetesApplicationOperation.scala
@@ -662,7 +662,7 @@ object KubernetesApplicationOperation extends Logging {
     val applicationError = {
       if (ApplicationState.isFailed(
           applicationState,
-          supportPersistedAppState = true) || ApplicationState.PENDING == applicationState) {
+          supportPersistedAppState = true) || applicationState == ApplicationState.PENDING) {
         val errorMap = containerStatusToBuildAppState.map { cs =>
           Map(
             "Pod" -> podName,
@@ -672,7 +672,7 @@ object KubernetesApplicationOperation extends Logging {
         }.getOrElse {
           Map("Pod" -> podName, "PodStatus" -> pod.getStatus)
         }
-        Some(JsonUtils.toPrettyJson(errorMap.asJava))
+        Some(JsonUtils.toJson(errorMap.asJava))
       } else {
         None
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

I saw that, a pod pending for 3 hours.
```
/var/log/hadoop/kyuubi/audit/k8s-audit.log.2026-01-23-08.gz::2026-01-23 08:09:31.356 INFO [-935552520-pool-3-thread-2861] org.apache.kyuubi.engine.KubernetesApplicationAuditLogger: eventType=UPDATE	label=cb370310-9c4c-4982-817e-85f4f6c031a9	context=kube-apiserver-a-spark	namespace=dls-prod	pod=kyuubi-hadp-adi-hadp-w-md-tbl-location-w-muso-0-ae7bd346-20260123-stm-cb370310-9c4c-4982-817e-85f4f6c031a9-driver	podState=Pending	containers=[]	appId=spark-f67cc33544654d828d36cc9553404a3e	appName=hadp-adi-hadp-w-md-t-818abc6d23397c33859c76dff9aa82e7244a92ba	appState=PENDING	appError=''
/var/log/hadoop/kyuubi/audit/k8s-audit.log.2026-01-23-11.gz::2026-01-23 11:09:50.121 INFO [-935552520-pool-3-thread-2902] org.apache.kyuubi.engine.KubernetesApplicationAuditLogger: eventType=UPDATE	label=cb370310-9c4c-4982-817e-85f4f6c031a9	context=kube-apiserver-a-spark	namespace=dls-prod	pod=kyuubi-hadp-adi-hadp-w-md-tbl-location-w-muso-0-ae7bd346-20260123-stm-cb370310-9c4c-4982-817e-85f4f6c031a9-driver	podState=Pending	containers=[]	appId=spark-f67cc33544654d828d36cc9553404a3e	appName=hadp-adi-hadp-w-md-t-818abc6d23397c33859c76dff9aa82e7244a92ba	appState=PENDING	appError=''
```

However, the audit log did not record that why the pod pending for so long time.

So, I think we should check the pod state if pod is pending.

Also, for yarn app, it would also return the app pending reason for example waiting for am allocation.
### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Code review.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

No.