### PR TITLE
Make TPC-H/DS connector compatible with Spark 4.2

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/KyuubiTPCDSResults.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpcds/src/main/scala/org/apache/kyuubi/spark/connector/tpcds/KyuubiTPCDSResults.scala
@@ -144,8 +144,8 @@ class KyuubiResultsIterator(
         case (Some(v: Long), DateType) =>
           RebaseDateTime.rebaseJulianToGregorianDays(v.toInt) - DateTimeUtils.JULIAN_DAY_OF_EPOCH
         case (Some(v), StringType) => UTF8String.fromString(v.toString)
-        case (Some(v), CharType(_)) => UTF8String.fromString(v.toString)
-        case (Some(v), VarcharType(_)) => UTF8String.fromString(v.toString)
+        case (Some(v), _: CharType) => UTF8String.fromString(v.toString)
+        case (Some(v), _: VarcharType) => UTF8String.fromString(v.toString)
         case (Some(v: TPCDSDecimal), t: DecimalType) =>
           Decimal(v.getNumber, t.precision, t.scale)
         case (Some(v: Int), t: DecimalType) =>

--- a/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHBatchScan.scala
+++ b/extensions/spark/kyuubi-spark-connector-tpch/src/main/scala/org/apache/kyuubi/spark/connector/tpch/TPCHBatchScan.scala
@@ -135,11 +135,11 @@ class TPCHPartitionReader(
           case (value, IntegerType) => rowAny += value.toInt
           case (value, LongType) => rowAny += value.toLong
           case (value, DoubleType) => rowAny += value.toDouble
-          case (value, DateType) => rowAny += LocalDate.parse(formatDate(value.toInt), dateFmt)
-              .toEpochDay.toInt
+          case (value, DateType) =>
+            rowAny += LocalDate.parse(formatDate(value.toInt), dateFmt).toEpochDay.toInt
           case (value, StringType) => rowAny += UTF8String.fromString(value)
-          case (value, CharType(_)) => rowAny += UTF8String.fromString(value)
-          case (value, VarcharType(_)) => rowAny += UTF8String.fromString(value)
+          case (value, _: CharType) => rowAny += UTF8String.fromString(value)
+          case (value, _: VarcharType) => rowAny += UTF8String.fromString(value)
           case (value, DecimalType()) => rowAny += Decimal(value)
           case (value, dt) => throw new IllegalArgumentException(s"value: $value, type: $dt")
         }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Adapt to SPARK-54870, which added a new arg to case class `CharType`/`VarCharType`

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
We don't have Spark 4.2 CI coverage yet, so CI only ensures it won't breaking for older Spark versions.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.