### PR TITLE
[KYUUBI #7389] Fix wrong parameter binding order in JDBCMetadataStore#transformMetadataState

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStore.scala
@@ -235,7 +235,7 @@ class JDBCMetadataStore(conf: KyuubiConf) extends MetadataStore with Logging {
       targetState: String): Boolean = {
     val query = s"UPDATE $METADATA_TABLE SET state = ? WHERE identifier = ? AND state = ?"
     JdbcUtils.withConnection { connection =>
-      withUpdateCount(connection, query, fromState, identifier, targetState) { updateCount =>
+      withUpdateCount(connection, query, targetState, identifier, fromState) { updateCount =>
         updateCount == 1
       }
     }

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/server/metadata/jdbc/JDBCMetadataStoreSuite.scala
@@ -248,6 +248,32 @@ class JDBCMetadataStoreSuite extends KyuubiFunSuite {
     }
   }
 
+  test("transformMetadataState should transition state correctly") {
+    val batchId = UUID.randomUUID().toString
+    val batchMetadata = Metadata(
+      identifier = batchId,
+      sessionType = SessionType.BATCH,
+      realUser = "kyuubi",
+      username = "kyuubi",
+      ipAddress = "127.0.0.1",
+      state = "INITIALIZED",
+      resource = "intern",
+      className = "org.apache.kyuubi.SparkWC",
+      requestName = "test_transform",
+      createTime = System.currentTimeMillis(),
+      engineType = "SPARK")
+
+    jdbcMetadataStore.insertMetadata(batchMetadata)
+
+    val result = jdbcMetadataStore.transformMetadataState(batchId, "INITIALIZED", "CANCELED")
+    assert(result, "should successfully transition from INITIALIZED to CANCELED")
+
+    val metadata = jdbcMetadataStore.getMetadata(batchId)
+    assert(metadata.state == "CANCELED", s"state should be CANCELED but was ${metadata.state}")
+
+    jdbcMetadataStore.cleanupMetadataByIdentifier(batchId)
+  }
+
   test("throw exception if update count is 0") {
     val metadata = Metadata(identifier = UUID.randomUUID().toString, state = "RUNNING")
     intercept[KyuubiException] {


### PR DESCRIPTION
Closes #7389

The SQL placeholders expect (targetState, identifier, fromState) but the code passed (fromState, identifier, targetState), causing the UPDATE to set state back to fromState and match on targetState instead. This made cancelUnscheduledBatch silently fail.

### Why are the changes needed?

In `JDBCMetadataStore#transformMetadataState`, the SQL is:
```sql
UPDATE metadata SET state = ? WHERE identifier = ? AND state = ?
```
The placeholders expect `(targetState, identifier, fromState)`, but the code passes `(fromState, identifier, targetState)`:
```scala
withUpdateCount(connection, query, fromState, identifier, targetState)
```

This causes `cancelUnscheduledBatch("INITIALIZED" -> "CANCELED")` to execute:
```sql
UPDATE metadata SET state = 'INITIALIZED' WHERE identifier = ? AND state = 'CANCELED'
```
Which matches no rows and silently returns `false`. The bug has existed since v1.8.0 ([KYUUBI #4790]).

### How was this patch tested?

Added a unit test `transformMetadataState should transition state correctly` in `JDBCMetadataStoreSuite` that:
1. Inserts a metadata record with `state = "INITIALIZED"`
2. Calls `transformMetadataState(id, "INITIALIZED", "CANCELED")`
3. Asserts the method returns `true`
4. Asserts the persisted state is `"CANCELED"`

### Was this patch authored or co-authored using generative AI tooling?

No.