### PR TITLE
[KYUUBI #7398] SERDEPROPERTIES are missing when KSHC create table

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -450,6 +450,7 @@ class HiveTableCatalog(sparkSession: SparkSession)
     val (serdeProps, optionsProps) = properties
       .filterKeys(_.startsWith(TableCatalog.OPTION_PREFIX))
       .map { case (key, value) => key.drop(TableCatalog.OPTION_PREFIX.length) -> value }
+      .toMap
       .partition { case (strippedKey, _) => properties.contains(strippedKey) }
     (optionsProps, serdeProps)
   }

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -437,9 +437,9 @@ class HiveTableCatalog(sparkSession: SparkSession)
   /**
    * Splits properties into optionsProps and serdeProps based on the `options.` prefix.
    *
-   * - optionsProps: keys with "options." prefix whose stripped key does NOT exist in properties,
+   * - optionsProps: keys with "options." prefix whose stripped key ALREADY exist in properties,
    *   indicating they were originally specified via OPTIONS clause.
-   * - serdeProps: keys with "options." prefix whose stripped key ALREADY exists in properties,
+   * - serdeProps: keys with "options." prefix whose stripped key does NOT exists in properties,
    *   indicating they were originally specified via SERDEPROPERTIES clause
    *
    * @param properties the full properties map
@@ -447,7 +447,7 @@ class HiveTableCatalog(sparkSession: SparkSession)
    */
   private def toOptionsAndSerdeProps(
       properties: Map[String, String]): (Map[String, String], Map[String, String]) = {
-    val (serdeProps, optionsProps) = properties
+    val (optionsProps, serdeProps) = properties
       .filterKeys(_.startsWith(TableCatalog.OPTION_PREFIX))
       .map { case (key, value) => key.drop(TableCatalog.OPTION_PREFIX.length) -> value }
       .toMap

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -322,6 +322,7 @@ class HiveTableCatalog(sparkSession: SparkSession)
         getStorageFormatAndProvider(
           maybeProvider,
           location,
+          tableProperties,
           toOptions(tableProperties))
       val isExternal = properties.containsKey(TableCatalog.PROP_EXTERNAL)
       val tableType =
@@ -583,15 +584,16 @@ private object HiveTableCatalog extends Logging {
   private def getStorageFormatAndProvider(
       provider: Option[String],
       location: Option[String],
-      options: Map[String, String]): (CatalogStorageFormat, String) = {
+      options: Map[String, String],
+      serdeProperties: Map[String, String]): (CatalogStorageFormat, String) = {
     val nonHiveStorageFormat = CatalogStorageFormat.empty.copy(
       locationUri = location.map(CatalogUtils.stringToURI),
-      properties = options)
+      properties = serdeProperties)
 
     val conf = SQLConf.get
     val defaultHiveStorage = HiveSerDe.getDefaultStorage(conf).copy(
       locationUri = location.map(CatalogUtils.stringToURI),
-      properties = options)
+      properties = serdeProperties)
 
     if (provider.isDefined) {
       (nonHiveStorageFormat, provider.get)

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -317,12 +317,12 @@ class HiveTableCatalog(sparkSession: SparkSession)
       val (partitionColumns, maybeBucketSpec) = partitions.toSeq.convertTransforms
       val location = Option(properties.get(TableCatalog.PROP_LOCATION))
       val maybeProvider = Option(properties.get(TableCatalog.PROP_PROVIDER))
+      val tableProperties = properties.asScala.toMap
       val (storage, provider) =
         getStorageFormatAndProvider(
           maybeProvider,
           location,
-          properties.asScala.toMap)
-      val tableProperties = properties.asScala
+          toOptions(tableProperties))
       val isExternal = properties.containsKey(TableCatalog.PROP_EXTERNAL)
       val tableType =
         if (isExternal || location.isDefined) {
@@ -339,7 +339,7 @@ class HiveTableCatalog(sparkSession: SparkSession)
         provider = Some(provider),
         partitionColumnNames = partitionColumns,
         bucketSpec = maybeBucketSpec,
-        properties = tableProperties.toMap,
+        properties = tableProperties,
         tracksPartitionsInCatalog = conf.manageFilesourcePartitions,
         comment = Option(properties.get(TableCatalog.PROP_COMMENT)))
 
@@ -609,7 +609,7 @@ private object HiveTableCatalog extends Logging {
               outputFormat = hiveSerde.outputFormat.orElse(defaultHiveStorage.outputFormat),
               // User specified serde takes precedence over the one inferred from file format.
               serde = maybeSerde.orElse(hiveSerde.serde).orElse(defaultHiveStorage.serde),
-              properties = options ++ defaultHiveStorage.properties)
+              properties = defaultHiveStorage.properties)
           case _ => throw KyuubiHiveConnectorException(s"Unsupported serde ${maybeSerde.get}.")
         }
       } else {
@@ -619,7 +619,7 @@ private object HiveTableCatalog extends Logging {
           outputFormat =
             maybeOutputFormat.orElse(defaultHiveStorage.outputFormat),
           serde = maybeSerde.orElse(defaultHiveStorage.serde),
-          properties = options ++ defaultHiveStorage.properties)
+          properties = defaultHiveStorage.properties)
       }
       (storageFormat, DDLUtils.HIVE_PROVIDER)
     } else {

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -440,12 +440,12 @@ class HiveTableCatalog(sparkSession: SparkSession)
    * - optionsProps: keys with "options." prefix whose stripped key ALREADY exist in properties,
    *   indicating they were originally specified via OPTIONS clause.
    * - serdeProps: keys with "options." prefix whose stripped key does NOT exists in properties,
-   *   indicating they were originally specified via SERDEPROPERTIES clause
+   *   indicating they were originally specified via SERDEPROPERTIES clause.
    *
    * @param properties the full properties map
    * @return a tuple of (optionsProps, serdeProps), both with the "options." prefix stripped
    */
-  private def toOptionsAndSerdeProps(
+  private[hive] def toOptionsAndSerdeProps(
       properties: Map[String, String]): (Map[String, String], Map[String, String]) = {
     val (optionsProps, serdeProps) = properties
       .filterKeys(_.startsWith(TableCatalog.OPTION_PREFIX))

--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/HiveTableCatalog.scala
@@ -317,13 +317,15 @@ class HiveTableCatalog(sparkSession: SparkSession)
       val (partitionColumns, maybeBucketSpec) = partitions.toSeq.convertTransforms
       val location = Option(properties.get(TableCatalog.PROP_LOCATION))
       val maybeProvider = Option(properties.get(TableCatalog.PROP_PROVIDER))
-      val tableProperties = properties.asScala.toMap
+      val tableProps = properties.asScala.toMap
+      val (optionsProps, serdeProps) = toOptionsAndSerdeProps(tableProps)
       val (storage, provider) =
         getStorageFormatAndProvider(
           maybeProvider,
           location,
-          tableProperties,
-          toOptions(tableProperties))
+          tableProps,
+          optionsProps,
+          serdeProps)
       val isExternal = properties.containsKey(TableCatalog.PROP_EXTERNAL)
       val tableType =
         if (isExternal || location.isDefined) {
@@ -340,7 +342,7 @@ class HiveTableCatalog(sparkSession: SparkSession)
         provider = Some(provider),
         partitionColumnNames = partitionColumns,
         bucketSpec = maybeBucketSpec,
-        properties = tableProperties,
+        properties = tableProps,
         tracksPartitionsInCatalog = conf.manageFilesourcePartitions,
         comment = Option(properties.get(TableCatalog.PROP_COMMENT)))
 
@@ -432,10 +434,24 @@ class HiveTableCatalog(sparkSession: SparkSession)
       catalog.renameTable(oldIdent.asTableIdentifier, newIdent.asTableIdentifier)
     }
 
-  private def toOptions(properties: Map[String, String]): Map[String, String] = {
-    properties.filterKeys(_.startsWith(TableCatalog.OPTION_PREFIX)).map {
-      case (key, value) => key.drop(TableCatalog.OPTION_PREFIX.length) -> value
-    }.toMap
+  /**
+   * Splits properties into optionsProps and serdeProps based on the `options.` prefix.
+   *
+   * - optionsProps: keys with "options." prefix whose stripped key does NOT exist in properties,
+   *   indicating they were originally specified via OPTIONS clause.
+   * - serdeProps: keys with "options." prefix whose stripped key ALREADY exists in properties,
+   *   indicating they were originally specified via SERDEPROPERTIES clause
+   *
+   * @param properties the full properties map
+   * @return a tuple of (optionsProps, serdeProps), both with the "options." prefix stripped
+   */
+  private def toOptionsAndSerdeProps(
+      properties: Map[String, String]): (Map[String, String], Map[String, String]) = {
+    val (serdeProps, optionsProps) = properties
+      .filterKeys(_.startsWith(TableCatalog.OPTION_PREFIX))
+      .map { case (key, value) => key.drop(TableCatalog.OPTION_PREFIX.length) -> value }
+      .partition { case (strippedKey, _) => properties.contains(strippedKey) }
+    (optionsProps, serdeProps)
   }
 
   override def listNamespaces(): Array[Array[String]] =
@@ -584,24 +600,25 @@ private object HiveTableCatalog extends Logging {
   private def getStorageFormatAndProvider(
       provider: Option[String],
       location: Option[String],
-      options: Map[String, String],
-      serdeProperties: Map[String, String]): (CatalogStorageFormat, String) = {
+      tableProps: Map[String, String],
+      optionsProps: Map[String, String],
+      serdeProps: Map[String, String]): (CatalogStorageFormat, String) = {
     val nonHiveStorageFormat = CatalogStorageFormat.empty.copy(
       locationUri = location.map(CatalogUtils.stringToURI),
-      properties = serdeProperties)
+      properties = optionsProps)
 
     val conf = SQLConf.get
     val defaultHiveStorage = HiveSerDe.getDefaultStorage(conf).copy(
       locationUri = location.map(CatalogUtils.stringToURI),
-      properties = serdeProperties)
+      properties = optionsProps)
 
     if (provider.isDefined) {
       (nonHiveStorageFormat, provider.get)
-    } else if (serdeIsDefined(options)) {
-      val maybeSerde = options.get("hive.serde")
-      val maybeStoredAs = options.get("hive.stored-as")
-      val maybeInputFormat = options.get("hive.input-format")
-      val maybeOutputFormat = options.get("hive.output-format")
+    } else if (serdeIsDefined(tableProps)) {
+      val maybeSerde = tableProps.get("hive.serde")
+      val maybeStoredAs = tableProps.get("hive.stored-as")
+      val maybeInputFormat = tableProps.get("hive.input-format")
+      val maybeOutputFormat = tableProps.get("hive.output-format")
       val storageFormat = if (maybeStoredAs.isDefined) {
         // If `STORED AS fileFormat` is used, infer inputFormat, outputFormat and serde from it.
         HiveSerDe.sourceToSerDe(maybeStoredAs.get) match {
@@ -611,7 +628,7 @@ private object HiveTableCatalog extends Logging {
               outputFormat = hiveSerde.outputFormat.orElse(defaultHiveStorage.outputFormat),
               // User specified serde takes precedence over the one inferred from file format.
               serde = maybeSerde.orElse(hiveSerde.serde).orElse(defaultHiveStorage.serde),
-              properties = defaultHiveStorage.properties)
+              properties = serdeProps ++ defaultHiveStorage.properties)
           case _ => throw KyuubiHiveConnectorException(s"Unsupported serde ${maybeSerde.get}.")
         }
       } else {
@@ -621,7 +638,7 @@ private object HiveTableCatalog extends Logging {
           outputFormat =
             maybeOutputFormat.orElse(defaultHiveStorage.outputFormat),
           serde = maybeSerde.orElse(defaultHiveStorage.serde),
-          properties = defaultHiveStorage.properties)
+          properties = serdeProps ++ defaultHiveStorage.properties)
       }
       (storageFormat, DDLUtils.HIVE_PROVIDER)
     } else {

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -287,6 +287,32 @@ class HiveCatalogSuite extends KyuubiHiveTest {
     catalog.dropTable(testIdent)
   }
 
+  test("toOptionsAndSerdeProps") {
+    val properties = Map(
+      "hive.serde" -> "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe",
+      "owner" -> "hadoop",
+      "header" -> "false",
+      "delimiter" -> "#",
+      TableCatalog.OPTION_PREFIX + "header" -> "false",
+      TableCatalog.OPTION_PREFIX + "delimiter" -> "#",
+      TableCatalog.OPTION_PREFIX + "field.delim" -> ",",
+      TableCatalog.OPTION_PREFIX + "line.delim" -> "\n")
+
+    val method = classOf[HiveTableCatalog].getDeclaredMethod(
+      "toOptionsAndSerdeProps",
+      classOf[scala.collection.immutable.Map[_, _]])
+    method.setAccessible(true)
+    val (optionsProps, serdeProps) = method.invoke(catalog, properties)
+      .asInstanceOf[(Map[String, String], Map[String, String])]
+
+    assert(optionsProps == Map(
+      "header" -> "false",
+      "delimiter" -> "#"))
+    assert(serdeProps == Map(
+      "field.delim" -> ",",
+      "line.delim" -> "\n"))
+  }
+
   test("createTable: SERDEPROPERTIES") {
     val properties = new util.HashMap[String, String]()
     properties.put("hive.serde", "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -298,12 +298,7 @@ class HiveCatalogSuite extends KyuubiHiveTest {
       TableCatalog.OPTION_PREFIX + "field.delim" -> ",",
       TableCatalog.OPTION_PREFIX + "line.delim" -> "\n")
 
-    val method = classOf[HiveTableCatalog].getDeclaredMethod(
-      "toOptionsAndSerdeProps",
-      classOf[scala.collection.immutable.Map[_, _]])
-    method.setAccessible(true)
-    val (optionsProps, serdeProps) = method.invoke(catalog, properties)
-      .asInstanceOf[(Map[String, String], Map[String, String])]
+    val (optionsProps, serdeProps) = catalog.toOptionsAndSerdeProps(properties)
 
     assert(optionsProps == Map(
       "header" -> "false",

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveCatalogSuite.scala
@@ -287,6 +287,25 @@ class HiveCatalogSuite extends KyuubiHiveTest {
     catalog.dropTable(testIdent)
   }
 
+  test("createTable: SERDEPROPERTIES") {
+    val properties = new util.HashMap[String, String]()
+    properties.put("hive.serde", "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe")
+    properties.put(TableCatalog.OPTION_PREFIX + "field.delim", ",")
+    assert(!catalog.tableExists(testIdent))
+
+    val table = catalog.createTable(
+      testIdent,
+      schema,
+      Array.empty[Transform],
+      properties).asInstanceOf[HiveTable]
+
+    assert(!table.catalogTable.storage.properties.keys.exists(
+      _.startsWith(TableCatalog.OPTION_PREFIX)))
+    assert(!table.catalogTable.storage.properties.contains("hive.serde"))
+    assert(table.catalogTable.storage.properties.contains("field.delim"))
+    catalog.dropTable(testIdent)
+  }
+
   test("loadTable") {
     val table = catalog.createTable(testIdent, schema, Array.empty[Transform], emptyProps)
     val loaded = catalog.loadTable(testIdent)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
1. Execute the following SQL to create table and insert.
```
CREATE TABLE test_table (name STRING, age INT)
ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
WITH SERDEPROPERTIES ('field.delim' = ',')
STORED AS TEXTFILE;

INSERT INTO TABLE test_table VALUES ('alice', 30);
```
2. Check the underlying HDFS data. Output is `alice30`, Expected is `alice,30`
```
hdfs dfs -cat /usr/hive/warehouse/test_table/part-00000-08cdc3f0-15af-413a-a709-46e24f1ace91-c000
```
3. Cause: SERDEPROPERTIES are missing when KSHC create table, it did not strip the `option.` prefix. See: https://github.com/apache/spark/pull/28026

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
No
