### PR TITLE
[KYUUBI #7403] Password with colon bug fixes

### DIFF
--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/authentication/BasicAuthenticationHandler.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/authentication/BasicAuthenticationHandler.scala
@@ -69,7 +69,7 @@ class BasicAuthenticationHandler(basicAuthType: AuthType)
     val authorization = getAuthorization(request)
     val inputToken = Option(authorization).map(a => Base64.getDecoder.decode(a.getBytes()))
       .getOrElse(Array.empty[Byte])
-    val creds = new String(inputToken, Charset.forName("UTF-8")).split(":")
+    val creds = new String(inputToken, Charset.forName("UTF-8")).split(":", 2)
 
     if (allowAnonymous) {
       authUser = creds.take(1).headOption.filterNot(_.isEmpty).getOrElse("anonymous")

--- a/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/authentication/KyuubiInternalAuthenticationHandler.scala
+++ b/kyuubi-server/src/main/scala/org/apache/kyuubi/server/http/authentication/KyuubiInternalAuthenticationHandler.scala
@@ -48,7 +48,7 @@ class KyuubiInternalAuthenticationHandler extends AuthenticationHandler with Log
     val authorization = getAuthorization(request)
     val inputToken = Option(authorization).map(a => Base64.getDecoder.decode(a.getBytes()))
       .getOrElse(Array.empty[Byte])
-    val creds = new String(inputToken, StandardCharsets.UTF_8).split(":")
+    val creds = new String(inputToken, StandardCharsets.UTF_8).split(":", 2)
 
     if (creds.size < 2 || creds(0).trim.isEmpty || creds(1).trim.isEmpty) {
       response.setHeader(WWW_AUTHENTICATE_HEADER, authScheme.toString)

--- a/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiRestAuthenticationSuite.scala
+++ b/kyuubi-server/src/test/scala/org/apache/kyuubi/operation/KyuubiRestAuthenticationSuite.scala
@@ -240,6 +240,15 @@ class KyuubiRestCustomAuthenticationTest extends KyuubiRestAuthenticationSuite {
     assert(HttpServletResponse.SC_OK == response.getStatus)
   }
 
+  test("test with invalid CUSTOM http basic authorization that contains colon") {
+    val response = webTarget.path("api/v1/sessions/count")
+      .request()
+      .header(AUTHORIZATION_HEADER, basicAuthorizationHeader("user", "password:with:colons"))
+      .get()
+
+    assert(HttpServletResponse.SC_FORBIDDEN == response.getStatus)
+  }
+
   test("test with invalid CUSTOM http basic authorization") {
     val response = webTarget.path("api/v1/sessions/count")
       .request()


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->

If a password contains a colon, REST API does not pick up colons. Similarly, password string like `correctpassword:random-charachars` gets parsed as `correctpassword`.


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Tested in local build, password with colon are getting parsed properly.


### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->

Test Suite was helped by Cursor auto-complete.

