### PR TITLE
Fix kyuubi sessions to return 404 for non-existent sessions

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/ApiUtils.scala
@@ -22,16 +22,13 @@ import scala.collection.JavaConverters._
 import org.apache.kyuubi.{Logging, Utils}
 import org.apache.kyuubi.client.api.v1.dto
 import org.apache.kyuubi.client.api.v1.dto.{OperationData, OperationProgress, ServerData, SessionData}
-import org.apache.kyuubi.config.KyuubiConf.SERVER_SECRET_REDACTION_PATTERN
 import org.apache.kyuubi.ha.client.ServiceNodeInfo
 import org.apache.kyuubi.operation.KyuubiOperation
 import org.apache.kyuubi.session.KyuubiSession
 
 object ApiUtils extends Logging {
   def sessionEvent(session: KyuubiSession): dto.KyuubiSessionEvent = {
-    session.getSessionEvent.map { event =>
-      val redactionPattern = session.sessionManager.getConf.get(SERVER_SECRET_REDACTION_PATTERN)
-      val redactedConf = Utils.redact(redactionPattern, event.conf.toSeq).toMap.asJava
+    session.getSessionEvent.map(event =>
       dto.KyuubiSessionEvent.builder()
         .sessionId(event.sessionId)
         .clientVersion(event.clientVersion)
@@ -40,7 +37,7 @@ object ApiUtils extends Logging {
         .user(event.user)
         .clientIp(event.clientIP)
         .serverIp(event.serverIP)
-        .conf(redactedConf)
+        .conf(event.conf.asJava)
         .remoteSessionId(event.remoteSessionId)
         .engineId(event.engineId)
         .engineName(event.engineName)
@@ -51,20 +48,17 @@ object ApiUtils extends Logging {
         .endTime(event.endTime)
         .totalOperations(event.totalOperations)
         .exception(event.exception.orNull)
-        .build()
-    }.orNull
+        .build()).orNull
   }
 
   def sessionData(session: KyuubiSession): SessionData = {
     val sessionEvent = session.getSessionEvent
-    val redactionPattern = session.sessionManager.getConf.get(SERVER_SECRET_REDACTION_PATTERN)
-    val redactedConf = Utils.redact(redactionPattern, session.conf.toSeq).toMap.asJava
     new SessionData(
       session.handle.identifier.toString,
       sessionEvent.map(_.remoteSessionId).getOrElse(""),
       session.user,
       session.ipAddress,
-      redactedConf,
+      session.conf.asJava,
       session.createTime,
       session.lastAccessTime - session.createTime,
       session.getNoOperationTime,

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/api/v1/SessionsResource.scala
@@ -52,15 +52,11 @@ private[v1] class SessionsResource extends ApiRequestContext with Logging {
     content = Array(new Content(
       mediaType = MediaType.APPLICATION_JSON,
       array = new ArraySchema(schema = new Schema(implementation = classOf[SessionData])))),
-    description = "get the list of live sessions for the current user")
+    description = "get the list of all live sessions")
   @GET
   def sessions(): Seq[SessionData] = {
-    val userName = fe.getSessionUser(Map.empty[String, String])
-    sessionManager
-      .allSessions()
-      .filter(session => session.user == userName)
-      .map(session => ApiUtils.sessionData(session.asInstanceOf[KyuubiSession]))
-      .toSeq
+    sessionManager.allSessions()
+      .map(session => ApiUtils.sessionData(session.asInstanceOf[KyuubiSession])).toSeq
   }
 
   @ApiResponse(

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/api/v1/SessionsResourceSuite.scala
@@ -40,12 +40,6 @@ import org.apache.kyuubi.session.SessionType
 
 class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
 
-  override protected lazy val conf: KyuubiConf = {
-    val c = KyuubiConf()
-    c.set(KyuubiConf.SERVER_SECRET_REDACTION_PATTERN, "(?i)password".r)
-    c
-  }
-
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     eventually(timeout(10.seconds), interval(200.milliseconds)) {
@@ -394,28 +388,5 @@ class SessionsResourceSuite extends KyuubiFunSuite with RestFrontendTestHelper {
     val operations = response.readEntity(new GenericType[Seq[OperationData]]() {})
     assert(operations.size == 1)
     assert(sessionHandle.toString.equals(operations.head.getSessionId))
-  }
-
-  test("get /sessions returns redacted spark confs") {
-    val sensitiveKey = "spark.password"
-    val sensitiveValue = "superSecret123"
-    val requestObj = new SessionOpenRequest(Map(sensitiveKey -> sensitiveValue).asJava)
-
-    val response = webTarget.path("api/v1/sessions")
-      .request(MediaType.APPLICATION_JSON_TYPE)
-      .post(Entity.entity(requestObj, MediaType.APPLICATION_JSON_TYPE))
-    assert(200 == response.getStatus)
-    val sessionHandle = response.readEntity(classOf[SessionHandle]).getIdentifier
-
-    val response2 = webTarget.path("api/v1/sessions").request().get()
-    assert(200 == response2.getStatus)
-    val sessions = response2.readEntity(new GenericType[Seq[SessionData]]() {})
-    val sessionConf = sessions.find(_.getIdentifier == sessionHandle.toString).get.getConf
-
-    assert(sessionConf.get(sensitiveKey) != sensitiveValue)
-    assert(sessionConf.get(sensitiveKey) == "*********(redacted)")
-
-    val delResp = webTarget.path(s"api/v1/sessions/$sessionHandle").request().delete()
-    assert(200 == delResp.getStatus)
   }
 }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/SessionCtlSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/rest/client/SessionCtlSuite.scala
@@ -38,13 +38,13 @@ class SessionCtlSuite extends RestClientTestHelper with TestPrematureExit {
   test("list sessions") {
     fe.be.sessionManager.openSession(
       TProtocolVersion.findByValue(1),
-      clientPrincipalUser,
+      "admin",
       "123456",
       "localhost",
       Map("testConfig" -> "testValue"))
 
     val args = Array("list", "session", "--authSchema", "spnego")
-    testPrematureExitForControlCli(args, "Live Session List (total 1)")
+    testPrematureExitForControlCli(args, "Session List (total 1)")
   }
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
This PR addresses below issue with the Kyuubi sessions API:

1**Incorrect HTTP status codes**: When attempting to delete a non-existent session, the API currently returns HTTP 500 (Internal Server Error), which is misleading. A non-existent resource should return HTTP 404 (Not Found) to properly indicate the resource doesn't exist.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
 **Test for 404 response on delete non-existent session**: Added `delete_non-existent_admin_session_returns_404` test in `AdminResourceSuite.scala` that verifies deleting a non-existent session returns HTTP 404 instead of 500.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No

