### PR TITLE
chore: Add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ kyuubi-server/src/main/antlr4/org/apache/kyuubi/sql/gen/
 # For draw.io
 .$*.bkp
 .$*.dtmp
+
+# Claude Code worktrees
+.worktrees/


### PR DESCRIPTION
## Summary
- Add `.worktrees/` to `.gitignore` to prevent git worktree directories from being tracked in version control

## Test plan
- [ ] Verify `.gitignore` includes `.worktrees/`
- [ ] Verify worktree directories are no longer tracked by git