### PR TITLE
Bump Kafka 3.9.2

### DIFF
--- a/dev/dependencyList
+++ b/dev/dependencyList
@@ -98,7 +98,7 @@ jetty-util/9.4.57.v20241219//jetty-util-9.4.57.v20241219.jar
 jline/2.14.6//jline-2.14.6.jar
 jspecify/1.0.0//jspecify-1.0.0.jar
 jul-to-slf4j/1.7.36//jul-to-slf4j-1.7.36.jar
-kafka-clients/3.9.1//kafka-clients-3.9.1.jar
+kafka-clients/3.9.2//kafka-clients-3.9.2.jar
 kubernetes-client-api/6.14.0//kubernetes-client-api-6.14.0.jar
 kubernetes-client/6.14.0//kubernetes-client-6.14.0.jar
 kubernetes-httpclient-okhttp/6.14.0//kubernetes-httpclient-okhttp-6.14.0.jar

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerKafkaLoggingEventHandlerSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/events/handler/ServerKafkaLoggingEventHandlerSuite.scala
@@ -97,5 +97,5 @@ abstract class ServerKafkaLoggingEventHandlerSuite extends WithKyuubiServer with
 }
 
 class ServerKafkaLoggingEventHandlerSuiteForKafka3 extends ServerKafkaLoggingEventHandlerSuite {
-  override val kafkaVersion = "3.9.1"
+  override val kafkaVersion = "3.9.2"
 }

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
         <jetty.version>9.4.57.v20241219</jetty.version>
         <jline.version>2.14.6</jline.version>
         <junit.version>4.13.2</junit.version>
-        <kafka.version>3.9.1</kafka.version>
+        <kafka.version>3.9.2</kafka.version>
         <!-- 6.14.0 requires Jackson 2.19.0+
              https://github.com/fabric8io/kubernetes-client/releases/tag/v6.14.0 -->
         <kubernetes-client.version>6.14.0</kubernetes-client.version>
@@ -1035,7 +1035,7 @@
                         <artifactId>zstd-jni</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>org.lz4</groupId>
+                        <groupId>at.yawk.lz4</groupId>
                         <artifactId>lz4-java</artifactId>
                     </exclusion>
                     <exclusion>


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Kafka 3.9.2 switches to `at.yawk.lz4:lz4-java` for security purpose, which does not really affect Kyuubi since we excluded all compression libs from kafka-clients, but it's always good to keep 3rd party libs up-to-date.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Pass GHA.

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No.
