### PR TITLE
[KYUUBI #7335] DynamicPartitionDataSingleWriter needs sort before write

### DIFF
--- a/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/write/HiveWrite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/main/scala/org/apache/kyuubi/spark/connector/hive/write/HiveWrite.scala
@@ -32,7 +32,9 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.catalyst.catalog.CatalogTable
 import org.apache.spark.sql.catalyst.catalog.CatalogTypes.TablePartitionSpec
-import org.apache.spark.sql.connector.write.{BatchWrite, LogicalWriteInfo, Write}
+import org.apache.spark.sql.connector.distributions.{Distribution, Distributions}
+import org.apache.spark.sql.connector.expressions.{Expressions, SortDirection, SortOrder}
+import org.apache.spark.sql.connector.write.{BatchWrite, LogicalWriteInfo, RequiresDistributionAndOrdering}
 import org.apache.spark.sql.execution.datasources.{BasicWriteJobStatsTracker, WriteJobDescription}
 import org.apache.spark.sql.execution.datasources.v2.FileBatchWrite
 import org.apache.spark.sql.execution.metric.SQLMetric
@@ -50,7 +52,8 @@ case class HiveWrite(
     info: LogicalWriteInfo,
     hiveTableCatalog: HiveTableCatalog,
     forceOverwrite: Boolean,
-    dynamicPartition: Map[String, Option[String]]) extends Write with Logging {
+    dynamicPartition: Map[String, Option[String]])
+  extends RequiresDistributionAndOrdering with Logging {
 
   private val options = info.options()
 
@@ -72,6 +75,14 @@ case class HiveWrite(
     hiveTable.getMetadata)
 
   override def description(): String = "Kyuubi-Hive-Connector"
+
+  override def requiredDistribution(): Distribution = Distributions.unspecified()
+
+  override def requiredOrdering(): Array[SortOrder] = {
+    partColumns.map { col =>
+      Expressions.sort(Expressions.column(col.name), SortDirection.ASCENDING)
+    }.toArray
+  }
 
   override def toBatch: BatchWrite = {
     val tmpLocation = HiveWriteHelper.getExternalTmpPath(externalCatalog, hadoopConf, tableLocation)

--- a/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveQuerySuite.scala
+++ b/extensions/spark/kyuubi-spark-connector-hive/src/test/scala/org/apache/kyuubi/spark/connector/hive/HiveQuerySuite.scala
@@ -117,6 +117,55 @@ class HiveQuerySuite extends KyuubiHiveTest {
     }
   }
 
+  test("[KYUUBI #7335] DynamicPartitionDataSingleWriter needs sort before write") {
+    withSparkSession(Map(
+      "hive.exec.dynamic.partition.mode" -> "nonstrict",
+      "spark.sql.shuffle.partitions" -> "1")) { spark =>
+      val table = "hive.default.test_part_table"
+      val tempTable = "hive.default.test_part_table_tmp"
+      withTable(table, tempTable) {
+        spark.sql(
+          s"""
+             | CREATE TABLE $table (
+             |   word STRING,
+             |   num BIGINT
+             | ) PARTITIONED BY (dt STRING)
+             | STORED AS ORC
+             |""".stripMargin)
+        spark.sql(
+          s"""
+             | CREATE TABLE $tempTable (
+             |   word STRING,
+             |   num BIGINT,
+             |   dt STRING
+             | ) STORED AS ORC
+             |""".stripMargin)
+        spark.sql(
+          s"""
+             | INSERT INTO $tempTable VALUES
+             | ('1', 1, '1111'),
+             | ('2', 2, '2222'),
+             | ('3', 4, '1111')
+             |""".stripMargin)
+
+        spark.sql(
+          s"""
+             | INSERT OVERWRITE TABLE $table PARTITION (dt)
+             | SELECT word, num, dt
+             | FROM $tempTable
+             | ORDER BY word
+             |""".stripMargin).collect()
+
+        checkAnswer(
+          spark.sql(s"SELECT * FROM $table"),
+          Seq(
+            Row("1", 1L, "1111"),
+            Row("2", 2L, "2222"),
+            Row("3", 4L, "1111")))
+      }
+    }
+  }
+
   test("[KYUUBI #4525] Partitioning predicates should take effect to filter data") {
     withSparkSession(Map("hive.exec.dynamic.partition.mode" -> "nonstrict")) { spark =>
       val table = "hive.default.employee"


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://kyuubi.readthedocs.io/en/master/contributing/code/index.html
  2. If the PR is related to an issue in https://github.com/apache/kyuubi/issues, add '[KYUUBI #XXXX]' in your PR title, e.g., '[KYUUBI #XXXX] Your PR title ...'.
  3. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP][KYUUBI #XXXX] Your PR title ...'.
-->

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug, and what versions are affected.
-->
Fix https://github.com/apache/kyuubi/issues/7335. For DynamicPartitionDataSingleWriter, the records to be written are required to be sorted on partition and/or bucket column(s) before writing. See [FileFormatDataWriter.scala](https://github.com/apache/spark/blob/master/sql/core/src/main/scala/org/apache/spark/sql/execution/datasources/FileFormatDataWriter.scala#L353-L363)

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
UT

### Was this patch authored or co-authored using generative AI tooling?
<!--
If a generative AI tooling has been used in the process of authoring this patch, please include
phrase 'Generated-by: ' followed by the name of the tool and its version.
If no, write 'No'.
Please refer to the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) for details.
-->
NO
